### PR TITLE
feat(chunk-2): Education/Experience structured dates + RHF modals

### DIFF
--- a/app/actions/experience.ts
+++ b/app/actions/experience.ts
@@ -1,6 +1,10 @@
 "use server";
 import { cookies } from "next/headers";
-import { ExperienceCreate, ExperienceUpdate } from "@/lib/api";
+import { ApiExperience, ExperienceCreate, ExperienceUpdate } from "@/lib/api";
+
+export type ServerActionResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
 
 const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000/api/v1";
@@ -14,7 +18,9 @@ async function getAuthHeader() {
   };
 }
 
-export async function createExperienceAction(data: ExperienceCreate) {
+export async function createExperienceAction(
+  data: ExperienceCreate,
+): Promise<ServerActionResponse<ApiExperience>> {
   try {
     const res = await fetch(`${API_BASE_URL}/experience`, {
       method: "POST",
@@ -22,17 +28,17 @@ export async function createExperienceAction(data: ExperienceCreate) {
       body: JSON.stringify(data),
     });
     const json = await res.json();
-    if (!res.ok) return { error: json.detail || "Failed to create experience" };
+    if (!res.ok) return { success: false, error: json.detail || "Failed to create experience" };
     return { success: true, data: json };
   } catch (err) {
-    return { error: err };
+    return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
   }
 }
 
 export async function updateExperienceAction(
   id: string,
   data: ExperienceUpdate,
-) {
+): Promise<ServerActionResponse<ApiExperience>> {
   try {
     const res = await fetch(`${API_BASE_URL}/experience/${id}`, {
       method: "PATCH",
@@ -40,14 +46,14 @@ export async function updateExperienceAction(
       body: JSON.stringify(data),
     });
     const json = await res.json();
-    if (!res.ok) return { error: json.detail || "Failed to update experience" };
+    if (!res.ok) return { success: false, error: json.detail || "Failed to update experience" };
     return { success: true, data: json };
   } catch (err) {
-    return { error: err };
+    return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
   }
 }
 
-export async function deleteExperienceAction(id: string) {
+export async function deleteExperienceAction(id: string): Promise<ServerActionResponse<void>> {
   try {
     const res = await fetch(`${API_BASE_URL}/experience/${id}`, {
       method: "DELETE",
@@ -55,10 +61,10 @@ export async function deleteExperienceAction(id: string) {
     });
     if (!res.ok) {
       const json = await res.json();
-      return { error: json.detail || "Failed to delete experience" };
+      return { success: false, error: json.detail || "Failed to delete experience" };
     }
-    return { success: true };
+    return { success: true, data: undefined };
   } catch (err) {
-    return { error: err };
+    return { success: false, error: err instanceof Error ? err.message : "Unknown error" };
   }
 }

--- a/app/admin/(dashboard)/blog/BlogClient.tsx
+++ b/app/admin/(dashboard)/blog/BlogClient.tsx
@@ -46,6 +46,11 @@ export default function BlogClient({ initialPosts }: { initialPosts: ApiBlogPost
     setIsModalOpen(true);
   };
 
+
+  const headers = ['Status', 'Title', 'Slug', 'Date', 'Actions'];
+
+
+
   return (
     <div className="space-y-6">
       <div className="flex justify-end">
@@ -58,11 +63,9 @@ export default function BlogClient({ initialPosts }: { initialPosts: ApiBlogPost
         <table className="w-full text-left border-collapse">
           <thead>
             <tr className="border-b border-[var(--border-subtle)] bg-[var(--bg-elevated)]">
-              <th className="p-4 text-sm font-medium text-[var(--text-secondary)]">Status</th>
-              <th className="p-4 text-sm font-medium text-[var(--text-secondary)]">Title</th>
-              <th className="p-4 text-sm font-medium text-[var(--text-secondary)]">Slug</th>
-              <th className="p-4 text-sm font-medium text-[var(--text-secondary)]">Date</th>
-              <th className="p-4 text-sm font-medium text-[var(--text-secondary)] text-right">Actions</th>
+              {headers.map((header, idx) => (
+                <th key={`${header}-${idx}`} className={`p-4 text-sm font-medium text-[var(--text-secondary)] ${idx === headers.length - 1 ? 'text-right' : ''}`}>{header}</th>
+              ))}
             </tr>
           </thead>
           <tbody className="divide-y divide-[var(--border-subtle)]">
@@ -110,9 +113,9 @@ export default function BlogClient({ initialPosts }: { initialPosts: ApiBlogPost
       </div>
 
       {isModalOpen && (
-        <BlogFormModal 
-          post={editingPost} 
-          onClose={() => setIsModalOpen(false)} 
+        <BlogFormModal
+          post={editingPost}
+          onClose={() => setIsModalOpen(false)}
           onSuccess={(savedPost) => {
             setIsModalOpen(false);
             if (editingPost) {

--- a/app/admin/(dashboard)/blog/BlogClient.tsx
+++ b/app/admin/(dashboard)/blog/BlogClient.tsx
@@ -13,9 +13,9 @@ export default function BlogClient({ initialPosts }: { initialPosts: ApiBlogPost
   const mappedPosts: BlogPost[] = initialPosts.map(p => ({
     id: p.id,
     slug: p.slug,
-    title: p.title,
-    excerpt: p.excerpt,
-    content: p.content,
+    title: p.title?.en ?? "",
+    excerpt: p.excerpt?.en ?? "",
+    content: p.content?.en ?? "",
     tags: p.tags || [],
     readingTime: p.reading_time || "5 min read",
     isPublished: p.is_published,

--- a/app/admin/(dashboard)/blog/BlogFormModal.tsx
+++ b/app/admin/(dashboard)/blog/BlogFormModal.tsx
@@ -6,6 +6,7 @@ import { BlogPost } from "@/lib/mockData";
 import Button from "@/components/ui/Button";
 import ImageUpload from "@/components/admin/ImageUpload";
 import { FiX, FiInfo } from "react-icons/fi";
+import { BlogField } from "@/components/admin/blog/BlogField";
 
 interface BlogFormModalProps {
   post: BlogPost | null;
@@ -96,28 +97,8 @@ export default function BlogFormModal({
           )}
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Title *
-              </label>
-              <input
-                name="title"
-                defaultValue={post?.title}
-                required
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Slug *
-              </label>
-              <input
-                name="slug"
-                defaultValue={post?.slug}
-                required
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
+            <BlogField label="Title *" defaultValue={post?.title} name="title" type="text" required />
+            <BlogField label="Slug *" defaultValue={post?.slug} name="slug" type="text" required />
           </div>
 
           <div className="space-y-2">
@@ -161,26 +142,8 @@ export default function BlogFormModal({
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Tags (comma separated)
-              </label>
-              <input
-                name="tags"
-                defaultValue={post?.tags?.join(", ")}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Reading Time
-              </label>
-              <input
-                name="reading_time"
-                defaultValue={post?.readingTime || "5 min read"}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
+            <BlogField label="Tags (comma separated)" defaultValue={post?.tags?.join(", ")} name="tags" type="text" />
+            <BlogField label="Reading Time" defaultValue={post?.readingTime || "5 min read"} name="reading_time" type="text" />
           </div>
 
           <div className="flex items-center gap-6 pt-2">

--- a/app/admin/(dashboard)/blog/BlogFormModal.tsx
+++ b/app/admin/(dashboard)/blog/BlogFormModal.tsx
@@ -29,10 +29,10 @@ export default function BlogFormModal({
 
     const fd = new FormData(e.currentTarget);
     const data = {
-      title: fd.get("title") as string,
+      title: { en: fd.get("title") as string, es: "" },
       slug: fd.get("slug") as string,
-      excerpt: fd.get("excerpt") as string,
-      content: fd.get("content") as string,
+      excerpt: { en: (fd.get("excerpt") as string) || "", es: "" },
+      content: { en: fd.get("content") as string, es: "" },
       image_url: imageUrl || null,
       tags: (fd.get("tags") as string)
         .split(",")
@@ -58,9 +58,9 @@ export default function BlogFormModal({
       onSuccess({
         id: b.id,
         slug: b.slug,
-        title: b.title,
-        excerpt: b.excerpt,
-        content: b.content,
+        title: b.title?.en ?? "",
+        excerpt: b.excerpt?.en ?? "",
+        content: b.content?.en ?? "",
         tags: b.tags || [],
         readingTime: b.reading_time || "5 min read",
         isPublished: b.is_published,

--- a/app/admin/(dashboard)/education/EducationClient.tsx
+++ b/app/admin/(dashboard)/education/EducationClient.tsx
@@ -95,7 +95,7 @@ export default function EducationClient({
                   </td>
                   <td className="p-4 font-medium text-[var(--text-primary)]">
                     <div className="flex items-center gap-2">
-                      {e.degree}
+                      {e.degree?.en ?? ""}
                       {e.url && (
                         <a
                           href={e.url}
@@ -111,7 +111,7 @@ export default function EducationClient({
                   <td className="p-4 text-[var(--text-secondary)]">
                     {e.institution}
                     <div className="text-xs text-[var(--text-muted)]">
-                      {e.date_range}
+                      {e.is_current ? `${e.start_date ?? ""} – Present` : `${e.start_date ?? ""}`}
                     </div>
                   </td>
                   <td className="p-4">

--- a/app/admin/(dashboard)/education/EducationFormModal.tsx
+++ b/app/admin/(dashboard)/education/EducationFormModal.tsx
@@ -1,204 +1,240 @@
 "use client";
 
-import { useState } from "react";
-import {
-  createEducationAction,
-  updateEducationAction,
-} from "@/app/actions/education";
-import Button from "@/components/ui/Button";
+import { useForm, FormProvider, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { FiX } from "react-icons/fi";
-import { ApiEducation, EducationCreate } from "@/lib/api";
+import Button from "@/components/ui/Button";
+import DateField from "@/components/admin/forms/DateField";
+import CheckboxField from "@/components/admin/forms/CheckboxField";
+import LocalizedTextField from "@/components/admin/forms/LocalizedTextField";
+import { EducationCreate } from "@/lib/schemas/education";
+import { createEducationAction, updateEducationAction } from "@/app/actions/education";
+import { ApiEducation } from "@/lib/api";
 
-interface EducationFormModalProps {
+interface Props {
   entry: ApiEducation | null;
   onClose: () => void;
   onSuccess: (e: ApiEducation) => void;
 }
 
-export default function EducationFormModal({
-  entry,
-  onClose,
-  onSuccess,
-}: EducationFormModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState("");
+export default function EducationFormModal({ entry, onClose, onSuccess }: Props) {
+  const methods = useForm<EducationCreate>({
+    resolver: zodResolver(EducationCreate) as Resolver<EducationCreate>,
+    defaultValues: entry
+      ? {
+          type: entry.type,
+          degree: entry.degree,
+          institution: entry.institution,
+          start_date: entry.start_date ?? null,
+          end_date: entry.end_date ?? null,
+          is_current: entry.is_current,
+          status: entry.status ?? null,
+          status_note: entry.status_note ?? null,
+          description: entry.description,
+          image_url: entry.image_url ?? null,
+          url: entry.url ?? null,
+          related_project_ids: entry.related_project_ids ?? null,
+          sort_order: entry.sort_order,
+        }
+      : {
+          type: "degree",
+          degree: { en: "", es: "" },
+          institution: "",
+          start_date: null,
+          end_date: null,
+          is_current: false,
+          status: null,
+          status_note: null,
+          description: { en: "", es: "" },
+          image_url: null,
+          url: null,
+          related_project_ids: null,
+          sort_order: 0,
+        },
+  });
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-    setError("");
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = methods;
 
-    const fd = new FormData(e.currentTarget);
-    const typeValue = fd.get("type") as string;
-    const data: EducationCreate = {
-      type: (typeValue === "certification" ? "certification" : "degree") as "degree" | "certification",
-      degree: (fd.get("degree") as string) || "",
-      institution: (fd.get("institution") as string) || "",
-      date_range: (fd.get("date_range") as string) || "",
-      description: (fd.get("description") as string) || "",
-      image_url: (fd.get("image_url") as string) || null,
-      url: (fd.get("url") as string) || null,
-      related_project_ids: entry?.related_project_ids || null,
-      sort_order: parseInt(fd.get("sort_order") as string) || 0,
+  const type = watch("type");
+  const isCurrent = watch("is_current");
+  const status = watch("status");
+  const isDegree = type === "degree";
+
+  const onSubmit = async (data: EducationCreate) => {
+    const payload = {
+      ...data,
+      end_date: isCurrent ? null : data.end_date,
+      status: isDegree ? data.status : null,
+      status_note: isDegree && data.status ? data.status_note : null,
     };
 
     const res = entry
-      ? await updateEducationAction(entry.id, data)
-      : await createEducationAction(data);
+      ? await updateEducationAction(entry.id, payload)
+      : await createEducationAction(payload);
 
-    setIsSubmitting(false);
-
-    if (res.success) {
-      onSuccess(res.data);
+    if (!res.success) {
+      methods.setError("root", { message: res.error });
     } else {
-      setError(res.error || "An error occurred");
+      onSuccess(res.data);
     }
   };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-      <div className="bg-[var(--bg-surface)] border border-[var(--border-subtle)] rounded-2xl w-full max-w-2xl shadow-2xl relative overflow-hidden">
-        <div className="p-6 border-b border-[var(--border-subtle)] flex justify-between items-center">
+      <div className="bg-[var(--bg-surface)] border border-[var(--border-subtle)] rounded-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto shadow-2xl relative">
+        <div className="sticky top-0 bg-[var(--bg-surface)]/90 backdrop-blur-md border-b border-[var(--border-subtle)] p-6 flex justify-between items-center z-10">
           <h2 className="text-xl font-bold text-[var(--text-primary)]">
             {entry ? "Edit Education Entry" : "New Education Entry"}
           </h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-          >
+          <button onClick={onClose} className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
             <FiX size={20} />
           </button>
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="p-6 space-y-5 max-h-[80vh] overflow-y-auto"
-        >
-          {error && (
-            <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
-              {error}
-            </div>
-          )}
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-6">
+            {errors.root && (
+              <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
+                {errors.root.message}
+              </div>
+            )}
 
-          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Type
-              </label>
+              <label className="text-sm font-medium text-[var(--text-secondary)]">Type</label>
               <select
-                name="type"
-                defaultValue={entry?.type || "degree"}
+                {...register("type")}
                 className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
               >
                 <option value="degree">Degree / Academic</option>
-                <option value="certification">
-                  Certification / Professional
-                </option>
+                <option value="certification">Certification / Professional</option>
               </select>
             </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Sort Order
-              </label>
-              <input
-                name="sort_order"
-                type="number"
-                defaultValue={entry?.sort_order || 0}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
-          </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Degree / Title *
-            </label>
-            <input
+            <LocalizedTextField
               name="degree"
-              defaultValue={entry?.degree}
+              label={isDegree ? "Degree / Title" : "Certification / Course"}
               required
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              placeholder="e.g. B.Sc. in Computer Science"
             />
-          </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Institution / Issuer *
-            </label>
-            <input
-              name="institution"
-              defaultValue={entry?.institution}
-              required
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              placeholder="e.g. Stanford University, AWS, Google"
-            />
-          </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--text-secondary)]">Institution / Issuer *</label>
+              <input
+                {...register("institution")}
+                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                placeholder={isDegree ? "e.g. Stanford University" : "e.g. AWS, Google, Udemy"}
+              />
+              {errors.institution && <p className="text-xs text-[var(--color-error)]">{errors.institution.message}</p>}
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Date Range *
-            </label>
-            <input
-              name="date_range"
-              defaultValue={entry?.date_range}
-              required
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              placeholder="e.g. 2018 - 2022, Issued May 2023"
-            />
-          </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <DateField
+                label={isDegree ? "Start date" : "Issued date"}
+                {...register("start_date")}
+                error={errors.start_date?.message}
+              />
+              {isDegree && (
+                <DateField
+                  label="End date"
+                  {...register("end_date")}
+                  disabled={isCurrent}
+                  error={errors.end_date?.message}
+                />
+              )}
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Description
-            </label>
-            <textarea
+            {isDegree && (
+              <CheckboxField
+                label="Currently studying"
+                {...register("is_current")}
+                onChange={(e) => {
+                  setValue("is_current", e.target.checked);
+                  if (e.target.checked) setValue("end_date", null);
+                }}
+              />
+            )}
+
+            {isDegree && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Status</label>
+                <select
+                  {...register("status")}
+                  className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                >
+                  <option value="">— none —</option>
+                  <option value="in_course">In course</option>
+                  <option value="graduated">Graduated</option>
+                  <option value="unfinished">Unfinished</option>
+                </select>
+              </div>
+            )}
+
+            {isDegree && status && (
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Status note</label>
+                <input
+                  {...register("status_note")}
+                  maxLength={200}
+                  placeholder="Optional clarification"
+                  className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
+            )}
+
+            <LocalizedTextField
               name="description"
-              defaultValue={entry?.description}
+              label="Description"
+              multiline
               rows={3}
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none resize-none"
-              placeholder="Briefly describe your focus or achievements..."
+              placeholder={{ en: "Briefly describe your focus or achievements…", es: "Describe brevemente tu enfoque o logros…" }}
             />
-          </div>
 
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Image URL (Icon/Logo)
-              </label>
-              <input
-                name="image_url"
-                defaultValue={entry?.image_url || ""}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-                placeholder="URL to institution logo"
-              />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Image URL</label>
+                <input
+                  {...register("image_url")}
+                  placeholder="Institution logo URL"
+                  className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Verification URL</label>
+                <input
+                  {...register("url")}
+                  placeholder="Link to degree/cert verification"
+                  className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
             </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                URL (Verification Link)
-              </label>
-              <input
-                name="url"
-                defaultValue={entry?.url || ""}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-                placeholder="Link to degree/cert verification"
-              />
-            </div>
-          </div>
 
-          <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
-            <Button
-              type="button"
-              onClick={onClose}
-              className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]"
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving..." : "Save Entry"}
-            </Button>
-          </div>
-        </form>
+            <details className="text-sm text-[var(--text-muted)]">
+              <summary className="cursor-pointer hover:text-[var(--text-secondary)]">Advanced</summary>
+              <div className="mt-3 space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Sort order (tie-breaker)</label>
+                <input
+                  {...register("sort_order", { valueAsNumber: true })}
+                  type="number"
+                  className="w-32 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
+            </details>
+
+            <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
+              <Button type="button" onClick={onClose} className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving…" : "Save Entry"}
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
       </div>
     </div>
   );

--- a/app/admin/(dashboard)/experience/ExperienceClient.tsx
+++ b/app/admin/(dashboard)/experience/ExperienceClient.tsx
@@ -93,13 +93,13 @@ export default function ExperienceClient({
                     {e.sort_order}
                   </td>
                   <td className="p-4 font-medium text-[var(--text-primary)]">
-                    {e.role}
+                    {e.role?.en ?? ""}
                   </td>
                   <td className="p-4 text-[var(--text-secondary)]">
                     {e.company}
                   </td>
                   <td className="p-4 text-sm text-[var(--text-secondary)]">
-                    {e.date_range}
+                    {e.is_current ? `${e.start_date ?? ""} – Present` : `${e.start_date ?? ""} – ${e.end_date ?? ""}`}
                   </td>
                   <td className="p-4">
                     <div className="flex justify-end gap-2">

--- a/app/admin/(dashboard)/experience/ExperienceFormModal.tsx
+++ b/app/admin/(dashboard)/experience/ExperienceFormModal.tsx
@@ -1,48 +1,72 @@
 "use client";
 
-import { useState } from "react";
-import { createExperienceAction, updateExperienceAction } from "@/app/actions/experience";
-import Button from "@/components/ui/Button";
+import { useForm, FormProvider, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import { FiX } from "react-icons/fi";
+import Button from "@/components/ui/Button";
+import DateField from "@/components/admin/forms/DateField";
+import CheckboxField from "@/components/admin/forms/CheckboxField";
+import LocalizedTextField from "@/components/admin/forms/LocalizedTextField";
+import LocalizedListField from "@/components/admin/forms/LocalizedListField";
+import { ExperienceCreate } from "@/lib/schemas/experience";
+import { createExperienceAction, updateExperienceAction } from "@/app/actions/experience";
 import { ApiExperience } from "@/lib/api";
 
-interface ExperienceFormModalProps {
+interface Props {
   experience: ApiExperience | null;
   onClose: () => void;
   onSuccess: (e: ApiExperience) => void;
 }
 
-export default function ExperienceFormModal({ experience, onClose, onSuccess }: ExperienceFormModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState("");
+export default function ExperienceFormModal({ experience, onClose, onSuccess }: Props) {
+  const methods = useForm<ExperienceCreate>({
+    resolver: zodResolver(ExperienceCreate) as Resolver<ExperienceCreate>,
+    defaultValues: experience
+      ? {
+          role: experience.role,
+          company: experience.company,
+          start_date: experience.start_date ?? "",
+          end_date: experience.end_date ?? null,
+          is_current: experience.is_current,
+          description: experience.description,
+          tech_stack: experience.tech_stack,
+          sort_order: experience.sort_order,
+        }
+      : {
+          role: { en: "", es: "" },
+          company: "",
+          start_date: "",
+          end_date: null,
+          is_current: false,
+          description: { en: [], es: [] },
+          tech_stack: [],
+          sort_order: 0,
+        },
+  });
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-    setError("");
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = methods;
 
-    const fd = new FormData(e.currentTarget);
-    const data = {
-      role: fd.get("role") as string,
-      company: fd.get("company") as string,
-      date_range: fd.get("date_range") as string,
-      description: (fd.get("description") as string).split("\n").filter(Boolean),
-      tech_stack: (fd.get("tech_stack") as string).split(",").map(s => s.trim()).filter(Boolean),
-      sort_order: parseInt(fd.get("sort_order") as string) || 0,
+  const isCurrent = watch("is_current");
+
+  const onSubmit = async (data: ExperienceCreate) => {
+    const payload = {
+      ...data,
+      end_date: isCurrent ? null : data.end_date,
     };
 
-    let res;
-    if (experience) {
-      res = await updateExperienceAction(experience.id, data);
+    const res = experience
+      ? await updateExperienceAction(experience.id, payload)
+      : await createExperienceAction(payload);
+
+    if (!res.success) {
+      methods.setError("root", { message: res.error });
     } else {
-      res = await createExperienceAction(data);
-    }
-
-    setIsSubmitting(false);
-
-    if (res.error) {
-      setError(res.error);
-    } else if (res.success) {
       onSuccess(res.data);
     }
   };
@@ -59,53 +83,85 @@ export default function ExperienceFormModal({ experience, onClose, onSuccess }: 
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          {error && (
-            <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
-              {error}
-            </div>
-          )}
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-6">
+            {errors.root && (
+              <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
+                {errors.root.message}
+              </div>
+            )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Role *</label>
-              <input name="role" defaultValue={experience?.role} required className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
-            </div>
+            <LocalizedTextField name="role" label="Role" required />
+
             <div className="space-y-2">
               <label className="text-sm font-medium text-[var(--text-secondary)]">Company *</label>
-              <input name="company" defaultValue={experience?.company} required className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
+              <input
+                {...register("company")}
+                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+              />
+              {errors.company && <p className="text-xs text-[var(--color-error)]">{errors.company.message}</p>}
             </div>
-          </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Timeline (e.g. 2022 - Present) *</label>
-            <input name="date_range" defaultValue={experience?.date_range} required className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
-          </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <DateField
+                label="Start date *"
+                {...register("start_date")}
+                error={errors.start_date?.message}
+              />
+              <DateField
+                label="End date"
+                {...register("end_date")}
+                disabled={isCurrent}
+                error={errors.end_date?.message}
+              />
+            </div>
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Description (one bullet point per line) *</label>
-            <textarea name="description" defaultValue={experience?.description?.join("\n")} required rows={5} className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
-          </div>
+            <CheckboxField
+              label="Currently here"
+              {...register("is_current")}
+              onChange={(e) => {
+                setValue("is_current", e.target.checked);
+                if (e.target.checked) setValue("end_date", null);
+              }}
+            />
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Tech Stack (comma separated)</label>
-            <input name="tech_stack" defaultValue={experience?.tech_stack?.join(", ")} className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
-          </div>
+            <LocalizedListField
+              name="description"
+              label="Description (one bullet per line)"
+              rows={5}
+            />
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">Sort Order</label>
-            <input name="sort_order" type="number" defaultValue={experience?.sort_order || 0} className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" />
-          </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--text-secondary)]">Tech stack (comma separated)</label>
+              <input
+                {...register("tech_stack")}
+                defaultValue={experience?.tech_stack?.join(", ")}
+                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+              />
+            </div>
 
-          <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
-            <Button type="button" onClick={onClose} className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]">
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving..." : "Save Experience"}
-            </Button>
-          </div>
-        </form>
+            <details className="text-sm text-[var(--text-muted)]">
+              <summary className="cursor-pointer hover:text-[var(--text-secondary)]">Advanced</summary>
+              <div className="mt-3 space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Sort order (tie-breaker)</label>
+                <input
+                  {...register("sort_order", { valueAsNumber: true })}
+                  type="number"
+                  className="w-32 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
+            </details>
+
+            <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
+              <Button type="button" onClick={onClose} className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving…" : "Save Experience"}
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
       </div>
     </div>
   );

--- a/app/admin/(dashboard)/profile/ProfileForm.tsx
+++ b/app/admin/(dashboard)/profile/ProfileForm.tsx
@@ -24,10 +24,10 @@ export default function ProfileForm({ initialProfile }: ProfileFormProps) {
     const fd = new FormData(e.currentTarget);
     const data = {
       name: fd.get("name") as string,
-      title: fd.get("title") as string,
-      bio: fd.get("bio") as string,
+      title: { en: fd.get("title") as string, es: "" },
+      bio: { en: fd.get("bio") as string, es: "" },
       email: fd.get("email") as string,
-      location: fd.get("location") as string,
+      location: { en: fd.get("location") as string, es: "" },
       github_url: (fd.get("github_url") as string) || null,
       linkedin_url: (fd.get("linkedin_url") as string) || null,
       whatsapp_number: (fd.get("whatsapp_number") as string) || null,

--- a/app/admin/(dashboard)/skills/SkillFormModal.tsx
+++ b/app/admin/(dashboard)/skills/SkillFormModal.tsx
@@ -34,7 +34,7 @@ export default function SkillFormModal({
 
     const data = {
       name: fd.get("name") as string,
-      category: categoryObj?.name || "", // Maintain string for backend compat
+      category: categoryObj?.name?.en ?? "",
       category_id: categoryId,
       years: parseInt(fd.get("years") as string) || 0,
       tags: (fd.get("tags") as string)
@@ -108,7 +108,7 @@ export default function SkillFormModal({
               <option value="">Select Category</option>
               {categories.map((c) => (
                 <option key={c.id} value={c.id}>
-                  {c.name}
+                  {c.name?.en ?? ""}
                 </option>
               ))}
             </select>

--- a/app/admin/(dashboard)/skills/categories/CategoriesClient.tsx
+++ b/app/admin/(dashboard)/skills/categories/CategoriesClient.tsx
@@ -97,7 +97,7 @@ export default function CategoriesClient({
                     {c.sort_order}
                   </td>
                   <td className="p-4 font-medium text-[var(--text-primary)]">
-                    {c.name}
+                    {c.name?.en ?? ""}
                   </td>
                   <td className="p-4">
                     <div className="flex justify-end gap-2">

--- a/app/admin/(dashboard)/skills/categories/CategoryFormModal.tsx
+++ b/app/admin/(dashboard)/skills/categories/CategoryFormModal.tsx
@@ -23,7 +23,7 @@ export default function CategoryFormModal({ category, onClose, onSuccess }: Cate
 
     const fd = new FormData(e.currentTarget);
     const data: SkillCategoryCreate = {
-      name: fd.get("name") as string,
+      name: { en: fd.get("name") as string, es: "" },
       sort_order: parseInt(fd.get("sort_order") as string) || 0,
     };
 
@@ -64,7 +64,7 @@ export default function CategoryFormModal({ category, onClose, onSuccess }: Cate
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-[var(--text-secondary)]">Category Name *</label>
-            <input name="name" defaultValue={category?.name} required className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" placeholder="e.g. Frontend, Tools" />
+            <input name="name" defaultValue={category?.name?.en} required className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none" placeholder="e.g. Frontend, Tools" />
           </div>
 
           <div className="space-y-2">

--- a/components/admin/blog/BlogField.tsx
+++ b/components/admin/blog/BlogField.tsx
@@ -1,0 +1,20 @@
+export const BlogField = ({ label, defaultValue, name, type, required }: {
+    label: string
+    defaultValue?: string
+    name: string
+    type?: string
+    required?: boolean
+}) => (
+    <div className="space-y-2">
+        <label className="text-sm font-medium text-[var(--text-secondary)]">
+            {label}
+        </label>
+        <input
+            name={name}
+            defaultValue={defaultValue}
+            type={type}
+            required={required}
+            className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+        />
+    </div>
+)

--- a/components/admin/forms/CheckboxField.tsx
+++ b/components/admin/forms/CheckboxField.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { forwardRef } from "react";
+
+interface CheckboxFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+}
+
+const CheckboxField = forwardRef<HTMLInputElement, CheckboxFieldProps>(
+  ({ label, error, ...props }, ref) => (
+    <div className="space-y-1">
+      <label className="flex items-center gap-2 cursor-pointer select-none">
+        <input
+          ref={ref}
+          type="checkbox"
+          {...props}
+          className="w-4 h-4 rounded border-[var(--border-default)] accent-[var(--accent-violet)] cursor-pointer"
+        />
+        <span className="text-sm font-medium text-[var(--text-secondary)]">{label}</span>
+      </label>
+      {error && <p className="text-xs text-[var(--color-error)]">{error}</p>}
+    </div>
+  ),
+);
+CheckboxField.displayName = "CheckboxField";
+
+export default CheckboxField;

--- a/components/admin/forms/DateField.tsx
+++ b/components/admin/forms/DateField.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { forwardRef } from "react";
+
+interface DateFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  error?: string;
+}
+
+const DateField = forwardRef<HTMLInputElement, DateFieldProps>(
+  ({ label, error, ...props }, ref) => (
+    <div className="space-y-1.5">
+      <label className="block text-sm font-medium text-[var(--text-secondary)]">
+        {label}
+      </label>
+      <input
+        ref={ref}
+        type="date"
+        {...props}
+        className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+      />
+      {error && <p className="text-xs text-[var(--color-error)]">{error}</p>}
+    </div>
+  ),
+);
+DateField.displayName = "DateField";
+
+export default DateField;

--- a/components/admin/forms/LocalizedListField.tsx
+++ b/components/admin/forms/LocalizedListField.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+interface LocalizedListFieldProps {
+  name: string;
+  label: string;
+  rows?: number;
+  placeholder?: { en?: string; es?: string };
+}
+
+export default function LocalizedListField({
+  name,
+  label,
+  rows = 5,
+  placeholder = {},
+}: LocalizedListFieldProps) {
+  const [activeLocale, setActiveLocale] = useState<"en" | "es">("en");
+  const { setValue, watch } = useFormContext();
+
+  const enList: string[] = watch(`${name}.en`) ?? [];
+  const esList: string[] = watch(`${name}.es`) ?? [];
+  const activeList = activeLocale === "en" ? enList : esList;
+
+  const handleChange = (raw: string) => {
+    const lines = raw.split("\n");
+    setValue(`${name}.${activeLocale}`, lines, { shouldDirty: true });
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium text-[var(--text-secondary)]">{label}</label>
+        <div className="flex items-center gap-1">
+          {(["en", "es"] as const).map((loc) => {
+            const list = loc === "en" ? enList : esList;
+            return (
+              <button
+                key={loc}
+                type="button"
+                onClick={() => setActiveLocale(loc)}
+                className={`px-2 py-0.5 rounded text-xs font-bold uppercase transition-colors ${
+                  activeLocale === loc
+                    ? "bg-[var(--accent-violet)] text-white"
+                    : "bg-[var(--bg-elevated)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                {loc}
+                {list.filter(Boolean).length === 0 && (
+                  <span className="ml-1 text-[var(--color-warning)] text-[10px]">⚠</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <textarea
+        value={activeList.join("\n")}
+        onChange={(e) => handleChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder[activeLocale] ?? "One bullet per line"}
+        className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none resize-none"
+      />
+      <p className="text-xs text-[var(--text-muted)]">One bullet point per line.</p>
+    </div>
+  );
+}

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -32,7 +32,7 @@ export default function LocalizedTextField({
 
   const fieldName = `${name}.${activeLocale}` as const;
   const error =
-    (errors as Record<string, Record<string, Record<string, { message?: string }>>>)?.[name]?.[activeLocale]?.message;
+    (errors as Record<string, Record<string, { message?: string }>>)?.[name]?.[activeLocale]?.message;
 
   const inputClass =
     "w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none resize-none";

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+interface LocalizedTextFieldProps {
+  name: string;
+  label: string;
+  multiline?: boolean;
+  rows?: number;
+  placeholder?: { en?: string; es?: string };
+  required?: boolean;
+}
+
+export default function LocalizedTextField({
+  name,
+  label,
+  multiline = false,
+  rows = 3,
+  placeholder = {},
+  required = false,
+}: LocalizedTextFieldProps) {
+  const [activeLocale, setActiveLocale] = useState<"en" | "es">("en");
+  const {
+    register,
+    formState: { errors },
+    watch,
+  } = useFormContext();
+
+  const enValue = watch(`${name}.en`) ?? "";
+  const esValue = watch(`${name}.es`) ?? "";
+
+  const fieldName = `${name}.${activeLocale}` as const;
+  const error =
+    (errors as Record<string, Record<string, Record<string, { message?: string }>>>)?.[name]?.[activeLocale]?.message;
+
+  const inputClass =
+    "w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none resize-none";
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium text-[var(--text-secondary)]">
+          {label}{required && " *"}
+        </label>
+        <div className="flex items-center gap-1">
+          {(["en", "es"] as const).map((loc) => {
+            const val = loc === "en" ? enValue : esValue;
+            return (
+              <button
+                key={loc}
+                type="button"
+                onClick={() => setActiveLocale(loc)}
+                className={`px-2 py-0.5 rounded text-xs font-bold uppercase transition-colors ${
+                  activeLocale === loc
+                    ? "bg-[var(--accent-violet)] text-white"
+                    : "bg-[var(--bg-elevated)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                }`}
+              >
+                {loc}
+                {val.length === 0 && (
+                  <span className="ml-1 text-[var(--color-warning)] text-[10px]">⚠</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {multiline ? (
+        <textarea
+          {...register(fieldName)}
+          rows={rows}
+          placeholder={placeholder[activeLocale]}
+          className={inputClass}
+        />
+      ) : (
+        <input
+          {...register(fieldName)}
+          placeholder={placeholder[activeLocale]}
+          className={inputClass}
+        />
+      )}
+
+      {error && <p className="text-xs text-[var(--color-error)]">{error}</p>}
+    </div>
+  );
+}

--- a/components/sections/Education.tsx
+++ b/components/sections/Education.tsx
@@ -72,9 +72,22 @@ export default async function Education() {
                       </div>
                     )}
 
-                    <h4 className="text-lg font-bold text-[var(--text-primary)] group-hover:text-[var(--accent-violet)] transition-colors">
-                      {edu.degree}
-                    </h4>
+                    <div className="flex items-start justify-between gap-2">
+                      <h4 className="text-lg font-bold text-[var(--text-primary)] group-hover:text-[var(--accent-violet)] transition-colors">
+                        {edu.degree}
+                      </h4>
+                      {edu.status && (
+                        <span className={`shrink-0 text-[10px] uppercase tracking-wider font-semibold px-2 py-0.5 rounded-full border ${
+                          edu.status === "graduated"
+                            ? "bg-[var(--accent-cyan)]/10 text-[var(--accent-cyan)] border-[var(--accent-cyan)]/30"
+                            : edu.status === "in_course"
+                            ? "bg-[var(--accent-violet)]/10 text-[var(--accent-violet)] border-[var(--accent-violet)]/30"
+                            : "bg-[var(--bg-surface)] text-[var(--text-muted)] border-[var(--border-default)]"
+                        }`}>
+                          {edu.status === "graduated" ? "Graduated" : edu.status === "in_course" ? "In Progress" : "Unfinished"}
+                        </span>
+                      )}
+                    </div>
                     <div className="flex justify-between items-center mt-2 mb-4">
                       <span className="text-[var(--text-secondary)] font-medium">
                         {edu.institution}

--- a/components/sections/Skills.tsx
+++ b/components/sections/Skills.tsx
@@ -19,7 +19,7 @@ export default async function Skills() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
         {skills.map((category, idx) => (
-          <ScrollReveal key={category.title} delay={0.1 * (idx + 1)}>
+          <ScrollReveal key={`skill-cat-${idx}`} delay={0.1 * (idx + 1)}>
             <div className="flex flex-col h-full bg-[var(--bg-surface)] rounded-xl p-6 border border-[var(--border-subtle)] shadow-sm hover:border-[var(--accent-cyan)]/30 transition-colors duration-300">
               <h3 className="text-lg font-bold text-[var(--text-primary)] mb-6 pb-4 border-b border-[var(--border-subtle)]">
                 {category.title}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -36,9 +36,9 @@ export type ProjectUpdate = Partial<ProjectCreate>;
 export interface ApiBlogPost {
   id: string;
   slug: string;
-  title: string;
-  excerpt: string;
-  content: string;
+  title: { en: string; es: string };
+  excerpt: { en: string; es: string };
+  content: { en: string; es: string };
   tags: string[] | null;
   reading_time: string | null;
   is_published: boolean;
@@ -81,7 +81,7 @@ export type SkillUpdate = Partial<SkillCreate>;
 
 export interface ApiSkillCategory {
   id: string;
-  name: string;
+  name: { en: string; es: string };
   sort_order: number;
 }
 
@@ -111,10 +111,10 @@ export type EducationUpdate = Partial<EducationCreate>;
 export interface ApiProfile {
   id: string;
   name: string;
-  title: string;
-  bio: string;
+  title: { en: string; es: string };
+  bio: { en: string; es: string };
   email: string;
-  location: string;
+  location: { en: string; es: string };
   github_url: string | null;
   linkedin_url: string | null;
   whatsapp_number: string | null;
@@ -142,7 +142,7 @@ export interface Profile {
 // --- Grouped Read Interfaces ---
 
 export interface ApiSkillGroup {
-  title: string;
+  name: { en: string; es: string };
   skills: ApiSkill[];
 }
 
@@ -171,10 +171,10 @@ export async function getProfile(): Promise<Profile | null> {
     const p: ApiProfile = await res.json();
     return {
       name: p.name,
-      title: p.title,
-      bio: p.bio,
+      title: p.title?.en ?? "",
+      bio: p.bio?.en ?? "",
       email: p.email,
-      location: p.location,
+      location: p.location?.en ?? "",
       githubUrl: p.github_url || undefined,
       linkedinUrl: p.linkedin_url || undefined,
       whatsappNumber: p.whatsapp_number || undefined,
@@ -356,7 +356,7 @@ export async function getSkills(): Promise<SkillCategory[]> {
     if (!Array.isArray(data)) return [];
 
     return data.map((g: ApiSkillGroup) => ({
-      title: g.title,
+      title: g.name?.en ?? "",
       skills: g.skills.map(s => ({
         name: s.name,
         years: s.years,
@@ -419,12 +419,12 @@ export async function getBlogPosts(): Promise<BlogPost[]> {
     return items.map((b: ApiBlogPost) => ({
       id: b.id,
       slug: b.slug,
-      title: b.title,
-      excerpt: b.excerpt,
+      title: b.title?.en ?? "",
+      excerpt: b.excerpt?.en ?? "",
       date: b.published_at || b.created_at,
       readingTime: b.reading_time || "5 min read",
       tags: b.tags || [],
-      content: b.content,
+      content: b.content?.en ?? "",
       imageUrl: b.image_url || undefined,
     }));
   } catch (error) {
@@ -442,12 +442,12 @@ export async function getBlogPostBySlug(slug: string): Promise<BlogPost | null> 
     return {
       id: b.id,
       slug: b.slug,
-      title: b.title,
-      excerpt: b.excerpt,
+      title: b.title?.en ?? "",
+      excerpt: b.excerpt?.en ?? "",
       date: b.published_at || b.created_at,
       readingTime: b.reading_time || "5 min read",
       tags: b.tags || [],
-      content: b.content,
+      content: b.content?.en ?? "",
       imageUrl: b.image_url || undefined,
     };
   } catch (error) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -387,6 +387,10 @@ export async function getEducation(): Promise<{ degrees: EducationItem[], certif
         institution: e.institution,
         dateRange: formatDateRange(e.start_date, e.end_date, e.is_current),
         description: e.description?.en ?? "",
+        imageUrl: e.image_url || undefined,
+        relatedProjectIds: e.related_project_ids || undefined,
+        status: e.status || undefined,
+        status_note: e.status_note || undefined,
       }));
 
     const certifications = data
@@ -397,6 +401,8 @@ export async function getEducation(): Promise<{ degrees: EducationItem[], certif
         issuer: e.institution,
         date: formatDateRange(e.start_date, null, false),
         url: e.url || undefined,
+        imageUrl: e.image_url || undefined,
+        relatedProjectIds: e.related_project_ids || undefined,
       }));
       
     return { degrees, certifications };

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -53,10 +53,12 @@ export type BlogUpdate = Partial<BlogCreate>;
 
 export interface ApiExperience {
   id: string;
-  role: string;
+  role: { en: string; es: string };
   company: string;
-  date_range: string;
-  description: string[];
+  start_date: string | null;
+  end_date: string | null;
+  is_current: boolean;
+  description: { en: string[]; es: string[] };
   tech_stack: string[];
   sort_order: number;
 }
@@ -89,10 +91,14 @@ export type SkillCategoryUpdate = Partial<SkillCategoryCreate>;
 export interface ApiEducation {
   id: string;
   type: "degree" | "certification";
-  degree: string;
+  degree: { en: string; es: string };
   institution: string;
-  date_range: string;
-  description: string;
+  start_date: string | null;
+  end_date: string | null;
+  is_current: boolean;
+  status: "in_course" | "graduated" | "unfinished" | null;
+  status_note: string | null;
+  description: { en: string; es: string };
   image_url: string | null;
   url: string | null;
   related_project_ids: string[] | null;
@@ -138,6 +144,21 @@ export interface Profile {
 export interface ApiSkillGroup {
   title: string;
   skills: ApiSkill[];
+}
+
+// --- Helpers ---
+
+function formatDateRange(
+  start: string | null,
+  end: string | null,
+  isCurrent: boolean,
+): string {
+  if (!start) return "";
+  const fmt = (d: string) =>
+    new Date(d + "T00:00:00").toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  if (isCurrent) return `${fmt(start)} – Present`;
+  if (!end) return fmt(start);
+  return `${fmt(start)} – ${fmt(end)}`;
 }
 
 // --- Public Data Fetchers ---
@@ -314,10 +335,10 @@ export async function getExperience(): Promise<ExperienceItem[]> {
 
     return data.map((e: ApiExperience) => ({
       id: e.id,
-      role: e.role,
+      role: e.role?.en ?? "",
       company: e.company,
-      dateRange: e.date_range,
-      description: e.description,
+      dateRange: formatDateRange(e.start_date, e.end_date, e.is_current),
+      description: e.description?.en ?? [],
       techStack: e.tech_stack,
     }));
   } catch (error) {
@@ -362,19 +383,19 @@ export async function getEducation(): Promise<{ degrees: EducationItem[], certif
       .filter(e => e.type === "degree")
       .map(e => ({
         id: e.id,
-        degree: e.degree,
+        degree: e.degree?.en ?? "",
         institution: e.institution,
-        dateRange: e.date_range,
-        description: e.description,
+        dateRange: formatDateRange(e.start_date, e.end_date, e.is_current),
+        description: e.description?.en ?? "",
       }));
-      
+
     const certifications = data
       .filter(e => e.type === "certification")
       .map(e => ({
         id: e.id,
-        name: e.degree,
+        name: e.degree?.en ?? "",
         issuer: e.institution,
-        date: e.date_range,
+        date: formatDateRange(e.start_date, null, false),
         url: e.url || undefined,
       }));
       

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -270,6 +270,8 @@ export interface EducationItem {
   description: string;
   imageUrl?: string;
   relatedProjectIds?: string[];
+  status?: "in_course" | "graduated" | "unfinished";
+  status_note?: string;
 }
 
 export interface CertificationItem {

--- a/lib/schemas/_localized.ts
+++ b/lib/schemas/_localized.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const LocalizedText = z.object({
+  en: z.string(),
+  es: z.string().default(""),
+});
+
+export const LocalizedList = z.object({
+  en: z.array(z.string()).default([]),
+  es: z.array(z.string()).default([]),
+});
+
+export type LocalizedText = z.infer<typeof LocalizedText>;
+export type LocalizedList = z.infer<typeof LocalizedList>;

--- a/lib/schemas/education.ts
+++ b/lib/schemas/education.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { LocalizedText } from "./_localized";
+
+export const DegreeStatus = z.enum(["in_course", "graduated", "unfinished"]);
+
+export const EducationCreate = z.object({
+  type: z.enum(["degree", "certification"]).default("degree"),
+  degree: LocalizedText,
+  institution: z.string().min(1, "Institution is required"),
+  start_date: z.string().nullable().default(null),
+  end_date: z.string().nullable().default(null),
+  is_current: z.boolean().default(false),
+  status: DegreeStatus.nullable().default(null),
+  status_note: z.string().max(200).nullable().default(null),
+  description: LocalizedText.default({ en: "", es: "" }),
+  image_url: z.string().nullable().default(null),
+  url: z.string().nullable().default(null),
+  related_project_ids: z.array(z.string()).nullable().default(null),
+  sort_order: z.number().int().default(0),
+}).refine(
+  (v) => !v.is_current || v.end_date === null,
+  { message: "If currently studying, end date must be empty.", path: ["end_date"] },
+).refine(
+  (v) => v.end_date === null || v.start_date === null || v.end_date >= v.start_date,
+  { message: "End date must be after start date.", path: ["end_date"] },
+);
+
+export type EducationCreate = z.infer<typeof EducationCreate>;

--- a/lib/schemas/experience.ts
+++ b/lib/schemas/experience.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { LocalizedText, LocalizedList } from "./_localized";
+
+export const ExperienceCreate = z.object({
+  role: LocalizedText,
+  company: z.string().min(1, "Company is required"),
+  start_date: z.string().min(1, "Start date is required"),
+  end_date: z.string().nullable().default(null),
+  is_current: z.boolean().default(false),
+  description: LocalizedList,
+  tech_stack: z.array(z.string()).default([]),
+  sort_order: z.number().int().default(0),
+}).refine(
+  (v) => !v.is_current || v.end_date === null,
+  { message: "If 'Currently here' is checked, end date must be empty.", path: ["end_date"] },
+).refine(
+  (v) => v.end_date === null || v.end_date >= v.start_date,
+  { message: "End date must be after start date.", path: ["end_date"] },
+);
+
+export type ExperienceCreate = z.infer<typeof ExperienceCreate>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,16 @@
       "name": "zergcore-portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.11.0",
         "next": "15.3.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.75.0",
         "react-icons": "^5.6.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -219,6 +222,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1020,6 +1035,12 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -5314,6 +5335,22 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-icons": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
@@ -6405,6 +6442,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.3.8",
+    "@hookform/resolvers": "^5.2.2",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.11.0",
+    "next": "15.3.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.75.0",
     "react-icons": "^5.6.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "software engineer"
   ],
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
## Summary

- Add Zod schemas for `ExperienceCreate` and `EducationCreate` with all structured-date fields and cross-field refinements
- Update `ApiExperience` / `ApiEducation` types in `lib/api.ts` to match new JSONB backend shapes
- Add `formatDateRange()` helper so public site components stay unchanged until chunk 4
- New shared form components: `DateField`, `CheckboxField`, `LocalizedTextField`, `LocalizedListField`
- Rewrite `ExperienceFormModal` and `EducationFormModal` with `react-hook-form` + `zodResolver`
- Fix `LocalizedTextField` error-path cast (one extra nesting level removed)
- Standardize `actions/experience.ts` to `ServerActionResponse<T>` discriminated union (matches education pattern)

## Dependencies

Requires backend PR #5 (`0002_edu_exp_structured` migration) to be merged and applied first.

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [ ] Smoke: open Experience modal, fill EN/ES role, dates, description bullets — saves correctly
- [ ] Smoke: open Education modal, switch type → certification → status fields hidden; switch back → status visible
- [ ] `is_current` checkbox clears end date and disables the field
- [ ] Validation errors surface correctly (empty required fields, end < start)