### PR TITLE
feat(projects): filterable projects page, skill multi-select, i18n keys (Chunk 5)

### DIFF
--- a/app/[locale]/projects/page.tsx
+++ b/app/[locale]/projects/page.tsx
@@ -1,4 +1,3 @@
-import Image from "next/image";
 import { getTranslations } from "next-intl/server";
 import { Link } from "@/lib/i18n/navigation";
 import Navbar from "@/components/layout/Navbar";
@@ -7,8 +6,9 @@ import WhatsAppFAB from "@/components/layout/WhatsAppFAB";
 import Section from "@/components/ui/Section";
 import CTABanner from "@/components/ui/CTABanner";
 import Container from "@/components/ui/Container";
-import { getProjects } from "@/lib/api";
-import { ArrowLeft, ExternalLink, ArrowRight } from "lucide-react";
+import ProjectsFilter from "@/components/sections/ProjectsFilter";
+import { getProjects, getProjectsGrouped, getSkillsFlat } from "@/lib/api";
+import { ArrowLeft } from "lucide-react";
 
 export async function generateMetadata() {
   const t = await getTranslations("projects");
@@ -18,11 +18,31 @@ export async function generateMetadata() {
   };
 }
 
-export default async function ProjectsPage() {
-  const [projects, t, tCta] = await Promise.all([
-    getProjects(),
+type GroupMode = "none" | "category" | "primary_skill";
+
+interface PageProps {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ skills?: string; group?: string }>;
+}
+
+export default async function ProjectsPage({ params, searchParams }: PageProps) {
+  const { locale } = await params;
+  const { skills: rawSkills, group: rawGroup } = await searchParams;
+
+  const selectedSkillIds = rawSkills ? rawSkills.split(",").filter(Boolean) : [];
+  const groupMode: GroupMode =
+    rawGroup === "category" || rawGroup === "primary_skill" ? rawGroup : "none";
+
+  const [t, tCta, allSkills, projects, groups] = await Promise.all([
     getTranslations("projects"),
     getTranslations("cta"),
+    getSkillsFlat(),
+    groupMode === "none"
+      ? getProjects({ skills: selectedSkillIds })
+      : Promise.resolve([]),
+    groupMode !== "none"
+      ? getProjectsGrouped({ skills: selectedSkillIds, group: groupMode })
+      : Promise.resolve([]),
   ]);
 
   return (
@@ -51,68 +71,14 @@ export default async function ProjectsPage() {
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
-            {projects.map((project) => (
-              <article
-                key={project.id}
-                className="group flex flex-col rounded-xl bg-[var(--bg-elevated)] border border-[var(--border-subtle)] hover:border-[var(--accent-cyan)]/40 transition-all duration-300 overflow-hidden"
-              >
-                <div className="relative h-48 bg-[var(--bg-surface)] overflow-hidden">
-                  <Image
-                    src={project.imageUrl}
-                    alt={project.title}
-                    fill
-                    className="object-cover opacity-60 group-hover:opacity-80 group-hover:scale-105 transition-all duration-500"
-                    sizes="(max-width: 768px) 100vw, 50vw"
-                  />
-                  <div className="absolute top-0 left-0 right-0 h-1 bg-[image:var(--gradient-brand)] opacity-60 group-hover:opacity-100 transition-opacity" />
-                </div>
-
-                <div className="flex flex-col flex-1 p-6">
-                  <div className="flex flex-wrap gap-1.5 mb-3">
-                    {project.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="text-[10px] font-mono px-2 py-0.5 rounded bg-[var(--bg-surface)] text-[var(--text-muted)] border border-[var(--border-default)]"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-
-                  <h2 className="text-xl font-bold text-[var(--text-primary)] mb-2 group-hover:text-[var(--accent-cyan)] transition-colors">
-                    {project.title}
-                  </h2>
-                  <p className="text-sm text-[var(--text-secondary)] leading-relaxed flex-1 mb-6">
-                    {project.description}
-                  </p>
-
-                  <div className="flex flex-wrap items-center gap-3 mt-auto">
-                    {project.caseStudyUrl && (
-                      <Link
-                        href={project.caseStudyUrl as `/projects/${string}`}
-                        className="inline-flex items-center gap-1.5 text-sm font-semibold text-[var(--accent-cyan)] hover:underline"
-                      >
-                        {t("caseStudy")}
-                        <ArrowRight size={14} />
-                      </Link>
-                    )}
-                    {project.liveUrl && (
-                      <a
-                        href={project.liveUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-                      >
-                        <ExternalLink size={13} />
-                        {t("liveDemo")}
-                      </a>
-                    )}
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
+          <ProjectsFilter
+            allSkills={allSkills}
+            projects={projects}
+            groups={groups}
+            selectedSkillIds={selectedSkillIds}
+            groupMode={groupMode}
+            locale={locale}
+          />
         </Section>
 
         <Container className="py-8">

--- a/app/[locale]/projects/page.tsx
+++ b/app/[locale]/projects/page.tsx
@@ -7,7 +7,7 @@ import Section from "@/components/ui/Section";
 import CTABanner from "@/components/ui/CTABanner";
 import Container from "@/components/ui/Container";
 import ProjectsFilter from "@/components/sections/ProjectsFilter";
-import { getProjects, getProjectsGrouped, getSkillsFlat } from "@/lib/api";
+import { getProjectsRaw, getProjectsGrouped, getSkillsFlat, mapApiProject } from "@/lib/api";
 import { ArrowLeft } from "lucide-react";
 
 export async function generateMetadata() {
@@ -33,17 +33,24 @@ export default async function ProjectsPage({ params, searchParams }: PageProps) 
   const groupMode: GroupMode =
     rawGroup === "category" || rawGroup === "primary_skill" ? rawGroup : "none";
 
-  const [t, tCta, allSkills, projects, groups] = await Promise.all([
+  const [t, tCta, allSkills, allProjectsRaw, filteredRaw, groups] = await Promise.all([
     getTranslations("projects"),
     getTranslations("cta"),
     getSkillsFlat(),
+    // Fetch all projects (no skill filter) to compute which skills are actually linked
+    getProjectsRaw(),
     groupMode === "none"
-      ? getProjects({ skills: selectedSkillIds })
+      ? getProjectsRaw({ skills: selectedSkillIds })
       : Promise.resolve([]),
     groupMode !== "none"
       ? getProjectsGrouped({ skills: selectedSkillIds, group: groupMode })
       : Promise.resolve([]),
   ]);
+
+  // Only show chips for skills that are actually linked to at least one project
+  const usedSkillIds = new Set(allProjectsRaw.flatMap(p => p.skills.map(s => s.id)));
+  const chipSkills = allSkills.filter(s => usedSkillIds.has(s.id));
+  const projects = filteredRaw.map(mapApiProject);
 
   return (
     <>
@@ -72,7 +79,7 @@ export default async function ProjectsPage({ params, searchParams }: PageProps) 
           </div>
 
           <ProjectsFilter
-            allSkills={allSkills}
+            allSkills={chipSkills}
             projects={projects}
             groups={groups}
             selectedSkillIds={selectedSkillIds}

--- a/app/admin/(dashboard)/projects/ProjectFormModal.tsx
+++ b/app/admin/(dashboard)/projects/ProjectFormModal.tsx
@@ -2,27 +2,37 @@
 
 import { useState } from "react";
 import { Project } from "@/lib/mockData";
+import { ApiSkill } from "@/lib/api";
 import {
   createProjectAction,
   updateProjectAction,
 } from "@/app/actions/projects";
 import Button from "@/components/ui/Button";
 import MultiImageUpload, { ProjectImage } from "@/components/admin/MultiImageUpload";
+import SkillMultiSelect from "@/components/admin/forms/SkillMultiSelect";
 import { FiX } from "react-icons/fi";
 
 interface ProjectFormModalProps {
   project: Project | null;
+  allSkills: ApiSkill[];
   onClose: () => void;
   onSuccess: (p: Project) => void;
 }
 
 export default function ProjectFormModal({
   project,
+  allSkills,
   onClose,
   onSuccess,
 }: ProjectFormModalProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [images, setImages] = useState<ProjectImage[]>(project?.images || []);
+  const initialSkillIds: string[] = (() => {
+    if (!project) return [];
+    const skills = (project as unknown as { skills?: { id: string }[] }).skills;
+    return skills?.map(s => s.id) ?? [];
+  })();
+  const [skillIds, setSkillIds] = useState<string[]>(initialSkillIds);
   const [error, setError] = useState("");
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -31,11 +41,14 @@ export default function ProjectFormModal({
     setError("");
 
     const fd = new FormData(e.currentTarget);
+    const titleEn = fd.get("title") as string;
+    const descriptionEn = fd.get("description") as string;
+
     const data = {
-      title: fd.get("title") as string,
+      title: { en: titleEn, es: "" },
       slug: fd.get("slug") as string,
-      description: fd.get("description") as string,
-      images: images,
+      description: { en: descriptionEn, es: "" },
+      images,
       image_url: images.find(img => img.is_primary)?.url || null,
       tags: (fd.get("tags") as string)
         .split(",")
@@ -45,13 +58,14 @@ export default function ProjectFormModal({
       live_url: (fd.get("live_url") as string) || null,
       is_featured: fd.get("is_featured") === "on",
       sort_order: parseInt(fd.get("sort_order") as string) || 0,
-      // Default nulls for case study fields until form is expanded
+      skill_ids: skillIds,
       role: null,
       timeline: null,
       problem: null,
       approach: null,
       outcomes: null,
       gallery: null,
+      primary_category_id: null,
     };
 
     let res;
@@ -67,22 +81,29 @@ export default function ProjectFormModal({
       setError(res.error);
     } else if (res.success) {
       const p = res.data;
-      const primaryImage = p.images?.find((img: { is_primary: boolean; url: string }) => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
+      const primaryImage =
+        p.images?.find((img: { is_primary: boolean; url: string }) => img.is_primary)?.url ||
+        p.image_url ||
+        "/placeholder-project.jpg";
       onSuccess({
         id: p.id,
         slug: p.slug,
-        title: p.title,
-        description: p.description,
+        title: p.title?.en ?? p.title ?? "",
+        description: p.description?.en ?? p.description ?? "",
         imageUrl: primaryImage,
         images: p.images || [],
         tags: p.tags || [],
         githubUrl: p.github_url,
         liveUrl: p.live_url,
-        role: p.role,
+        role: p.role?.en ?? p.role ?? undefined,
         timeline: p.timeline,
-        problem: p.problem,
-        approach: p.approach || [],
-        outcomes: p.outcomes || [],
+        problem: p.problem?.en ?? p.problem ?? undefined,
+        approach: (p.approach as Array<{heading: {en:string}|string; body: {en:string}|string}>|null)
+          ?.map(s => ({
+            heading: typeof s.heading === "string" ? s.heading : s.heading.en ?? "",
+            body: typeof s.body === "string" ? s.body : s.body.en ?? "",
+          })) || [],
+        outcomes: p.outcomes?.en ?? p.outcomes ?? [],
         gallery: p.gallery || [],
         is_featured: p.is_featured,
         sort_order: p.sort_order,
@@ -115,11 +136,15 @@ export default function ProjectFormModal({
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
               <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Title *
+                Title (EN) *
               </label>
               <input
                 name="title"
-                defaultValue={project?.title}
+                defaultValue={
+                  typeof project?.title === "string"
+                    ? project.title
+                    : (project?.title as unknown as { en: string })?.en ?? ""
+                }
                 required
                 className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
               />
@@ -139,11 +164,15 @@ export default function ProjectFormModal({
 
           <div className="space-y-2">
             <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Description *
+              Description (EN) *
             </label>
             <textarea
               name="description"
-              defaultValue={project?.description}
+              defaultValue={
+                typeof project?.description === "string"
+                  ? project.description
+                  : (project?.description as unknown as { en: string })?.en ?? ""
+              }
               required
               rows={3}
               className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
@@ -158,9 +187,15 @@ export default function ProjectFormModal({
             />
           </div>
 
+          <SkillMultiSelect
+            allSkills={allSkills}
+            selectedIds={skillIds}
+            onChange={setSkillIds}
+          />
+
           <div className="space-y-2">
             <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Tags (comma separated)
+              Tags (comma separated, legacy)
             </label>
             <input
               name="tags"

--- a/app/admin/(dashboard)/projects/ProjectsClient.tsx
+++ b/app/admin/(dashboard)/projects/ProjectsClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Project } from "@/lib/mockData";
+import { ApiSkill } from "@/lib/api";
 import { FiPlus, FiEdit2, FiTrash2, FiExternalLink } from "react-icons/fi";
 import Button from "@/components/ui/Button";
 import { deleteProjectAction } from "@/app/actions/projects";
@@ -9,8 +10,10 @@ import ProjectFormModal from "./ProjectFormModal";
 
 export default function ProjectsClient({
   initialProjects,
+  allSkills,
 }: {
   initialProjects: Project[];
+  allSkills: ApiSkill[];
 }) {
   const [projects, setProjects] = useState<Project[]>(initialProjects);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -135,6 +138,7 @@ export default function ProjectsClient({
       {isModalOpen && (
         <ProjectFormModal
           project={editingProject}
+          allSkills={allSkills}
           onClose={() => setIsModalOpen(false)}
           onSuccess={(savedProject) => {
             setIsModalOpen(false);

--- a/app/admin/(dashboard)/projects/page.tsx
+++ b/app/admin/(dashboard)/projects/page.tsx
@@ -1,10 +1,10 @@
-import { getProjects } from "@/lib/api";
+import { getProjects, getSkillsFlat } from "@/lib/api";
 import ProjectsClient from "./ProjectsClient";
 
-export const revalidate = 0; // Don't cache admin page
+export const revalidate = 0;
 
 export default async function AdminProjectsPage() {
-  const projects = await getProjects();
+  const [projects, allSkills] = await Promise.all([getProjects(), getSkillsFlat()]);
 
   return (
     <div className="max-w-6xl mx-auto">
@@ -17,7 +17,7 @@ export default async function AdminProjectsPage() {
         </p>
       </div>
 
-      <ProjectsClient initialProjects={projects} />
+      <ProjectsClient initialProjects={projects} allSkills={allSkills} />
     </div>
   );
 }

--- a/components/admin/forms/SkillMultiSelect.tsx
+++ b/components/admin/forms/SkillMultiSelect.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { ApiSkill } from "@/lib/api";
+import { FiX } from "react-icons/fi";
+
+interface Props {
+  allSkills: ApiSkill[];
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+}
+
+export default function SkillMultiSelect({ allSkills, selectedIds, onChange }: Props) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedSkills = allSkills.filter(s => selectedIds.includes(s.id));
+  const candidates = allSkills.filter(
+    s => !selectedIds.includes(s.id) && s.name.toLowerCase().includes(query.toLowerCase())
+  );
+
+  function toggle(id: string) {
+    if (selectedIds.includes(id)) {
+      onChange(selectedIds.filter(x => x !== id));
+    } else {
+      onChange([...selectedIds, id]);
+      setQuery("");
+    }
+  }
+
+  useEffect(() => {
+    function onClickOutside(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, []);
+
+  return (
+    <div className="space-y-2" ref={containerRef}>
+      <label className="text-sm font-medium text-[var(--text-secondary)]">Skills</label>
+
+      {selectedSkills.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selectedSkills.map(s => (
+            <span
+              key={s.id}
+              className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] border border-[var(--accent-violet)]/30"
+            >
+              {s.name}
+              <button
+                type="button"
+                onClick={() => toggle(s.id)}
+                className="hover:text-[var(--color-error)] transition-colors"
+                aria-label={`Remove ${s.name}`}
+              >
+                <FiX size={12} />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="relative">
+        <input
+          type="text"
+          placeholder="Type to search skills…"
+          value={query}
+          onChange={e => { setQuery(e.target.value); setOpen(true); }}
+          onFocus={() => setOpen(true)}
+          className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none text-sm"
+        />
+
+        {open && candidates.length > 0 && (
+          <ul className="absolute z-20 mt-1 w-full max-h-48 overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] shadow-xl">
+            {candidates.map(s => (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  onClick={() => toggle(s.id)}
+                  className="w-full text-left px-4 py-2 text-sm text-[var(--text-primary)] hover:bg-[var(--bg-elevated)] transition-colors"
+                >
+                  {s.name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/sections/Projects.tsx
+++ b/components/sections/Projects.tsx
@@ -6,7 +6,7 @@ import { getProjects } from "@/lib/api";
 import { ArrowRight } from "lucide-react";
 
 export default async function Projects() {
-  const projects = await getProjects(true);
+  const projects = await getProjects({ featured: true });
 
   return (
     <Section id="projects">

--- a/components/sections/ProjectsFilter.tsx
+++ b/components/sections/ProjectsFilter.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import Image from "next/image";
+import { Link } from "@/lib/i18n/navigation";
+import type { Project } from "@/lib/mockData";
+import type { ApiSkill, ApiProjectGroup, LocalizedText } from "@/lib/api";
+import { ArrowRight, ExternalLink, X } from "lucide-react";
+
+type GroupMode = "none" | "category" | "primary_skill";
+
+interface Props {
+  allSkills: ApiSkill[];
+  projects: Project[];
+  groups: ApiProjectGroup[];
+  selectedSkillIds: string[];
+  groupMode: GroupMode;
+  locale: string;
+}
+
+function getLocalizedLabel(label: LocalizedText | string, locale: string): string {
+  if (typeof label === "string") return label;
+  return label[locale as keyof LocalizedText] || label.en || "";
+}
+
+function ProjectArticle({ project, t }: { project: Project; t: ReturnType<typeof useTranslations> }) {
+  return (
+    <article className="group flex flex-col rounded-xl bg-[var(--bg-elevated)] border border-[var(--border-subtle)] hover:border-[var(--accent-cyan)]/40 transition-all duration-300 overflow-hidden">
+      <div className="relative h-48 bg-[var(--bg-surface)] overflow-hidden">
+        <Image
+          src={project.imageUrl}
+          alt={project.title}
+          fill
+          className="object-cover opacity-60 group-hover:opacity-80 group-hover:scale-105 transition-all duration-500"
+          sizes="(max-width: 768px) 100vw, 50vw"
+        />
+        <div className="absolute top-0 left-0 right-0 h-1 bg-[image:var(--gradient-brand)] opacity-60 group-hover:opacity-100 transition-opacity" />
+      </div>
+
+      <div className="flex flex-col flex-1 p-6">
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {project.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-[10px] font-mono px-2 py-0.5 rounded bg-[var(--bg-surface)] text-[var(--text-muted)] border border-[var(--border-default)]"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <h2 className="text-xl font-bold text-[var(--text-primary)] mb-2 group-hover:text-[var(--accent-cyan)] transition-colors">
+          {project.title}
+        </h2>
+        <p className="text-sm text-[var(--text-secondary)] leading-relaxed flex-1 mb-6">
+          {project.description}
+        </p>
+
+        <div className="flex flex-wrap items-center gap-3 mt-auto">
+          {project.caseStudyUrl && (
+            <Link
+              href={project.caseStudyUrl as `/projects/${string}`}
+              className="inline-flex items-center gap-1.5 text-sm font-semibold text-[var(--accent-cyan)] hover:underline"
+            >
+              {t("caseStudy")}
+              <ArrowRight size={14} />
+            </Link>
+          )}
+          {project.liveUrl && (
+            <a
+              href={project.liveUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+            >
+              <ExternalLink size={13} />
+              {t("liveDemo")}
+            </a>
+          )}
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default function ProjectsFilter({
+  allSkills,
+  projects,
+  groups,
+  selectedSkillIds,
+  groupMode,
+  locale,
+}: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const t = useTranslations("projects");
+
+  function buildUrl(skillIds: string[], mode: GroupMode) {
+    const params = new URLSearchParams();
+    if (skillIds.length) params.set("skills", skillIds.join(","));
+    if (mode !== "none") params.set("group", mode);
+    const qs = params.toString();
+    return qs ? `${pathname}?${qs}` : pathname;
+  }
+
+  function toggleSkill(id: string) {
+    const next = selectedSkillIds.includes(id)
+      ? selectedSkillIds.filter(x => x !== id)
+      : [...selectedSkillIds, id];
+    router.push(buildUrl(next, groupMode));
+  }
+
+  function setGroupMode(mode: GroupMode) {
+    router.push(buildUrl(selectedSkillIds, mode));
+  }
+
+  function clearFilters() {
+    router.push(pathname);
+  }
+
+  const hasFilters = selectedSkillIds.length > 0;
+  // Show all skills when there are no projects yet; otherwise show all skills
+  // (backend filters which projects are returned — the chip set stays stable)
+  const displaySkills = allSkills;
+
+  const GROUP_MODES: { value: GroupMode; labelKey: string }[] = [
+    { value: "none", labelKey: "groupByNone" },
+    { value: "category", labelKey: "groupByCategory" },
+    { value: "primary_skill", labelKey: "groupByPrimarySkill" },
+  ];
+
+  const isEmpty = groupMode === "none" ? projects.length === 0 : groups.length === 0;
+
+  return (
+    <div className="space-y-8">
+      {/* Filter bar */}
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+            {t("filterBySkills")}
+          </span>
+          {displaySkills.map(s => {
+            const active = selectedSkillIds.includes(s.id);
+            return (
+              <button
+                key={s.id}
+                onClick={() => toggleSkill(s.id)}
+                className={[
+                  "inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-all",
+                  active
+                    ? "bg-[var(--accent-cyan)]/15 text-[var(--accent-cyan)] border-[var(--accent-cyan)]/40"
+                    : "bg-[var(--bg-elevated)] text-[var(--text-secondary)] border-[var(--border-default)] hover:border-[var(--accent-cyan)]/30",
+                ].join(" ")}
+              >
+                {s.name}
+                {active && <X size={10} />}
+              </button>
+            );
+          })}
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="text-xs text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors underline"
+            >
+              {t("clearFilters")}
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+            {t("groupBy")}
+          </span>
+          <div className="flex rounded-lg border border-[var(--border-default)] overflow-hidden">
+            {GROUP_MODES.map(({ value, labelKey }) => (
+              <button
+                key={value}
+                onClick={() => setGroupMode(value)}
+                className={[
+                  "px-3 py-1.5 text-xs font-medium transition-colors",
+                  groupMode === value
+                    ? "bg-[var(--accent-violet)]/15 text-[var(--accent-violet)]"
+                    : "text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]",
+                ].join(" ")}
+              >
+                {t(labelKey as Parameters<typeof t>[0])}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Results */}
+      {isEmpty ? (
+        <div className="flex flex-col items-center gap-4 py-16 text-center">
+          <p className="text-[var(--text-secondary)]">{t("noProjectsMatch")}</p>
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="text-sm text-[var(--accent-cyan)] hover:underline"
+            >
+              {t("clearFilters")}
+            </button>
+          )}
+        </div>
+      ) : groupMode === "none" ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+          {projects.map(p => <ProjectArticle key={p.id} project={p} t={t} />)}
+        </div>
+      ) : (
+        <div className="space-y-12">
+          {groups.map(group => (
+            <section key={group.key}>
+              <h2 className="text-lg font-bold text-[var(--text-primary)] mb-6 flex items-center gap-3">
+                <span className="w-8 h-0.5 bg-[var(--accent-cyan)] inline-block" />
+                {getLocalizedLabel(group.label, locale)}
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+                {group.items.map(p => {
+                  const primaryImage =
+                    p.images?.find(img => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
+                  const displayProject: Project = {
+                    id: p.id,
+                    slug: p.slug,
+                    title: typeof p.title === "string" ? p.title : p.title.en || "",
+                    description: typeof p.description === "string" ? p.description : p.description.en || "",
+                    imageUrl: primaryImage,
+                    images: p.images || [],
+                    tags: p.tags || [],
+                    githubUrl: p.github_url || undefined,
+                    liveUrl: p.live_url || undefined,
+                    caseStudyUrl: p.problem || p.role ? `/projects/${p.slug}` : undefined,
+                    is_featured: p.is_featured,
+                    sort_order: p.sort_order,
+                  };
+                  return <ProjectArticle key={p.id} project={displayProject} t={t} />;
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/sections/ProjectsFilter.tsx
+++ b/components/sections/ProjectsFilter.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useRouter, usePathname } from "next/navigation";
+import { useState } from "react";
+import { useRouter, usePathname } from "@/lib/i18n/navigation";
 import { useTranslations } from "next-intl";
 import Image from "next/image";
 import { Link } from "@/lib/i18n/navigation";
@@ -9,6 +10,8 @@ import type { ApiSkill, ApiProjectGroup, LocalizedText } from "@/lib/api";
 import { ArrowRight, ExternalLink, X } from "lucide-react";
 
 type GroupMode = "none" | "category" | "primary_skill";
+
+const CHIP_LIMIT = 12;
 
 interface Props {
   allSkills: ApiSkill[];
@@ -95,6 +98,7 @@ export default function ProjectsFilter({
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations("projects");
+  const [showAllChips, setShowAllChips] = useState(false);
 
   function buildUrl(skillIds: string[], mode: GroupMode) {
     const params = new URLSearchParams();
@@ -116,13 +120,19 @@ export default function ProjectsFilter({
   }
 
   function clearFilters() {
+    setShowAllChips(false);
     router.push(pathname);
   }
 
   const hasFilters = selectedSkillIds.length > 0;
-  // Show all skills when there are no projects yet; otherwise show all skills
-  // (backend filters which projects are returned — the chip set stays stable)
-  const displaySkills = allSkills;
+
+  // Ensure selected chips are always visible even if beyond CHIP_LIMIT
+  const hasHiddenSelected =
+    !showAllChips &&
+    allSkills.slice(CHIP_LIMIT).some(s => selectedSkillIds.includes(s.id));
+  const expanded = showAllChips || hasHiddenSelected;
+  const visibleSkills = expanded ? allSkills : allSkills.slice(0, CHIP_LIMIT);
+  const hiddenCount = allSkills.length - visibleSkills.length;
 
   const GROUP_MODES: { value: GroupMode; labelKey: string }[] = [
     { value: "none", labelKey: "groupByNone" },
@@ -136,37 +146,55 @@ export default function ProjectsFilter({
     <div className="space-y-8">
       {/* Filter bar */}
       <div className="flex flex-col gap-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-            {t("filterBySkills")}
-          </span>
-          {displaySkills.map(s => {
-            const active = selectedSkillIds.includes(s.id);
-            return (
+        {allSkills.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+              {t("filterBySkills")}
+            </span>
+            {visibleSkills.map(s => {
+              const active = selectedSkillIds.includes(s.id);
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => toggleSkill(s.id)}
+                  className={[
+                    "inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-all",
+                    active
+                      ? "bg-[var(--accent-cyan)]/15 text-[var(--accent-cyan)] border-[var(--accent-cyan)]/40"
+                      : "bg-[var(--bg-elevated)] text-[var(--text-secondary)] border-[var(--border-default)] hover:border-[var(--accent-cyan)]/30",
+                  ].join(" ")}
+                >
+                  {s.name}
+                  {active && <X size={10} />}
+                </button>
+              );
+            })}
+            {hiddenCount > 0 && (
               <button
-                key={s.id}
-                onClick={() => toggleSkill(s.id)}
-                className={[
-                  "inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-all",
-                  active
-                    ? "bg-[var(--accent-cyan)]/15 text-[var(--accent-cyan)] border-[var(--accent-cyan)]/40"
-                    : "bg-[var(--bg-elevated)] text-[var(--text-secondary)] border-[var(--border-default)] hover:border-[var(--accent-cyan)]/30",
-                ].join(" ")}
+                onClick={() => setShowAllChips(true)}
+                className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors px-2 py-1 rounded-full border border-dashed border-[var(--border-default)]"
               >
-                {s.name}
-                {active && <X size={10} />}
+                +{hiddenCount} {t("moreFilters")}
               </button>
-            );
-          })}
-          {hasFilters && (
-            <button
-              onClick={clearFilters}
-              className="text-xs text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors underline"
-            >
-              {t("clearFilters")}
-            </button>
-          )}
-        </div>
+            )}
+            {showAllChips && allSkills.length > CHIP_LIMIT && (
+              <button
+                onClick={() => setShowAllChips(false)}
+                className="text-xs text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors underline"
+              >
+                {t("showFewer")}
+              </button>
+            )}
+            {hasFilters && (
+              <button
+                onClick={clearFilters}
+                className="text-xs text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors underline"
+              >
+                {t("clearFilters")}
+              </button>
+            )}
+          </div>
+        )}
 
         <div className="flex items-center gap-2">
           <span className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -297,7 +297,7 @@ export async function uploadImage(file: File): Promise<{ url: string, public_id:
   }
 }
 
-function mapApiProject(p: ApiProject): Project {
+export function mapApiProject(p: ApiProject): Project {
   const primaryImage = p.images?.find(img => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
   const loc = (f: LocalizedText | string | null | undefined) => getEnText(f);
   return {
@@ -340,6 +340,25 @@ export async function getProjects(params?: {
     return data.map((p: ApiProject) => mapApiProject(p));
   } catch (error) {
     console.error("Error fetching projects:", error);
+    return [];
+  }
+}
+
+export async function getProjectsRaw(params?: {
+  featured?: boolean;
+  skills?: string[];
+}): Promise<ApiProject[]> {
+  try {
+    const url = new URL(`${API_BASE_URL}/projects`);
+    if (params?.featured !== undefined) url.searchParams.set("featured", params.featured.toString());
+    if (params?.skills?.length) url.searchParams.set("skills", params.skills.join(","));
+    const res = await fetch(url.toString(), { next: { revalidate: 60 } } as NextFetchOptions);
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data as ApiProject[];
+  } catch (error) {
+    console.error("Error fetching projects raw:", error);
     return [];
   }
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -22,28 +22,42 @@ export interface ApiProjectImage {
   is_primary: boolean;
 }
 
+export interface ApiSkillRef {
+  id: string;
+  name: string;
+  category_id: string | null;
+}
+
 export interface ApiProject {
   id: string;
   slug: string;
-  title: string;
-  description: string;
+  title: LocalizedText;
+  description: LocalizedText;
   images: ApiProjectImage[] | null;
-  // Deprecated fields
+  // Deprecated (read-only post-migration)
   image_url: string | null;
   gallery: string[] | null;
   tags: string[] | null;
   github_url: string | null;
   live_url: string | null;
-  role: string | null;
+  role: LocalizedText | null;
   timeline: string | null;
-  problem: string | null;
-  approach: { heading: string; body: string }[] | null;
-  outcomes: string[] | null;
+  problem: LocalizedText | null;
+  approach: Array<{ heading: LocalizedText; body: LocalizedText }> | null;
+  outcomes: { en: string[]; es: string[] } | null;
   is_featured: boolean;
   sort_order: number;
+  primary_category_id: string | null;
+  skills: ApiSkillRef[];
 }
 
-export type ProjectCreate = Omit<ApiProject, 'id'>;
+export interface ApiProjectGroup {
+  key: string;
+  label: LocalizedText;
+  items: ApiProject[];
+}
+
+export type ProjectCreate = Omit<ApiProject, 'id' | 'skills'> & { skill_ids?: string[] };
 export type ProjectUpdate = Partial<ProjectCreate>;
 
 export interface ApiBlogPost {
@@ -283,42 +297,80 @@ export async function uploadImage(file: File): Promise<{ url: string, public_id:
   }
 }
 
-export async function getProjects(featured?: boolean): Promise<Project[]> {
+function mapApiProject(p: ApiProject): Project {
+  const primaryImage = p.images?.find(img => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
+  const loc = (f: LocalizedText | string | null | undefined) => getEnText(f);
+  return {
+    id: p.id,
+    slug: p.slug,
+    title: loc(p.title),
+    description: loc(p.description),
+    imageUrl: primaryImage,
+    images: p.images || [],
+    tags: p.tags || [],
+    githubUrl: p.github_url || undefined,
+    liveUrl: p.live_url || undefined,
+    caseStudyUrl: p.problem || p.role ? `/projects/${p.slug}` : undefined,
+    role: p.role ? loc(p.role) : undefined,
+    timeline: p.timeline || undefined,
+    problem: p.problem ? loc(p.problem) : undefined,
+    approach: p.approach?.map(s => ({
+      heading: loc(s.heading),
+      body: loc(s.body),
+    })),
+    outcomes: p.outcomes?.en,
+    gallery: p.gallery || [],
+    is_featured: p.is_featured,
+    sort_order: p.sort_order,
+  };
+}
+
+export async function getProjects(params?: {
+  featured?: boolean;
+  skills?: string[];
+}): Promise<Project[]> {
   try {
     const url = new URL(`${API_BASE_URL}/projects`);
-    if (featured !== undefined) {
-      url.searchParams.append("featured", featured.toString());
-    }
+    if (params?.featured !== undefined) url.searchParams.set("featured", params.featured.toString());
+    if (params?.skills?.length) url.searchParams.set("skills", params.skills.join(","));
     const res = await fetch(url.toString(), { next: { revalidate: 60 } } as NextFetchOptions);
     if (!res.ok) return [];
-    
     const data = await res.json();
     if (!Array.isArray(data)) return [];
-
-    return data.map((p: ApiProject) => {
-      const primaryImage = p.images?.find(img => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
-      return {
-        id: p.id,
-        slug: p.slug,
-        title: p.title,
-        description: p.description,
-        imageUrl: primaryImage,
-        images: p.images || [],
-        tags: p.tags || [],
-        githubUrl: p.github_url || undefined,
-        liveUrl: p.live_url || undefined,
-        role: p.role || undefined,
-        timeline: p.timeline || undefined,
-        problem: p.problem || undefined,
-        approach: p.approach || undefined,
-        outcomes: p.outcomes || undefined,
-        gallery: p.gallery || [],
-        is_featured: p.is_featured,
-        sort_order: p.sort_order,
-      };
-    });
+    return data.map((p: ApiProject) => mapApiProject(p));
   } catch (error) {
     console.error("Error fetching projects:", error);
+    return [];
+  }
+}
+
+export async function getProjectsGrouped(params: {
+  skills?: string[];
+  group: "category" | "primary_skill";
+}): Promise<ApiProjectGroup[]> {
+  try {
+    const url = new URL(`${API_BASE_URL}/projects`);
+    url.searchParams.set("group", params.group);
+    if (params.skills?.length) url.searchParams.set("skills", params.skills.join(","));
+    const res = await fetch(url.toString(), { next: { revalidate: 60 } } as NextFetchOptions);
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.groups as ApiProjectGroup[]) ?? [];
+  } catch (error) {
+    console.error("Error fetching grouped projects:", error);
+    return [];
+  }
+}
+
+export async function getSkillsFlat(): Promise<ApiSkill[]> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/skills`, { next: { revalidate: 60 } } as NextFetchOptions);
+    if (!res.ok) return [];
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.flatMap((g: ApiSkillGroup) => g.skills);
+  } catch (error) {
+    console.error("Error fetching skills flat:", error);
     return [];
   }
 }
@@ -327,28 +379,8 @@ export async function getProjectBySlug(slug: string): Promise<Project | null> {
   try {
     const res = await fetch(`${API_BASE_URL}/projects/${slug}`, { next: { revalidate: 60 } });
     if (!res.ok) return null;
-    
     const p: ApiProject = await res.json();
-    const primaryImage = p.images?.find(img => img.is_primary)?.url || p.image_url || "/placeholder-project.jpg";
-    return {
-      id: p.id,
-      slug: p.slug,
-      title: p.title,
-      description: p.description,
-      imageUrl: primaryImage,
-      images: p.images || [],
-      tags: p.tags || [],
-      githubUrl: p.github_url || undefined,
-      liveUrl: p.live_url || undefined,
-      role: p.role || undefined,
-      timeline: p.timeline || undefined,
-      problem: p.problem || undefined,
-      approach: p.approach || undefined,
-      outcomes: p.outcomes || undefined,
-      gallery: p.gallery || [],
-      is_featured: p.is_featured,
-      sort_order: p.sort_order,
-    };
+    return mapApiProject(p);  // locale ignored for now — project detail always shows EN
   } catch (error) {
     console.error(`Error fetching project ${slug}:`, error);
     return null;

--- a/messages/en.json
+++ b/messages/en.json
@@ -40,7 +40,15 @@
     "liveDemo": "Live Demo",
     "viewCode": "View Code",
     "caseStudy": "Case Study",
-    "backToProjects": "Back to Projects"
+    "backToProjects": "Back to Projects",
+    "filterBySkills": "Filter by skill",
+    "groupBy": "Group by",
+    "groupByNone": "All",
+    "groupByCategory": "Category",
+    "groupByPrimarySkill": "Primary skill",
+    "clearFilters": "Clear filters",
+    "noProjectsMatch": "No projects match these filters.",
+    "allProjects": "All Projects"
   },
   "skills": {
     "sectionLabel": "Technical",

--- a/messages/en.json
+++ b/messages/en.json
@@ -48,7 +48,9 @@
     "groupByPrimarySkill": "Primary skill",
     "clearFilters": "Clear filters",
     "noProjectsMatch": "No projects match these filters.",
-    "allProjects": "All Projects"
+    "allProjects": "All Projects",
+    "moreFilters": "more",
+    "showFewer": "Show fewer"
   },
   "skills": {
     "sectionLabel": "Technical",

--- a/messages/es.json
+++ b/messages/es.json
@@ -40,7 +40,15 @@
     "liveDemo": "Demo en vivo",
     "viewCode": "Ver código",
     "caseStudy": "Caso de estudio",
-    "backToProjects": "Volver a proyectos"
+    "backToProjects": "Volver a proyectos",
+    "filterBySkills": "Filtrar por habilidad",
+    "groupBy": "Agrupar por",
+    "groupByNone": "Todos",
+    "groupByCategory": "Categoría",
+    "groupByPrimarySkill": "Habilidad principal",
+    "clearFilters": "Limpiar filtros",
+    "noProjectsMatch": "Ningún proyecto coincide con estos filtros.",
+    "allProjects": "Todos los proyectos"
   },
   "skills": {
     "sectionLabel": "Habilidades",

--- a/messages/es.json
+++ b/messages/es.json
@@ -48,7 +48,9 @@
     "groupByPrimarySkill": "Habilidad principal",
     "clearFilters": "Limpiar filtros",
     "noProjectsMatch": "Ningún proyecto coincide con estos filtros.",
-    "allProjects": "Todos los proyectos"
+    "allProjects": "Todos los proyectos",
+    "moreFilters": "más",
+    "showFewer": "Ver menos"
   },
   "skills": {
     "sectionLabel": "Habilidades",


### PR DESCRIPTION
## Summary

- Updates `lib/api.ts`: `ApiProject` fields (`title`, `description`, `role`, `problem`, `outcomes`, `approach`) typed as `LocalizedText`; adds `ApiProjectGroup`, `getProjectsGrouped()`, `getSkillsFlat()`
- New `components/admin/forms/SkillMultiSelect.tsx`: typeahead multi-select for skills (no new deps)
- Admin `ProjectFormModal`: wires in `SkillMultiSelect`, submits `skill_ids`, handles both string and `LocalizedText` API shapes
- New `components/sections/ProjectsFilter.tsx`: client component with skill chip filters + group-by toggle (URL state via `?skills=&group=`)
- Rewrites `app/[locale]/projects/page.tsx` as a server component that passes filter state to `ProjectsFilter`
- Adds i18n keys to `messages/en.json` and `messages/es.json`: `filterBySkills`, `groupBy`, `groupByNone`, `groupByCategory`, `groupByPrimarySkill`, `clearFilters`, `noProjectsMatch`, `allProjects`

## Test plan

- [ ] `npm run lint` → no warnings/errors
- [ ] `npx tsc --noEmit` → clean
- [ ] `/projects` page renders with skill chips and group-by toggle
- [ ] Selecting a skill chip filters projects via URL `?skills=<id>`
- [ ] Group-by toggle switches between flat grid and grouped sections
- [ ] Admin: create/edit project modal shows skill multi-select
- [ ] Both EN and ES locales render filter labels correctly