### PR TITLE
feat(chunk-8): translation queue UI, AI usage dashboard, and UX fixes

### DIFF
--- a/app/actions/ai.ts
+++ b/app/actions/ai.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { cookies } from "next/headers";
+import type { AiUsageData } from "@/lib/types/ai";
+
+export type { AiUsageData } from "@/lib/types/ai";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
+
+export async function getAiUsage(): Promise<AiUsageData | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+
+  try {
+    const res = await fetch(`${API_BASE}/ai/usage`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return null;
+    return res.json() as Promise<AiUsageData>;
+  } catch {
+    return null;
+  }
+}

--- a/app/actions/translations.ts
+++ b/app/actions/translations.ts
@@ -65,12 +65,13 @@ export async function skipFieldAction(
   entity: string,
   record_id: string,
   field: string,
+  target_locale: "en" | "es",
 ): Promise<{ success: boolean }> {
   try {
     const res = await fetch(`${API_BASE}/translations/skip`, {
       method: "POST",
       headers: await authHeaders(),
-      body: JSON.stringify({ entity, record_id, field }),
+      body: JSON.stringify({ entity, record_id, field, target_locale }),
     });
     return { success: res.ok };
   } catch {

--- a/app/actions/translations.ts
+++ b/app/actions/translations.ts
@@ -9,8 +9,10 @@ export interface QueueItem {
   record_id: string;
   field: string;
   label: string;
-  en_text: string;
-  es_current: string;
+  source_locale: "en" | "es";
+  target_locale: "en" | "es";
+  source_text: string;
+  current_text: string;
   draft_text: string;
   skipped: boolean;
 }
@@ -79,7 +81,8 @@ export async function saveTranslationAction(
   entity: string,
   record_id: string,
   field: string,
-  es_text: string,
+  target_locale: "en" | "es",
+  translated_text: string,
 ): Promise<{ success: boolean; error?: string }> {
   const entityToPath: Record<string, string> = {
     profiles:         "profile",
@@ -93,16 +96,12 @@ export async function saveTranslationAction(
   const path = entityToPath[entity];
   if (!path) return { success: false, error: `Unknown entity: ${entity}` };
 
-  const isProfile = entity === "profiles";
-  const method = isProfile ? "PATCH" : "PATCH";
-  const url = `${API_BASE}/${path}`;
-
   try {
     const body: Record<string, unknown> = {};
-    body[field] = { es: es_text };
+    body[field] = { [target_locale]: translated_text };
 
-    const res = await fetch(url, {
-      method,
+    const res = await fetch(`${API_BASE}/${path}`, {
+      method: "PATCH",
       headers: await authHeaders(),
       body: JSON.stringify(body),
     });

--- a/app/actions/translations.ts
+++ b/app/actions/translations.ts
@@ -81,6 +81,8 @@ export async function saveTranslationAction(
   entity: string,
   record_id: string,
   field: string,
+  source_locale: "en" | "es",
+  source_text: string,
   target_locale: "en" | "es",
   translated_text: string,
 ): Promise<{ success: boolean; error?: string }> {
@@ -97,8 +99,9 @@ export async function saveTranslationAction(
   if (!path) return { success: false, error: `Unknown entity: ${entity}` };
 
   try {
+    // Send both locales so the backend JSONB column is never partially overwritten.
     const body: Record<string, unknown> = {};
-    body[field] = { [target_locale]: translated_text };
+    body[field] = { [source_locale]: source_text, [target_locale]: translated_text };
 
     const res = await fetch(`${API_BASE}/${path}`, {
       method: "PATCH",

--- a/app/actions/translations.ts
+++ b/app/actions/translations.ts
@@ -15,6 +15,7 @@ export interface QueueItem {
   current_text: string;
   draft_text: string;
   skipped: boolean;
+  is_list: boolean;
 }
 
 async function authHeaders() {
@@ -77,6 +78,20 @@ export async function skipFieldAction(
   }
 }
 
+function toFieldValue(text: string, is_list: boolean): string | string[] {
+  if (!is_list) return text;
+  return text.split("\n").filter((l) => l.trim() !== "");
+}
+
+function extractErrorMessage(detail: unknown): string {
+  if (typeof detail === "string") return detail;
+  if (Array.isArray(detail) && detail.length > 0) {
+    const first = detail[0];
+    if (first && typeof first === "object" && "msg" in first) return String(first.msg);
+  }
+  return "Save failed";
+}
+
 export async function saveTranslationAction(
   entity: string,
   record_id: string,
@@ -85,6 +100,7 @@ export async function saveTranslationAction(
   source_text: string,
   target_locale: "en" | "es",
   translated_text: string,
+  is_list: boolean,
 ): Promise<{ success: boolean; error?: string }> {
   const entityToPath: Record<string, string> = {
     profiles:         "profile",
@@ -100,8 +116,12 @@ export async function saveTranslationAction(
 
   try {
     // Send both locales so the backend JSONB column is never partially overwritten.
+    // For list fields (e.g. experience.description), split newlines back into arrays.
     const body: Record<string, unknown> = {};
-    body[field] = { [source_locale]: source_text, [target_locale]: translated_text };
+    body[field] = {
+      [source_locale]: toFieldValue(source_text, is_list),
+      [target_locale]: toFieldValue(translated_text, is_list),
+    };
 
     const res = await fetch(`${API_BASE}/${path}`, {
       method: "PATCH",
@@ -110,7 +130,7 @@ export async function saveTranslationAction(
     });
     if (!res.ok) {
       const json = await res.json().catch(() => ({}));
-      return { success: false, error: json.detail ?? "Save failed" };
+      return { success: false, error: extractErrorMessage(json.detail) };
     }
     return { success: true };
   } catch (e) {

--- a/app/actions/translations.ts
+++ b/app/actions/translations.ts
@@ -1,0 +1,117 @@
+"use server";
+
+import { cookies } from "next/headers";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
+
+export interface QueueItem {
+  entity: string;
+  record_id: string;
+  field: string;
+  label: string;
+  en_text: string;
+  es_current: string;
+  draft_text: string;
+  skipped: boolean;
+}
+
+async function authHeaders() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function getTranslationQueue(entity?: string): Promise<QueueItem[]> {
+  const url = `${API_BASE}/translations/queue${entity ? `?entity=${entity}` : ""}`;
+  try {
+    const res = await fetch(url, { headers: await authHeaders(), cache: "no-store" });
+    if (!res.ok) return [];
+    return res.json();
+  } catch {
+    return [];
+  }
+}
+
+export async function generateDraftAction(
+  entity: string,
+  record_id: string,
+  field: string,
+  en_text: string,
+): Promise<{ success: true; es_text: string } | { success: false; error: string }> {
+  try {
+    const res = await fetch(`${API_BASE}/translations/draft`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ entity, record_id, field, en_text }),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { success: false, error: json.detail ?? "Failed to generate draft" };
+    }
+    const { es_text } = await res.json();
+    return { success: true, es_text };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
+  }
+}
+
+export async function skipFieldAction(
+  entity: string,
+  record_id: string,
+  field: string,
+): Promise<{ success: boolean }> {
+  try {
+    const res = await fetch(`${API_BASE}/translations/skip`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ entity, record_id, field }),
+    });
+    return { success: res.ok };
+  } catch {
+    return { success: false };
+  }
+}
+
+export async function saveTranslationAction(
+  entity: string,
+  record_id: string,
+  field: string,
+  es_text: string,
+): Promise<{ success: boolean; error?: string }> {
+  const entityToPath: Record<string, string> = {
+    profiles:         "profile",
+    experiences:      `experience/${record_id}`,
+    education:        `education/${record_id}`,
+    projects:         `projects/${record_id}`,
+    blog_posts:       `blog/${record_id}`,
+    skill_categories: `skill-categories/${record_id}`,
+  };
+
+  const path = entityToPath[entity];
+  if (!path) return { success: false, error: `Unknown entity: ${entity}` };
+
+  const isProfile = entity === "profiles";
+  const method = isProfile ? "PATCH" : "PATCH";
+  const url = `${API_BASE}/${path}`;
+
+  try {
+    const body: Record<string, unknown> = {};
+    body[field] = { es: es_text };
+
+    const res = await fetch(url, {
+      method,
+      headers: await authHeaders(),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { success: false, error: json.detail ?? "Save failed" };
+    }
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Unknown error" };
+  }
+}

--- a/app/admin/(dashboard)/ai/usage/page.tsx
+++ b/app/admin/(dashboard)/ai/usage/page.tsx
@@ -1,12 +1,21 @@
 import { getAiUsage } from "@/app/actions/ai";
 
+function fmt(n: number | null, unit = ""): string {
+  if (n == null) return "—";
+  return unit ? `${n.toLocaleString()} ${unit}` : n.toLocaleString();
+}
+
 export default async function AIUsagePage() {
   const data = await getAiUsage();
 
   return (
-    <div className="p-6 max-w-6xl">
-      <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">AI Usage</h1>
-      <p className="text-sm text-[var(--text-muted)] mb-6">Last 100 AI calls. Refreshes every 60 seconds.</p>
+    <div className="p-6 max-w-6xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">AI Usage</h1>
+        <p className="text-sm text-[var(--text-muted)]">
+          Token counts: tiktoken (OpenAI/Groq) · chars÷3.5 estimate (Gemini). Refreshes every 60 s.
+        </p>
+      </div>
 
       {!data ? (
         <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-6">
@@ -16,50 +25,114 @@ export default async function AIUsagePage() {
           </p>
         </div>
       ) : (
-        <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead className="border-b border-[var(--border-default)]">
-              <tr>
-                {["Feature", "Provider", "Model", "In", "Out", "ms", "Status", "Time"].map((h) => (
-                  <th
-                    key={h}
-                    className="text-left px-4 py-3 text-[var(--text-muted)] font-medium whitespace-nowrap"
-                  >
-                    {h}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {data.calls.length === 0 ? (
-                <tr>
-                  <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
-                    No AI calls recorded yet.
-                  </td>
-                </tr>
-              ) : (
-                data.calls.map((row, i) => (
-                  <tr key={i} className="border-b border-[var(--border-default)] hover:bg-[var(--bg-base)]">
-                    <td className="px-4 py-2 font-medium">{row.feature}</td>
-                    <td className="px-4 py-2">{row.provider}</td>
-                    <td className="px-4 py-2 text-xs text-[var(--text-muted)] max-w-32 truncate">{row.model}</td>
-                    <td className="px-4 py-2">{row.prompt_tokens ?? "—"}</td>
-                    <td className="px-4 py-2">{row.completion_tokens ?? "—"}</td>
-                    <td className="px-4 py-2">{row.latency_ms ?? "—"}</td>
-                    <td className="px-4 py-2">
-                      <span className={row.succeeded ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}>
-                        {row.succeeded ? "✓" : "✗"}
-                      </span>
-                    </td>
-                    <td className="px-4 py-2 text-xs text-[var(--text-muted)] whitespace-nowrap">
-                      {new Date(row.created_at).toLocaleString()}
-                    </td>
+        <>
+          {/* ── Summary by feature / model ── */}
+          <section>
+            <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-3">
+              Summary by feature
+            </h2>
+            <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b border-[var(--border-default)]">
+                  <tr>
+                    {["Feature", "Model", "Provider", "Calls", "Avg latency", "In (tok)", "Out (tok)", "Total (tok)"].map((h) => (
+                      <th key={h} className="text-left px-4 py-3 text-[var(--text-muted)] font-medium whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
                   </tr>
-                ))
-              )}
-            </tbody>
-          </table>
-        </div>
+                </thead>
+                <tbody>
+                  {data.stats.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
+                        No calls recorded yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    <>
+                      {data.stats.map((row, i) => (
+                        <tr key={i} className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-base)]">
+                          <td className="px-4 py-2 font-medium">{row.feature}</td>
+                          <td className="px-4 py-2 text-xs text-[var(--text-muted)] max-w-40 truncate">{row.model}</td>
+                          <td className="px-4 py-2 text-[var(--text-secondary)]">{row.provider}</td>
+                          <td className="px-4 py-2">{row.call_count}</td>
+                          <td className="px-4 py-2">{fmt(row.avg_latency_ms, "ms")}</td>
+                          <td className="px-4 py-2">{fmt(row.total_prompt_tokens, "tok")}</td>
+                          <td className="px-4 py-2">{fmt(row.total_completion_tokens, "tok")}</td>
+                          <td className="px-4 py-2 font-medium">{fmt(row.total_tokens, "tok")}</td>
+                        </tr>
+                      ))}
+                      {/* Totals row */}
+                      <tr className="bg-[var(--bg-base)] font-semibold">
+                        <td className="px-4 py-2" colSpan={3}>Total</td>
+                        <td className="px-4 py-2">{data.stats.reduce((s, r) => s + r.call_count, 0)}</td>
+                        <td className="px-4 py-2">—</td>
+                        <td className="px-4 py-2">
+                          {fmt(data.stats.reduce((s, r) => s + r.total_prompt_tokens, 0), "tok")}
+                        </td>
+                        <td className="px-4 py-2">
+                          {fmt(data.stats.reduce((s, r) => s + r.total_completion_tokens, 0), "tok")}
+                        </td>
+                        <td className="px-4 py-2">
+                          {fmt(data.stats.reduce((s, r) => s + r.total_tokens, 0), "tok")}
+                        </td>
+                      </tr>
+                    </>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {/* ── Last 100 calls ── */}
+          <section>
+            <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-3">
+              Last 100 calls
+            </h2>
+            <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b border-[var(--border-default)]">
+                  <tr>
+                    {["Feature", "Provider", "Model", "In (tok)", "Out (tok)", "Latency (ms)", "Status", "Time"].map((h) => (
+                      <th key={h} className="text-left px-4 py-3 text-[var(--text-muted)] font-medium whitespace-nowrap">
+                        {h}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.calls.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
+                        No AI calls recorded yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    data.calls.map((row, i) => (
+                      <tr key={i} className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-base)]">
+                        <td className="px-4 py-2 font-medium">{row.feature}</td>
+                        <td className="px-4 py-2">{row.provider}</td>
+                        <td className="px-4 py-2 text-xs text-[var(--text-muted)] max-w-32 truncate">{row.model}</td>
+                        <td className="px-4 py-2">{fmt(row.prompt_tokens, "tok")}</td>
+                        <td className="px-4 py-2">{fmt(row.completion_tokens, "tok")}</td>
+                        <td className="px-4 py-2">{fmt(row.latency_ms, "ms")}</td>
+                        <td className="px-4 py-2">
+                          <span className={row.succeeded ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}>
+                            {row.succeeded ? "✓" : "✗"}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-xs text-[var(--text-muted)] whitespace-nowrap">
+                          {new Date(row.created_at).toLocaleString()}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </>
       )}
     </div>
   );

--- a/app/admin/(dashboard)/ai/usage/page.tsx
+++ b/app/admin/(dashboard)/ai/usage/page.tsx
@@ -7,13 +7,15 @@ function fmt(n: number | null, unit = ""): string {
 
 export default async function AIUsagePage() {
   const data = await getAiUsage();
+  const stats = data?.stats ?? [];
+  const calls = data?.calls ?? [];
 
   return (
     <div className="p-6 max-w-6xl space-y-8">
       <div>
         <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">AI Usage</h1>
         <p className="text-sm text-[var(--text-muted)]">
-          Token counts: tiktoken (OpenAI/Groq) · chars÷3.5 estimate (Gemini). Refreshes every 60 s.
+          Token counts: tiktoken (OpenAI/Groq) · google-genai count_tokens (Gemini). Refreshes every 60 s.
         </p>
       </div>
 
@@ -43,7 +45,7 @@ export default async function AIUsagePage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {data.stats.length === 0 ? (
+                  {stats.length === 0 ? (
                     <tr>
                       <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
                         No calls recorded yet.
@@ -51,7 +53,7 @@ export default async function AIUsagePage() {
                     </tr>
                   ) : (
                     <>
-                      {data.stats.map((row, i) => (
+                      {stats.map((row, i) => (
                         <tr key={i} className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-base)]">
                           <td className="px-4 py-2 font-medium">{row.feature}</td>
                           <td className="px-4 py-2 text-xs text-[var(--text-muted)] max-w-40 truncate">{row.model}</td>
@@ -63,20 +65,13 @@ export default async function AIUsagePage() {
                           <td className="px-4 py-2 font-medium">{fmt(row.total_tokens, "tok")}</td>
                         </tr>
                       ))}
-                      {/* Totals row */}
                       <tr className="bg-[var(--bg-base)] font-semibold">
                         <td className="px-4 py-2" colSpan={3}>Total</td>
-                        <td className="px-4 py-2">{data.stats.reduce((s, r) => s + r.call_count, 0)}</td>
+                        <td className="px-4 py-2">{stats.reduce((s, r) => s + r.call_count, 0)}</td>
                         <td className="px-4 py-2">—</td>
-                        <td className="px-4 py-2">
-                          {fmt(data.stats.reduce((s, r) => s + r.total_prompt_tokens, 0), "tok")}
-                        </td>
-                        <td className="px-4 py-2">
-                          {fmt(data.stats.reduce((s, r) => s + r.total_completion_tokens, 0), "tok")}
-                        </td>
-                        <td className="px-4 py-2">
-                          {fmt(data.stats.reduce((s, r) => s + r.total_tokens, 0), "tok")}
-                        </td>
+                        <td className="px-4 py-2">{fmt(stats.reduce((s, r) => s + r.total_prompt_tokens, 0), "tok")}</td>
+                        <td className="px-4 py-2">{fmt(stats.reduce((s, r) => s + r.total_completion_tokens, 0), "tok")}</td>
+                        <td className="px-4 py-2">{fmt(stats.reduce((s, r) => s + r.total_tokens, 0), "tok")}</td>
                       </tr>
                     </>
                   )}
@@ -102,14 +97,14 @@ export default async function AIUsagePage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {data.calls.length === 0 ? (
+                  {calls.length === 0 ? (
                     <tr>
                       <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
                         No AI calls recorded yet.
                       </td>
                     </tr>
                   ) : (
-                    data.calls.map((row, i) => (
+                    calls.map((row, i) => (
                       <tr key={i} className="border-b border-[var(--border-subtle)] hover:bg-[var(--bg-base)]">
                         <td className="px-4 py-2 font-medium">{row.feature}</td>
                         <td className="px-4 py-2">{row.provider}</td>

--- a/app/admin/(dashboard)/ai/usage/page.tsx
+++ b/app/admin/(dashboard)/ai/usage/page.tsx
@@ -1,0 +1,99 @@
+import { cookies } from "next/headers";
+
+interface AiCallRow {
+  feature: string;
+  provider: string;
+  model: string;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  latency_ms: number | null;
+  succeeded: boolean;
+  created_at: string;
+}
+
+interface AiUsageData {
+  calls: AiCallRow[];
+}
+
+async function fetchAiUsage(): Promise<AiUsageData | null> {
+  try {
+    const cookieStore = await cookies();
+    const token = cookieStore.get("admin_token")?.value;
+    const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
+    const res = await fetch(`${baseUrl}/ai/usage`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}
+
+export default async function AIUsagePage() {
+  const data = await fetchAiUsage();
+
+  return (
+    <div className="p-6 max-w-6xl">
+      <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">AI Usage</h1>
+      <p className="text-sm text-[var(--text-muted)] mb-6">
+        Last 100 AI calls. Refreshes every 60 seconds.
+      </p>
+
+      {!data ? (
+        <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-6">
+          <p className="text-[var(--text-muted)] text-sm">
+            Usage data unavailable. The <code className="text-[var(--accent-cyan)] text-xs">ai_calls</code> migration must be applied first, and the{" "}
+            <code className="text-[var(--accent-cyan)] text-xs">GET /api/v1/ai/usage</code> endpoint must exist.
+          </p>
+        </div>
+      ) : (
+        <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b border-[var(--border-default)]">
+              <tr>
+                {["Feature", "Provider", "Model", "In", "Out", "ms", "Status", "Time"].map((h) => (
+                  <th
+                    key={h}
+                    className="text-left px-4 py-3 text-[var(--text-muted)] font-medium whitespace-nowrap"
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.calls.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-muted)] text-sm">
+                    No AI calls recorded yet.
+                  </td>
+                </tr>
+              ) : (
+                data.calls.map((row, i) => (
+                  <tr key={i} className="border-b border-[var(--border-default)] hover:bg-[var(--bg-base)]">
+                    <td className="px-4 py-2 font-medium">{row.feature}</td>
+                    <td className="px-4 py-2">{row.provider}</td>
+                    <td className="px-4 py-2 text-xs text-[var(--text-muted)] max-w-32 truncate">{row.model}</td>
+                    <td className="px-4 py-2">{row.prompt_tokens ?? "—"}</td>
+                    <td className="px-4 py-2">{row.completion_tokens ?? "—"}</td>
+                    <td className="px-4 py-2">{row.latency_ms ?? "—"}</td>
+                    <td className="px-4 py-2">
+                      <span className={row.succeeded ? "text-[var(--color-success)]" : "text-[var(--color-error)]"}>
+                        {row.succeeded ? "✓" : "✗"}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2 text-xs text-[var(--text-muted)] whitespace-nowrap">
+                      {new Date(row.created_at).toLocaleString()}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/ai/usage/page.tsx
+++ b/app/admin/(dashboard)/ai/usage/page.tsx
@@ -1,51 +1,18 @@
-import { cookies } from "next/headers";
-
-interface AiCallRow {
-  feature: string;
-  provider: string;
-  model: string;
-  prompt_tokens: number | null;
-  completion_tokens: number | null;
-  latency_ms: number | null;
-  succeeded: boolean;
-  created_at: string;
-}
-
-interface AiUsageData {
-  calls: AiCallRow[];
-}
-
-async function fetchAiUsage(): Promise<AiUsageData | null> {
-  try {
-    const cookieStore = await cookies();
-    const token = cookieStore.get("admin_token")?.value;
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
-    const res = await fetch(`${baseUrl}/ai/usage`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-      next: { revalidate: 60 },
-    });
-    if (!res.ok) return null;
-    return res.json();
-  } catch {
-    return null;
-  }
-}
+import { getAiUsage } from "@/app/actions/ai";
 
 export default async function AIUsagePage() {
-  const data = await fetchAiUsage();
+  const data = await getAiUsage();
 
   return (
     <div className="p-6 max-w-6xl">
       <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-2">AI Usage</h1>
-      <p className="text-sm text-[var(--text-muted)] mb-6">
-        Last 100 AI calls. Refreshes every 60 seconds.
-      </p>
+      <p className="text-sm text-[var(--text-muted)] mb-6">Last 100 AI calls. Refreshes every 60 seconds.</p>
 
       {!data ? (
         <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-6">
           <p className="text-[var(--text-muted)] text-sm">
-            Usage data unavailable. The <code className="text-[var(--accent-cyan)] text-xs">ai_calls</code> migration must be applied first, and the{" "}
-            <code className="text-[var(--accent-cyan)] text-xs">GET /api/v1/ai/usage</code> endpoint must exist.
+            Usage data unavailable. The{" "}
+            <code className="text-[var(--accent-cyan)] text-xs">ai_calls</code> migration must be applied first.
           </p>
         </div>
       ) : (

--- a/app/admin/(dashboard)/blog/BlogFormModal.tsx
+++ b/app/admin/(dashboard)/blog/BlogFormModal.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState } from "react";
+import { useForm, FormProvider, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FiX } from "react-icons/fi";
 import { createBlogPostAction, updateBlogPostAction } from "@/app/actions/blog";
 import { BlogPost } from "@/lib/mockData";
 import Button from "@/components/ui/Button";
 import ImageUpload from "@/components/admin/ImageUpload";
-import { FiX, FiInfo } from "react-icons/fi";
-import { BlogField } from "@/components/admin/blog/BlogField";
+import LocalizedTextField from "@/components/admin/forms/LocalizedTextField";
+import { BlogCreate } from "@/lib/schemas/blog";
 
 interface BlogFormModalProps {
   post: BlogPost | null;
@@ -14,171 +17,161 @@ interface BlogFormModalProps {
   onSuccess: (p: BlogPost) => void;
 }
 
-export default function BlogFormModal({
-  post,
-  onClose,
-  onSuccess,
-}: BlogFormModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
+export default function BlogFormModal({ post, onClose, onSuccess }: BlogFormModalProps) {
   const [imageUrl, setImageUrl] = useState(post?.imageUrl || "");
   const [error, setError] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-    setError("");
+  const getLocalized = (field: unknown, locale = "en"): string => {
+    if (!field) return "";
+    if (typeof field === "string") return field;
+    return (field as Record<string, string>)[locale] ?? "";
+  };
 
-    const fd = new FormData(e.currentTarget);
-    const data = {
-      title: { en: fd.get("title") as string, es: "" },
-      slug: fd.get("slug") as string,
-      excerpt: { en: (fd.get("excerpt") as string) || "", es: "" },
-      content: { en: fd.get("content") as string, es: "" },
+  const methods = useForm<BlogCreate>({
+    resolver: zodResolver(BlogCreate) as Resolver<BlogCreate>,
+    defaultValues: {
+      title: { en: getLocalized(post?.title), es: "" },
+      slug: post?.slug ?? "",
+      excerpt: { en: getLocalized(post?.excerpt), es: "" },
+      content: { en: getLocalized(post?.content), es: "" },
+      tags: post?.tags?.join(", ") ?? "",
+      reading_time: post?.readingTime ?? "5 min read",
+      is_published: post?.isPublished ?? false,
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = methods;
+
+  const onSubmit = async (data: BlogCreate) => {
+    setError("");
+    const payload = {
+      title: data.title,
+      slug: data.slug,
+      excerpt: data.excerpt,
+      content: data.content,
       image_url: imageUrl || null,
-      tags: (fd.get("tags") as string)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-      reading_time: (fd.get("reading_time") as string) || null,
-      is_published: fd.get("is_published") === "on",
+      tags: data.tags.split(",").map((s) => s.trim()).filter(Boolean),
+      reading_time: data.reading_time || null,
+      is_published: data.is_published,
     };
 
-    let res;
-    if (post) {
-      res = await updateBlogPostAction(post.id, data);
-    } else {
-      res = await createBlogPostAction(data);
-    }
-
-    setIsSubmitting(false);
+    const res = post ? await updateBlogPostAction(post.id, payload) : await createBlogPostAction(payload);
 
     if (res.error) {
       setError(res.error);
-    } else if (res.success) {
-      const b = res.data;
-
-      const getEnText = (field: unknown) => {
-        if (!field) return "";
-        if (typeof field === "string") return field;
-        const localized = field as { en?: string };
-        return localized.en || "";
-      };
-
-      onSuccess({
-        id: b.id,
-        slug: b.slug,
-        title: getEnText(b.title),
-        excerpt: getEnText(b.excerpt),
-        content: getEnText(b.content),
-        tags: b.tags || [],
-        readingTime: b.reading_time || "5 min read",
-        isPublished: b.is_published,
-        imageUrl: b.image_url,
-        date:
-          b.published_at?.split("T")[0] ||
-          b.created_at?.split("T")[0] ||
-          new Date().toISOString().split("T")[0],
-      });
+      return;
     }
+
+    const b = res.data;
+    const getEnText = (field: unknown) => {
+      if (!field) return "";
+      if (typeof field === "string") return field;
+      return (field as { en?: string }).en || "";
+    };
+
+    onSuccess({
+      id: b.id,
+      slug: b.slug,
+      title: getEnText(b.title),
+      excerpt: getEnText(b.excerpt),
+      content: getEnText(b.content),
+      tags: b.tags || [],
+      readingTime: b.reading_time || "5 min read",
+      isPublished: b.is_published,
+      imageUrl: b.image_url,
+      date:
+        b.published_at?.split("T")[0] ||
+        b.created_at?.split("T")[0] ||
+        new Date().toISOString().split("T")[0],
+    });
   };
+
+  const inputClass =
+    "w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-      <div className="bg-(--bg-surface) border border-(--border-subtle) rounded-2xl w-full max-w-4xl max-h-[95vh] overflow-y-auto shadow-2xl relative">
-        <div className="sticky top-0 bg-(--bg-surface)/90 backdrop-blur-md border-b border-(--border-subtle) p-6 flex justify-between items-center z-10">
-          <h2 className="text-xl font-bold text-foreground">
+      <div className="bg-[var(--bg-surface)] border border-[var(--border-subtle)] rounded-2xl w-full max-w-4xl max-h-[95vh] overflow-y-auto shadow-2xl relative">
+        <div className="sticky top-0 bg-[var(--bg-surface)]/90 backdrop-blur-md border-b border-[var(--border-subtle)] p-6 flex justify-between items-center z-10">
+          <h2 className="text-xl font-bold text-[var(--text-primary)]">
             {post ? "Edit Blog Post" : "New Blog Post"}
           </h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-(--text-secondary) hover:text-foreground transition-colors"
-          >
+          <button onClick={onClose} className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
             <FiX size={20} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          {error && (
-            <div className="p-3 rounded-lg bg-(--color-error)/10 text-(--color-error) text-sm font-medium">
-              {error}
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-6">
+            {error && (
+              <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
+                {error}
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <LocalizedTextField name="title" label="Title" required fieldKind="title" />
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Slug *</label>
+                <input {...register("slug")} className={inputClass} />
+                {errors.slug && <p className="text-xs text-[var(--color-error)]">{errors.slug.message}</p>}
+              </div>
             </div>
-          )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <BlogField label="Title *" defaultValue={post?.title} name="title" type="text" required />
-            <BlogField label="Slug *" defaultValue={post?.slug} name="slug" type="text" required />
-          </div>
+            <ImageUpload label="Featured Image" value={imageUrl} onChange={setImageUrl} />
 
-          <div className="space-y-2">
-            <ImageUpload
-              label="Featured Image"
-              value={imageUrl}
-              onChange={setImageUrl}
-            />
-          </div>
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-(--text-secondary)">
-              Excerpt
-            </label>
-            <textarea
+            <LocalizedTextField
               name="excerpt"
-              defaultValue={post?.excerpt}
+              label="Excerpt"
+              multiline
               rows={2}
-              className="w-full bg-(--bg-elevated) border border-(--border-default) rounded-xl px-4 py-2 text-foreground focus:ring-2 focus:ring-(--accent-violet) outline-none"
-              placeholder="Brief summary of the post..."
+              fieldKind="paragraph"
+              placeholder={{ en: "Brief summary of the post…", es: "Breve resumen del artículo…" }}
             />
-          </div>
 
-          <div className="space-y-2">
-            <div className="flex justify-between items-center">
-              <label className="text-sm font-medium text-(--text-secondary)">
-                Content (Markdown) *
-              </label>
-              <span className="text-xs text-(--text-muted) flex items-center gap-1">
-                <FiInfo className="w-3 h-3" /> Supports basic markdown
-              </span>
-            </div>
-            <textarea
+            <LocalizedTextField
               name="content"
-              defaultValue={post?.content}
-              required
-              rows={12}
-              className="w-full bg-(--bg-elevated) border border-(--border-default) rounded-xl px-4 py-3 text-foreground font-mono text-sm focus:ring-2 focus:ring-(--accent-violet) outline-none"
-              placeholder="# Hello World\n\nThis is a blog post..."
+              label="Content (Markdown)"
+              multiline
+              rows={14}
+              fieldKind="paragraph"
+              placeholder={{ en: "# Hello World\n\nThis is a blog post…", es: "# Hola Mundo\n\nEste es un artículo…" }}
             />
-          </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <BlogField label="Tags (comma separated)" defaultValue={post?.tags?.join(", ")} name="tags" type="text" />
-            <BlogField label="Reading Time" defaultValue={post?.readingTime || "5 min read"} name="reading_time" type="text" />
-          </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Tags (comma separated)</label>
+                <input {...register("tags")} className={inputClass} placeholder="react, typescript, fastapi" />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Reading Time</label>
+                <input {...register("reading_time")} className={inputClass} placeholder="5 min read" />
+              </div>
+            </div>
 
-          <div className="flex items-center gap-6 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-(--text-secondary)">
+            <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-[var(--text-primary)]">
               <input
                 type="checkbox"
-                name="is_published"
-                defaultChecked={post?.isPublished ?? false}
-                className="w-4 h-4 rounded text-(--accent-violet) bg-(--bg-elevated) border-(--border-default) focus:ring-(--accent-violet) focus:ring-offset-(--bg-surface)"
+                {...register("is_published")}
+                className="w-4 h-4 rounded text-[var(--accent-violet)] bg-[var(--bg-elevated)] border-[var(--border-default)] focus:ring-[var(--accent-violet)]"
               />
               Published (Visible on site)
             </label>
-          </div>
 
-          <div className="pt-6 border-t border-(--border-subtle) flex justify-end gap-3">
-            <Button
-              type="button"
-              onClick={onClose}
-              className="bg-(--bg-elevated) hover:bg-(--border-subtle) text-foreground"
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving..." : "Save Post"}
-            </Button>
-          </div>
-        </form>
+            <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
+              <Button type="button" onClick={onClose} className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving..." : "Save Post"}
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
       </div>
     </div>
   );

--- a/app/admin/(dashboard)/experience/ExperienceClient.tsx
+++ b/app/admin/(dashboard)/experience/ExperienceClient.tsx
@@ -39,10 +39,7 @@ export default function ExperienceClient({
     setIsModalOpen(true);
   };
 
-  // Sort by sort_order or created date if needed, but here we just show what backend gives
-  const sortedExperiences = [...experiences].sort(
-    (a, b) => (a.sort_order || 0) - (b.sort_order || 0),
-  );
+  const sortedExperiences = experiences;
 
   return (
     <div className="space-y-6">
@@ -130,13 +127,17 @@ export default function ExperienceClient({
           onClose={() => setIsModalOpen(false)}
           onSuccess={(savedExp) => {
             setIsModalOpen(false);
-            if (editingExperience) {
-              setExperiences(
-                experiences.map((e) => (e.id === savedExp.id ? savedExp : e)),
-              );
-            } else {
-              setExperiences([...experiences, savedExp]);
-            }
+            const updated = editingExperience
+              ? experiences.map((e) => (e.id === savedExp.id ? savedExp : e))
+              : [...experiences, savedExp];
+            updated.sort((a, b) => {
+              if (a.is_current !== b.is_current) return a.is_current ? -1 : 1;
+              const aEnd = a.end_date ?? new Date().toISOString().slice(0, 10);
+              const bEnd = b.end_date ?? new Date().toISOString().slice(0, 10);
+              if (aEnd !== bEnd) return aEnd > bEnd ? -1 : 1;
+              return (a.start_date ?? "") > (b.start_date ?? "") ? -1 : 1;
+            });
+            setExperiences(updated);
           }}
         />
       )}

--- a/app/admin/(dashboard)/experience/ExperienceFormModal.tsx
+++ b/app/admin/(dashboard)/experience/ExperienceFormModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { useForm, FormProvider, type Resolver } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FiX } from "react-icons/fi";
@@ -8,6 +9,7 @@ import DateField from "@/components/admin/forms/DateField";
 import CheckboxField from "@/components/admin/forms/CheckboxField";
 import LocalizedTextField from "@/components/admin/forms/LocalizedTextField";
 import LocalizedListField from "@/components/admin/forms/LocalizedListField";
+import AISuggestButton from "@/components/admin/AISuggestButton";
 import { ExperienceCreate } from "@/lib/schemas/experience";
 import { createExperienceAction, updateExperienceAction } from "@/app/actions/experience";
 import { ApiExperience } from "@/lib/api";
@@ -19,6 +21,8 @@ interface Props {
 }
 
 export default function ExperienceFormModal({ experience, onClose, onSuccess }: Props) {
+  const [techStack, setTechStack] = useState(experience?.tech_stack?.join(", ") ?? "");
+
   const methods = useForm<ExperienceCreate>({
     resolver: zodResolver(ExperienceCreate) as Resolver<ExperienceCreate>,
     defaultValues: experience
@@ -29,7 +33,7 @@ export default function ExperienceFormModal({ experience, onClose, onSuccess }: 
           end_date: experience.end_date ?? null,
           is_current: experience.is_current,
           description: experience.description,
-          tech_stack: experience.tech_stack,
+          tech_stack: [],
           sort_order: experience.sort_order,
         }
       : {
@@ -53,11 +57,14 @@ export default function ExperienceFormModal({ experience, onClose, onSuccess }: 
   } = methods;
 
   const isCurrent = watch("is_current");
+  const descriptionEn: string[] = watch("description.en") ?? [];
+  const descriptionSource = descriptionEn.filter(Boolean).join("\n");
 
   const onSubmit = async (data: ExperienceCreate) => {
     const payload = {
       ...data,
       end_date: isCurrent ? null : data.end_date,
+      tech_stack: techStack.split(",").map((s) => s.trim()).filter(Boolean),
     };
 
     const res = experience
@@ -132,10 +139,18 @@ export default function ExperienceFormModal({ experience, onClose, onSuccess }: 
             />
 
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">Tech stack (comma separated)</label>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Tech stack (comma separated)</label>
+                <AISuggestButton
+                  sourceText={descriptionSource}
+                  label="Suggest from description"
+                  onAccept={(text) => setTechStack(text)}
+                />
+              </div>
               <input
-                {...register("tech_stack")}
-                defaultValue={experience?.tech_stack?.join(", ")}
+                value={techStack}
+                onChange={(e) => setTechStack(e.target.value)}
+                placeholder="Python, FastAPI, PostgreSQL"
                 className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
               />
             </div>

--- a/app/admin/(dashboard)/projects/ProjectFormModal.tsx
+++ b/app/admin/(dashboard)/projects/ProjectFormModal.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useState } from "react";
+import { useForm, FormProvider, type Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { FiX } from "react-icons/fi";
 import { Project } from "@/lib/mockData";
 import { ApiSkill } from "@/lib/api";
-import {
-  createProjectAction,
-  updateProjectAction,
-} from "@/app/actions/projects";
+import { createProjectAction, updateProjectAction } from "@/app/actions/projects";
 import Button from "@/components/ui/Button";
 import MultiImageUpload, { ProjectImage } from "@/components/admin/MultiImageUpload";
 import SkillMultiSelect from "@/components/admin/forms/SkillMultiSelect";
-import { FiX } from "react-icons/fi";
+import LocalizedTextField from "@/components/admin/forms/LocalizedTextField";
+import AISuggestButton from "@/components/admin/AISuggestButton";
+import { ProjectCreate } from "@/lib/schemas/project";
 
 interface ProjectFormModalProps {
   project: Project | null;
@@ -25,34 +27,55 @@ export default function ProjectFormModal({
   onClose,
   onSuccess,
 }: ProjectFormModalProps) {
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [images, setImages] = useState<ProjectImage[]>(project?.images || []);
   const [skillIds, setSkillIds] = useState<string[]>(project?.skillIds ?? []);
+  const [tags, setTags] = useState(project?.tags?.join(", ") ?? "");
   const [error, setError] = useState("");
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setIsSubmitting(true);
+  const getLocalized = (field: unknown, locale = "en"): string => {
+    if (!field) return "";
+    if (typeof field === "string") return field;
+    return (field as Record<string, string>)[locale] ?? "";
+  };
+
+  const methods = useForm<ProjectCreate>({
+    resolver: zodResolver(ProjectCreate) as Resolver<ProjectCreate>,
+    defaultValues: {
+      title: {
+        en: getLocalized(project?.title),
+        es: getLocalized(project?.title, "es"),
+      },
+      slug: project?.slug ?? "",
+      description: {
+        en: getLocalized(project?.description),
+        es: getLocalized(project?.description, "es"),
+      },
+      github_url: project?.githubUrl ?? "",
+      live_url: project?.liveUrl ?? "",
+      is_featured: project?.is_featured ?? false,
+      sort_order: project?.sort_order ?? 0,
+    },
+  });
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isSubmitting },
+  } = methods;
+
+  const descriptionEn: string = watch("description.en") ?? "";
+  const descriptionSource = typeof descriptionEn === "string" ? descriptionEn : "";
+
+  const onSubmit = async (data: ProjectCreate) => {
     setError("");
-
-    const fd = new FormData(e.currentTarget);
-    const titleEn = fd.get("title") as string;
-    const descriptionEn = fd.get("description") as string;
-
-    const data = {
-      title: { en: titleEn, es: "" },
-      slug: fd.get("slug") as string,
-      description: { en: descriptionEn, es: "" },
+    const payload = {
+      ...data,
+      github_url: data.github_url || null,
+      live_url: data.live_url || null,
+      tags: tags.split(",").map((s) => s.trim()).filter(Boolean),
       images,
-      image_url: images.find(img => img.is_primary)?.url || null,
-      tags: (fd.get("tags") as string)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean),
-      github_url: (fd.get("github_url") as string) || null,
-      live_url: (fd.get("live_url") as string) || null,
-      is_featured: fd.get("is_featured") === "on",
-      sort_order: parseInt(fd.get("sort_order") as string) || 0,
+      image_url: images.find((img) => img.is_primary)?.url || null,
       skill_ids: skillIds,
       role: null,
       timeline: null,
@@ -63,49 +86,49 @@ export default function ProjectFormModal({
       primary_category_id: null,
     };
 
-    let res;
-    if (project) {
-      res = await updateProjectAction(project.id, data);
-    } else {
-      res = await createProjectAction(data);
-    }
-
-    setIsSubmitting(false);
+    const res = project
+      ? await updateProjectAction(project.id, payload)
+      : await createProjectAction(payload);
 
     if (res.error) {
       setError(res.error);
-    } else if (res.success) {
-      const p = res.data;
-      const primaryImage =
-        p.images?.find((img: { is_primary: boolean; url: string }) => img.is_primary)?.url ||
-        p.image_url ||
-        "/placeholder-project.jpg";
-      onSuccess({
-        id: p.id,
-        slug: p.slug,
-        title: p.title?.en ?? p.title ?? "",
-        description: p.description?.en ?? p.description ?? "",
-        imageUrl: primaryImage,
-        images: p.images || [],
-        tags: p.tags || [],
-        githubUrl: p.github_url,
-        liveUrl: p.live_url,
-        role: p.role?.en ?? p.role ?? undefined,
-        timeline: p.timeline,
-        problem: p.problem?.en ?? p.problem ?? undefined,
-        approach: (p.approach as Array<{heading: {en:string}|string; body: {en:string}|string}>|null)
-          ?.map(s => ({
-            heading: typeof s.heading === "string" ? s.heading : s.heading.en ?? "",
-            body: typeof s.body === "string" ? s.body : s.body.en ?? "",
-          })) || [],
-        outcomes: p.outcomes?.en ?? p.outcomes ?? [],
-        gallery: p.gallery || [],
-        is_featured: p.is_featured,
-        sort_order: p.sort_order,
-        skillIds: p.skills?.map((s: { id: string }) => s.id) ?? skillIds,
-      });
+      return;
     }
+
+    const p = res.data;
+    const primaryImage =
+      p.images?.find((img: { is_primary: boolean; url: string }) => img.is_primary)?.url ||
+      p.image_url ||
+      "/placeholder-project.jpg";
+
+    onSuccess({
+      id: p.id,
+      slug: p.slug,
+      title: p.title?.en ?? p.title ?? "",
+      description: p.description?.en ?? p.description ?? "",
+      imageUrl: primaryImage,
+      images: p.images || [],
+      tags: p.tags || [],
+      githubUrl: p.github_url,
+      liveUrl: p.live_url,
+      role: p.role?.en ?? p.role ?? undefined,
+      timeline: p.timeline,
+      problem: p.problem?.en ?? p.problem ?? undefined,
+      approach: (p.approach as Array<{ heading: { en: string } | string; body: { en: string } | string }> | null)
+        ?.map((s) => ({
+          heading: typeof s.heading === "string" ? s.heading : s.heading.en ?? "",
+          body: typeof s.body === "string" ? s.body : s.body.en ?? "",
+        })) || [],
+      outcomes: p.outcomes?.en ?? p.outcomes ?? [],
+      gallery: p.gallery || [],
+      is_featured: p.is_featured,
+      sort_order: p.sort_order,
+      skillIds: p.skills?.map((s: { id: string }) => s.id) ?? skillIds,
+    });
   };
+
+  const inputClass =
+    "w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
@@ -114,152 +137,117 @@ export default function ProjectFormModal({
           <h2 className="text-xl font-bold text-[var(--text-primary)]">
             {project ? "Edit Project" : "New Project"}
           </h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
-          >
+          <button onClick={onClose} className="p-2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
             <FiX size={20} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-6">
-          {error && (
-            <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
-              {error}
-            </div>
-          )}
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)} className="p-6 space-y-6">
+            {error && (
+              <div className="p-3 rounded-lg bg-[var(--color-error)]/10 text-[var(--color-error)] text-sm font-medium">
+                {error}
+              </div>
+            )}
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Title (EN) *
-              </label>
-              <input
-                name="title"
-                defaultValue={
-                  typeof project?.title === "string"
-                    ? project.title
-                    : (project?.title as unknown as { en: string })?.en ?? ""
-                }
-                required
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Slug *
-              </label>
-              <input
-                name="slug"
-                defaultValue={project?.slug}
-                required
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
-            </div>
-          </div>
+            <LocalizedTextField name="title" label="Title" required fieldKind="title" />
 
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Description (EN) *
-            </label>
-            <textarea
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-[var(--text-secondary)]">Slug *</label>
+              <input {...register("slug")} className={inputClass} />
+              {errors.slug && <p className="text-xs text-[var(--color-error)]">{errors.slug.message}</p>}
+            </div>
+
+            <LocalizedTextField
               name="description"
-              defaultValue={
-                typeof project?.description === "string"
-                  ? project.description
-                  : (project?.description as unknown as { en: string })?.en ?? ""
-              }
-              required
-              rows={3}
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+              label="Description"
+              multiline
+              rows={4}
+              fieldKind="paragraph"
             />
-          </div>
 
-          <div className="space-y-2">
-            <MultiImageUpload
-              label="Project Images (Max 5)"
-              images={images}
-              onChange={setImages}
-            />
-          </div>
+            <MultiImageUpload label="Project Images (Max 5)" images={images} onChange={setImages} />
 
-          <SkillMultiSelect
-            allSkills={allSkills}
-            selectedIds={skillIds}
-            onChange={setSkillIds}
-          />
-
-          <div className="space-y-2">
-            <label className="text-sm font-medium text-[var(--text-secondary)]">
-              Tags (comma separated, legacy)
-            </label>
-            <input
-              name="tags"
-              defaultValue={project?.tags?.join(", ")}
-              className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-            />
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                GitHub URL
-              </label>
-              <input
-                name="github_url"
-                defaultValue={project?.githubUrl}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Skills</label>
+                <AISuggestButton
+                  sourceText={descriptionSource}
+                  label="Suggest from description"
+                  mode="suggest_skills"
+                  availableSkills={allSkills.map((s) => s.name)}
+                  onAccept={(text) => {
+                    const names = text.split(",").map((s) => s.trim()).filter(Boolean);
+                    const matched = allSkills
+                      .filter((s) => names.some((n) => n.toLowerCase() === s.name.toLowerCase()))
+                      .map((s) => s.id);
+                    setSkillIds((prev) => Array.from(new Set([...prev, ...matched])));
+                  }}
+                />
+              </div>
+              <SkillMultiSelect allSkills={allSkills} selectedIds={skillIds} onChange={setSkillIds} />
             </div>
+
             <div className="space-y-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Live URL
-              </label>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Tags (comma separated)</label>
+                <AISuggestButton
+                  sourceText={descriptionSource}
+                  label="Suggest from description"
+                  mode="suggest_tags"
+                  onAccept={(text) => setTags(text)}
+                />
+              </div>
               <input
-                name="live_url"
-                defaultValue={project?.liveUrl}
-                className="w-full bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-xl px-4 py-2 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                value={tags}
+                onChange={(e) => setTags(e.target.value)}
+                className={inputClass}
+                placeholder="react, typescript, fastapi"
               />
             </div>
-          </div>
 
-          <div className="flex items-center gap-6 pt-2">
-            <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-[var(--text-primary)]">
-              <input
-                type="checkbox"
-                name="is_featured"
-                defaultChecked={project?.is_featured ?? false}
-                className="w-4 h-4 rounded text-[var(--accent-violet)] bg-[var(--bg-elevated)] border-[var(--border-default)] focus:ring-[var(--accent-violet)] focus:ring-offset-[var(--bg-surface)]"
-              />
-              Featured Project
-            </label>
-
-            <div className="flex items-center gap-2">
-              <label className="text-sm font-medium text-[var(--text-secondary)]">
-                Sort Order:
-              </label>
-              <input
-                type="number"
-                name="sort_order"
-                defaultValue={project?.sort_order ?? 0}
-                className="w-20 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-lg px-3 py-1 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
-              />
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">GitHub URL</label>
+                <input {...register("github_url")} className={inputClass} />
+                {errors.github_url && <p className="text-xs text-[var(--color-error)]">{errors.github_url.message}</p>}
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Live URL</label>
+                <input {...register("live_url")} className={inputClass} />
+                {errors.live_url && <p className="text-xs text-[var(--color-error)]">{errors.live_url.message}</p>}
+              </div>
             </div>
-          </div>
 
-          <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
-            <Button
-              type="button"
-              onClick={onClose}
-              className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]"
-            >
-              Cancel
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? "Saving..." : "Save Project"}
-            </Button>
-          </div>
-        </form>
+            <div className="flex items-center gap-6 pt-2">
+              <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-[var(--text-primary)]">
+                <input
+                  type="checkbox"
+                  {...register("is_featured")}
+                  className="w-4 h-4 rounded text-[var(--accent-violet)] bg-[var(--bg-elevated)] border-[var(--border-default)] focus:ring-[var(--accent-violet)]"
+                />
+                Featured Project
+              </label>
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Sort Order:</label>
+                <input
+                  type="number"
+                  {...register("sort_order", { valueAsNumber: true })}
+                  className="w-20 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-lg px-3 py-1 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
+                />
+              </div>
+            </div>
+
+            <div className="pt-6 border-t border-[var(--border-subtle)] flex justify-end gap-3">
+              <Button type="button" onClick={onClose} className="bg-[var(--bg-elevated)] hover:bg-[var(--border-subtle)] text-[var(--text-primary)]">
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving..." : "Save Project"}
+              </Button>
+            </div>
+          </form>
+        </FormProvider>
       </div>
     </div>
   );

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -79,7 +79,9 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
     setErrorMsg("");
     startTransition(async () => {
       const result = await saveTranslationAction(
-        item.entity, item.record_id, item.field, item.target_locale, targetText,
+        item.entity, item.record_id, item.field,
+        item.source_locale, item.source_text,
+        item.target_locale, targetText,
       );
       if (result.success) {
         setStatus("done");

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -41,7 +41,7 @@ const FIELD_LABELS: Record<string, string> = {
   content: "Content",
 };
 
-const LOCALE_LABEL: Record<string, string> = { en: "English", es: "Español" };
+const LOCALE_LABEL: Record<string, string> = { en: "English", es: "Spanish" };
 
 function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   const [targetText, setTargetText] = useState(item.draft_text || item.current_text || "");

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { generateDraftAction, skipFieldAction, saveTranslationAction, QueueItem } from "@/app/actions/translations";
+
+const ENTITY_LABELS: Record<string, string> = {
+  profiles:         "Profile",
+  experiences:      "Experience",
+  education:        "Education",
+  projects:         "Project",
+  blog_posts:       "Blog Post",
+  skill_categories: "Skill Category",
+};
+
+const FIELD_LABELS: Record<string, string> = {
+  title: "Title",
+  bio: "Bio",
+  location: "Location",
+  role: "Role",
+  description: "Description",
+  degree: "Degree",
+  problem: "Problem",
+  outcomes: "Outcomes",
+  name: "Name",
+  excerpt: "Excerpt",
+  content: "Content",
+};
+
+function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
+  const [esText, setEsText] = useState(item.draft_text || item.es_current || "");
+  const [status, setStatus] = useState<"idle" | "translating" | "saving" | "done" | "error">("idle");
+  const [errorMsg, setErrorMsg] = useState("");
+  const [, startTransition] = useTransition();
+
+  const handleTranslate = () => {
+    setStatus("translating");
+    setErrorMsg("");
+    startTransition(async () => {
+      const result = await generateDraftAction(item.entity, item.record_id, item.field, item.en_text);
+      if (result.success) {
+        setEsText(result.es_text);
+        setStatus("idle");
+      } else {
+        setErrorMsg(result.error);
+        setStatus("error");
+      }
+    });
+  };
+
+  const handleSave = () => {
+    if (!esText.trim()) return;
+    setStatus("saving");
+    setErrorMsg("");
+    startTransition(async () => {
+      const result = await saveTranslationAction(item.entity, item.record_id, item.field, esText);
+      if (result.success) {
+        setStatus("done");
+        onDone();
+      } else {
+        setErrorMsg(result.error ?? "Save failed");
+        setStatus("error");
+      }
+    });
+  };
+
+  const handleSkip = () => {
+    startTransition(async () => {
+      await skipFieldAction(item.entity, item.record_id, item.field);
+      onDone();
+    });
+  };
+
+  if (status === "done") return null;
+
+  return (
+    <div className="border border-[var(--border-default)] rounded-xl p-4 space-y-3 bg-[var(--bg-surface)]">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2 text-sm">
+          <span className="px-2 py-0.5 rounded-md bg-[var(--accent-violet)]/10 text-[var(--accent-violet)] font-medium text-xs">
+            {ENTITY_LABELS[item.entity] ?? item.entity}
+          </span>
+          <span className="text-[var(--text-muted)]">{item.label}</span>
+          <span className="text-[var(--text-muted)]">/</span>
+          <span className="font-medium text-[var(--text-primary)]">
+            {FIELD_LABELS[item.field] ?? item.field}
+          </span>
+        </div>
+        <button
+          onClick={handleSkip}
+          className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+        >
+          Skip
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <p className="text-xs text-[var(--text-muted)] mb-1">English (source)</p>
+          <div className="bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded-lg p-3 text-sm text-[var(--text-secondary)] min-h-[80px] whitespace-pre-wrap">
+            {item.en_text || <em className="text-[var(--text-muted)]">empty</em>}
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs text-[var(--text-muted)] mb-1">Spanish (draft)</p>
+          <textarea
+            value={esText}
+            onChange={(e) => setEsText(e.target.value)}
+            rows={4}
+            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors"
+            placeholder="Spanish translation…"
+          />
+        </div>
+      </div>
+
+      {status === "error" && (
+        <p className="text-xs text-[var(--color-error)]">{errorMsg}</p>
+      )}
+
+      <div className="flex items-center gap-2 justify-end">
+        <button
+          onClick={handleTranslate}
+          disabled={status === "translating" || status === "saving"}
+          className="px-3 py-1.5 rounded-lg text-xs font-medium border border-[var(--border-default)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)] disabled:opacity-50 transition-colors"
+        >
+          {status === "translating" ? "Translating…" : "Translate with AI"}
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={!esText.trim() || status === "translating" || status === "saving"}
+          className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--accent-violet)] text-white hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {status === "saving" ? "Saving…" : "Save & publish"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function TranslationQueue({ initialItems }: { initialItems: QueueItem[] }) {
+  const [items, setItems] = useState(initialItems);
+  const [entityFilter, setEntityFilter] = useState<string>("all");
+
+  const visibleItems = entityFilter === "all"
+    ? items
+    : items.filter((i) => i.entity === entityFilter);
+
+  const entities = [...new Set(initialItems.map((i) => i.entity))];
+
+  const markDone = (item: QueueItem) => {
+    setItems((prev) => prev.filter((i) => !(i.entity === item.entity && i.record_id === item.record_id && i.field === item.field)));
+  };
+
+  return (
+    <div className="space-y-4">
+      {entities.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setEntityFilter("all")}
+            className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+              entityFilter === "all"
+                ? "bg-[var(--accent-violet)] text-white"
+                : "bg-[var(--bg-elevated)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            }`}
+          >
+            All ({items.length})
+          </button>
+          {entities.map((ent) => (
+            <button
+              key={ent}
+              onClick={() => setEntityFilter(ent)}
+              className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${
+                entityFilter === ent
+                  ? "bg-[var(--accent-violet)] text-white"
+                  : "bg-[var(--bg-elevated)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              {ENTITY_LABELS[ent] ?? ent} ({items.filter((i) => i.entity === ent).length})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {visibleItems.length === 0 ? (
+        <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-8 text-center">
+          <p className="text-[var(--text-muted)] text-sm">
+            {items.length === 0
+              ? "All fields have Spanish translations."
+              : "No items match the current filter."}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {visibleItems.map((item) => (
+            <QueueRow
+              key={`${item.entity}-${item.record_id}-${item.field}`}
+              item={item}
+              onDone={() => markDone(item)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { skipFieldAction, saveTranslationAction, QueueItem } from "@/app/actions/translations";
 import { streamRewrite } from "@/lib/aiStream";
 
@@ -49,6 +49,14 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   const [errorMsg, setErrorMsg] = useState("");
   const [, startTransition] = useTransition();
   const abortRef = useRef<AbortController | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [targetText]);
 
   const handleTranslate = () => {
     abortRef.current?.abort();
@@ -145,11 +153,12 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
             )}
           </div>
           <textarea
+            ref={textareaRef}
             value={targetText}
             onChange={(e) => setTargetText(e.target.value)}
             disabled={status === "translating"}
             rows={4}
-            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70"
+            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70 overflow-hidden"
             placeholder={`${LOCALE_LABEL[item.target_locale]} translation…`}
           />
         </div>

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -158,7 +158,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
             onChange={(e) => setTargetText(e.target.value)}
             disabled={status === "translating"}
             rows={4}
-            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70 overflow-hidden"
+            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-none focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70 overflow-y-auto max-h-64"
             placeholder={`${LOCALE_LABEL[item.target_locale]} translation…`}
           />
         </div>

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -82,6 +82,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
         item.entity, item.record_id, item.field,
         item.source_locale, item.source_text,
         item.target_locale, targetText,
+        item.is_list,
       );
       if (result.success) {
         setStatus("done");

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -109,7 +109,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   const handleSkip = () => {
     abortRef.current?.abort();
     startTransition(async () => {
-      await skipFieldAction(item.entity, item.record_id, item.field);
+      await skipFieldAction(item.entity, item.record_id, item.field, item.target_locale);
       onDone();
     });
   };

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -1,7 +1,22 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { generateDraftAction, skipFieldAction, saveTranslationAction, QueueItem } from "@/app/actions/translations";
+import { useRef, useState, useTransition } from "react";
+import { skipFieldAction, saveTranslationAction, QueueItem } from "@/app/actions/translations";
+import { streamRewrite } from "@/lib/aiStream";
+
+const FIELD_KIND: Record<string, "title" | "paragraph" | "bullet"> = {
+  title:       "title",
+  bio:         "paragraph",
+  location:    "title",
+  role:        "title",
+  description: "paragraph",
+  degree:      "title",
+  problem:     "paragraph",
+  outcomes:    "paragraph",
+  name:        "title",
+  excerpt:     "paragraph",
+  content:     "paragraph",
+};
 
 const ENTITY_LABELS: Record<string, string> = {
   profiles:         "Profile",
@@ -31,19 +46,28 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   const [status, setStatus] = useState<"idle" | "translating" | "saving" | "done" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [, startTransition] = useTransition();
+  const abortRef = useRef<AbortController | null>(null);
 
   const handleTranslate = () => {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
     setStatus("translating");
     setErrorMsg("");
-    startTransition(async () => {
-      const result = await generateDraftAction(item.entity, item.record_id, item.field, item.en_text);
-      if (result.success) {
-        setEsText(result.es_text);
-        setStatus("idle");
-      } else {
-        setErrorMsg(result.error);
+    setEsText("");
+
+    streamRewrite({
+      text: item.en_text,
+      locale: "en",
+      fieldKind: FIELD_KIND[item.field] ?? "paragraph",
+      mode: "translate",
+      targetLocale: "es",
+      signal: abortRef.current.signal,
+      onChunk: (chunk) => setEsText((prev) => prev + chunk),
+      onDone: () => setStatus("idle"),
+      onError: (msg) => {
+        setErrorMsg(msg);
         setStatus("error");
-      }
+      },
     });
   };
 
@@ -64,6 +88,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   };
 
   const handleSkip = () => {
+    abortRef.current?.abort();
     startTransition(async () => {
       await skipFieldAction(item.entity, item.record_id, item.field);
       onDone();
@@ -102,12 +127,18 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
         </div>
 
         <div>
-          <p className="text-xs text-[var(--text-muted)] mb-1">Spanish (draft)</p>
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs text-[var(--text-muted)]">Spanish (draft)</p>
+            {status === "translating" && (
+              <span className="text-xs text-[var(--accent-violet)] animate-pulse">Translating…</span>
+            )}
+          </div>
           <textarea
             value={esText}
             onChange={(e) => setEsText(e.target.value)}
+            disabled={status === "translating"}
             rows={4}
-            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors"
+            className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70"
             placeholder="Spanish translation…"
           />
         </div>

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -51,6 +51,10 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   const abortRef = useRef<AbortController | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Single-word source texts (proper nouns, tech terms, loanwords) are likely
+  // the same in both languages — prompt the user to skip the AI call.
+  const suggestKeepAsIs = item.source_text.trim().split(/\s+/).length === 1;
+
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
@@ -135,9 +139,16 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
-          <p className="text-xs text-[var(--text-muted)] mb-1">
-            {LOCALE_LABEL[item.source_locale]} (source)
-          </p>
+          <div className="flex items-center gap-2 mb-1">
+            <p className="text-xs text-[var(--text-muted)]">
+              {LOCALE_LABEL[item.source_locale]} (source)
+            </p>
+            {suggestKeepAsIs && (
+              <span className="text-xs px-1.5 py-0.5 rounded-md bg-[var(--accent-amber)]/10 text-[var(--accent-amber)] font-medium">
+                Single word — try Keep as-is
+              </span>
+            )}
+          </div>
           <div className="bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded-lg p-3 text-sm text-[var(--text-secondary)] min-h-[80px] max-h-64 overflow-y-auto whitespace-pre-wrap">
             {item.source_text || <em className="text-[var(--text-muted)]">empty</em>}
           </div>
@@ -169,6 +180,22 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
       )}
 
       <div className="flex items-center gap-2 justify-end">
+        <button
+          onClick={() => {
+            abortRef.current?.abort();
+            setTargetText(item.source_text);
+            setStatus("idle");
+            setErrorMsg("");
+          }}
+          disabled={status === "translating" || status === "saving"}
+          className={`px-3 py-1.5 rounded-lg text-xs font-medium border disabled:opacity-50 transition-colors ${
+            suggestKeepAsIs
+              ? "border-[var(--accent-amber)]/40 text-[var(--accent-amber)] hover:bg-[var(--accent-amber)]/10"
+              : "border-[var(--border-default)] text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+          }`}
+        >
+          Keep as-is
+        </button>
         <button
           onClick={handleTranslate}
           disabled={status === "translating" || status === "saving"}

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -138,7 +138,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
           <p className="text-xs text-[var(--text-muted)] mb-1">
             {LOCALE_LABEL[item.source_locale]} (source)
           </p>
-          <div className="bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded-lg p-3 text-sm text-[var(--text-secondary)] min-h-[80px] whitespace-pre-wrap">
+          <div className="bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded-lg p-3 text-sm text-[var(--text-secondary)] min-h-[80px] max-h-64 overflow-y-auto whitespace-pre-wrap">
             {item.source_text || <em className="text-[var(--text-muted)]">empty</em>}
           </div>
         </div>

--- a/app/admin/(dashboard)/translations/TranslationQueue.tsx
+++ b/app/admin/(dashboard)/translations/TranslationQueue.tsx
@@ -41,8 +41,10 @@ const FIELD_LABELS: Record<string, string> = {
   content: "Content",
 };
 
+const LOCALE_LABEL: Record<string, string> = { en: "English", es: "Español" };
+
 function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
-  const [esText, setEsText] = useState(item.draft_text || item.es_current || "");
+  const [targetText, setTargetText] = useState(item.draft_text || item.current_text || "");
   const [status, setStatus] = useState<"idle" | "translating" | "saving" | "done" | "error">("idle");
   const [errorMsg, setErrorMsg] = useState("");
   const [, startTransition] = useTransition();
@@ -53,16 +55,16 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
     abortRef.current = new AbortController();
     setStatus("translating");
     setErrorMsg("");
-    setEsText("");
+    setTargetText("");
 
     streamRewrite({
-      text: item.en_text,
-      locale: "en",
+      text: item.source_text,
+      locale: item.source_locale,
       fieldKind: FIELD_KIND[item.field] ?? "paragraph",
       mode: "translate",
-      targetLocale: "es",
+      targetLocale: item.target_locale,
       signal: abortRef.current.signal,
-      onChunk: (chunk) => setEsText((prev) => prev + chunk),
+      onChunk: (chunk) => setTargetText((prev) => prev + chunk),
       onDone: () => setStatus("idle"),
       onError: (msg) => {
         setErrorMsg(msg);
@@ -72,11 +74,13 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
   };
 
   const handleSave = () => {
-    if (!esText.trim()) return;
+    if (!targetText.trim()) return;
     setStatus("saving");
     setErrorMsg("");
     startTransition(async () => {
-      const result = await saveTranslationAction(item.entity, item.record_id, item.field, esText);
+      const result = await saveTranslationAction(
+        item.entity, item.record_id, item.field, item.target_locale, targetText,
+      );
       if (result.success) {
         setStatus("done");
         onDone();
@@ -120,26 +124,30 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
-          <p className="text-xs text-[var(--text-muted)] mb-1">English (source)</p>
+          <p className="text-xs text-[var(--text-muted)] mb-1">
+            {LOCALE_LABEL[item.source_locale]} (source)
+          </p>
           <div className="bg-[var(--bg-base)] border border-[var(--border-subtle)] rounded-lg p-3 text-sm text-[var(--text-secondary)] min-h-[80px] whitespace-pre-wrap">
-            {item.en_text || <em className="text-[var(--text-muted)]">empty</em>}
+            {item.source_text || <em className="text-[var(--text-muted)]">empty</em>}
           </div>
         </div>
 
         <div>
           <div className="flex items-center justify-between mb-1">
-            <p className="text-xs text-[var(--text-muted)]">Spanish (draft)</p>
+            <p className="text-xs text-[var(--text-muted)]">
+              {LOCALE_LABEL[item.target_locale]} (translation)
+            </p>
             {status === "translating" && (
               <span className="text-xs text-[var(--accent-violet)] animate-pulse">Translating…</span>
             )}
           </div>
           <textarea
-            value={esText}
-            onChange={(e) => setEsText(e.target.value)}
+            value={targetText}
+            onChange={(e) => setTargetText(e.target.value)}
             disabled={status === "translating"}
             rows={4}
             className="w-full bg-[var(--bg-base)] border border-[var(--border-default)] rounded-lg p-3 text-sm text-[var(--text-primary)] resize-y focus:outline-none focus:border-[var(--accent-violet)] transition-colors disabled:opacity-70"
-            placeholder="Spanish translation…"
+            placeholder={`${LOCALE_LABEL[item.target_locale]} translation…`}
           />
         </div>
       </div>
@@ -158,7 +166,7 @@ function QueueRow({ item, onDone }: { item: QueueItem; onDone: () => void }) {
         </button>
         <button
           onClick={handleSave}
-          disabled={!esText.trim() || status === "translating" || status === "saving"}
+          disabled={!targetText.trim() || status === "translating" || status === "saving"}
           className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[var(--accent-violet)] text-white hover:opacity-90 disabled:opacity-50 transition-opacity"
         >
           {status === "saving" ? "Saving…" : "Save & publish"}

--- a/app/admin/(dashboard)/translations/page.tsx
+++ b/app/admin/(dashboard)/translations/page.tsx
@@ -1,0 +1,26 @@
+import { getTranslationQueue } from "@/app/actions/translations";
+import TranslationQueue from "./TranslationQueue";
+
+export default async function TranslationsPage() {
+  const items = await getTranslationQueue();
+
+  return (
+    <div className="max-w-5xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)]">Translation Queue</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Fields missing a Spanish translation.{" "}
+          {items.length > 0
+            ? `${items.length} field${items.length !== 1 ? "s" : ""} need attention.`
+            : "Everything is translated."}
+        </p>
+        <p className="text-xs text-[var(--text-muted)] mt-2">
+          Run <code className="text-[var(--accent-cyan)]">python -m app.tools.translate_seed</code> to
+          pre-populate AI drafts for all missing fields, then review and publish each one here.
+        </p>
+      </div>
+
+      <TranslationQueue initialItems={items} />
+    </div>
+  );
+}

--- a/app/api/ai/rewrite/route.ts
+++ b/app/api/ai/rewrite/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+
+  if (!token) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const body = await req.json();
+  const backendUrl = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(`${backendUrl}/ai/rewrite`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return new Response("AI service unreachable", { status: 503 });
+  }
+
+  if (!upstream.ok) {
+    const errText = await upstream.text();
+    return new Response(errText || "AI service error", { status: upstream.status });
+  }
+
+  return new Response(upstream.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/components/admin/AIEnhanceButton.tsx
+++ b/components/admin/AIEnhanceButton.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from "react";
 import AIEnhancePanel from "./AIEnhancePanel";
+import type { RewriteFieldKind } from "@/lib/types/ai";
 
 interface AIEnhanceButtonProps {
   sourceText: string;
   locale: "en" | "es";
-  fieldKind: "bullet" | "paragraph" | "title";
+  fieldKind: RewriteFieldKind;
   fieldLabel: string;
   onAccept: (text: string) => void;
 }

--- a/components/admin/AIEnhanceButton.tsx
+++ b/components/admin/AIEnhanceButton.tsx
@@ -10,6 +10,7 @@ interface AIEnhanceButtonProps {
   fieldKind: RewriteFieldKind;
   fieldLabel: string;
   onAccept: (text: string) => void;
+  onAcceptTranslation?: (text: string, targetLocale: "en" | "es") => void;
 }
 
 export default function AIEnhanceButton({
@@ -18,9 +19,11 @@ export default function AIEnhanceButton({
   fieldKind,
   fieldLabel,
   onAccept,
+  onAcceptTranslation,
 }: AIEnhanceButtonProps) {
   const [panelOpen, setPanelOpen] = useState(false);
-  const tooShort = sourceText.trim().length < 20;
+  const minLength = fieldKind === "title" ? 2 : 20;
+  const tooShort = sourceText.trim().length < minLength;
 
   return (
     <>
@@ -28,17 +31,18 @@ export default function AIEnhanceButton({
         type="button"
         disabled={tooShort}
         onClick={() => setPanelOpen(true)}
-        title={tooShort ? "Text too short (min 20 chars)" : "Improve with AI"}
+        title={tooShort ? `Text too short (min ${minLength} chars)` : "Improve with AI"}
         className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs text-[var(--accent-violet)] border border-[var(--accent-violet)]/60 hover:bg-[var(--accent-violet)] hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
       >
         <span aria-hidden>✨</span>
-        <span>Rewrite</span>
+        <span>Enhance</span>
       </button>
 
       <AIEnhancePanel
         isOpen={panelOpen}
         onClose={() => setPanelOpen(false)}
         onAccept={onAccept}
+        onAcceptTranslation={onAcceptTranslation}
         sourceText={sourceText}
         locale={locale}
         fieldKind={fieldKind}

--- a/components/admin/AIEnhanceButton.tsx
+++ b/components/admin/AIEnhanceButton.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import AIEnhancePanel from "./AIEnhancePanel";
+
+interface AIEnhanceButtonProps {
+  sourceText: string;
+  locale: "en" | "es";
+  fieldKind: "bullet" | "paragraph" | "title";
+  fieldLabel: string;
+  onAccept: (text: string) => void;
+}
+
+export default function AIEnhanceButton({
+  sourceText,
+  locale,
+  fieldKind,
+  fieldLabel,
+  onAccept,
+}: AIEnhanceButtonProps) {
+  const [panelOpen, setPanelOpen] = useState(false);
+  const tooShort = sourceText.trim().length < 20;
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={tooShort}
+        onClick={() => setPanelOpen(true)}
+        title={tooShort ? "Text too short (min 20 chars)" : "Improve with AI"}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs text-[var(--accent-violet)] border border-[var(--accent-violet)]/60 hover:bg-[var(--accent-violet)] hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <span aria-hidden>✨</span>
+        <span>Rewrite</span>
+      </button>
+
+      <AIEnhancePanel
+        isOpen={panelOpen}
+        onClose={() => setPanelOpen(false)}
+        onAccept={onAccept}
+        sourceText={sourceText}
+        locale={locale}
+        fieldKind={fieldKind}
+        fieldLabel={fieldLabel}
+      />
+    </>
+  );
+}

--- a/components/admin/AIEnhancePanel.tsx
+++ b/components/admin/AIEnhancePanel.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import { streamRewrite } from "@/lib/aiStream";
-import type { RewriteStyle, RewriteFieldKind } from "@/lib/types/ai";
+import type { RewriteStyle, RewriteFieldKind, RewriteMode } from "@/lib/types/ai";
 
 interface AIEnhancePanelProps {
   isOpen: boolean;
   onClose: () => void;
   onAccept: (text: string) => void;
+  onAcceptTranslation?: (text: string, targetLocale: "en" | "es") => void;
   sourceText: string;
   locale: "en" | "es";
   fieldKind: RewriteFieldKind;
@@ -18,6 +19,7 @@ export default function AIEnhancePanel({
   isOpen,
   onClose,
   onAccept,
+  onAcceptTranslation,
   sourceText,
   locale,
   fieldKind,
@@ -27,10 +29,14 @@ export default function AIEnhancePanel({
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedStyle, setSelectedStyle] = useState<RewriteStyle | null>(null);
+  const [activeMode, setActiveMode] = useState<RewriteMode>("rewrite");
+  const [activeTargetLocale, setActiveTargetLocale] = useState<"en" | "es">(
+    locale === "en" ? "es" : "en"
+  );
   const abortRef = useRef<AbortController | null>(null);
 
   const startStream = useCallback(
-    (style: RewriteStyle | null) => {
+    (opts: { style?: RewriteStyle | null; mode?: RewriteMode; targetLocale?: "en" | "es" }) => {
       abortRef.current?.abort();
       abortRef.current = new AbortController();
 
@@ -42,7 +48,9 @@ export default function AIEnhancePanel({
         text: sourceText,
         locale,
         fieldKind,
-        style,
+        style: opts.style ?? null,
+        mode: opts.mode ?? "rewrite",
+        targetLocale: opts.targetLocale,
         signal: abortRef.current.signal,
         onChunk: (chunk) => setStreamedText((prev) => prev + chunk),
         onDone: () => setIsStreaming(false),
@@ -60,7 +68,9 @@ export default function AIEnhancePanel({
       setStreamedText("");
       setError(null);
       setSelectedStyle(null);
-      startStream(null);
+      setActiveMode("rewrite");
+      setActiveTargetLocale(locale === "en" ? "es" : "en");
+      startStream({ mode: "rewrite" });
     }
     return () => {
       if (!isOpen) abortRef.current?.abort();
@@ -69,7 +79,24 @@ export default function AIEnhancePanel({
 
   const handleRegenerate = (style: RewriteStyle | null) => {
     setSelectedStyle(style);
-    startStream(style);
+    setActiveMode("rewrite");
+    startStream({ style, mode: "rewrite" });
+  };
+
+  const handleTranslate = (targetLocale: "en" | "es") => {
+    setActiveTargetLocale(targetLocale);
+    setActiveMode("translate");
+    setSelectedStyle(null);
+    startStream({ mode: "translate", targetLocale });
+  };
+
+  const handleAccept = () => {
+    if (activeMode === "translate" && onAcceptTranslation) {
+      onAcceptTranslation(streamedText, activeTargetLocale);
+    } else {
+      onAccept(streamedText);
+    }
+    onClose();
   };
 
   const handleClose = () => {
@@ -77,6 +104,11 @@ export default function AIEnhancePanel({
     setIsStreaming(false);
     onClose();
   };
+
+  const modeLabel =
+    activeMode === "translate"
+      ? `Translating → ${activeTargetLocale.toUpperCase()}`
+      : `AI Suggestion`;
 
   if (!isOpen) return null;
 
@@ -90,7 +122,7 @@ export default function AIEnhancePanel({
           <div className="flex items-center gap-2">
             <span className="text-[var(--accent-violet)] text-base">✨</span>
             <h3 className="text-sm font-semibold text-[var(--text-primary)]">
-              AI Suggestion — {fieldLabel}
+              {modeLabel} — {fieldLabel}
             </h3>
           </div>
           <button
@@ -119,9 +151,31 @@ export default function AIEnhancePanel({
           )}
         </div>
 
-        {/* Style hints */}
+        {/* Translate */}
         <div className="px-4 py-2 border-t border-[var(--border-default)]">
-          <p className="text-xs text-[var(--text-muted)] mb-2">Regenerate with hint:</p>
+          <p className="text-xs text-[var(--text-muted)] mb-2">Translate to:</p>
+          <div className="flex gap-2">
+            {(["en", "es"] as const).map((tl) => (
+              <button
+                key={tl}
+                type="button"
+                disabled={isStreaming || tl === locale}
+                onClick={() => handleTranslate(tl)}
+                className={`px-2 py-1 rounded text-xs border transition-colors disabled:opacity-40 ${
+                  activeMode === "translate" && activeTargetLocale === tl
+                    ? "border-[var(--accent-violet)] text-[var(--accent-violet)] bg-[var(--accent-violet)]/10"
+                    : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-violet)]"
+                }`}
+              >
+                → {tl === "en" ? "English" : "Español"}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Rewrite style hints */}
+        <div className="px-4 py-2 border-t border-[var(--border-default)]">
+          <p className="text-xs text-[var(--text-muted)] mb-2">Rewrite with hint:</p>
           <div className="flex gap-2">
             {(["shorter", "technical", "friendlier"] as const).map((s) => (
               <button
@@ -130,7 +184,7 @@ export default function AIEnhancePanel({
                 disabled={isStreaming}
                 onClick={() => handleRegenerate(s)}
                 className={`px-2 py-1 rounded text-xs border transition-colors disabled:opacity-40 ${
-                  selectedStyle === s
+                  activeMode === "rewrite" && selectedStyle === s
                     ? "border-[var(--accent-violet)] text-[var(--accent-violet)] bg-[var(--accent-violet)]/10"
                     : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-violet)]"
                 }`}
@@ -152,7 +206,11 @@ export default function AIEnhancePanel({
           </button>
           <button
             type="button"
-            onClick={() => handleRegenerate(selectedStyle)}
+            onClick={() =>
+              activeMode === "translate"
+                ? handleTranslate(activeTargetLocale)
+                : handleRegenerate(selectedStyle)
+            }
             disabled={isStreaming}
             className="flex-1 px-3 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-base)] transition-colors disabled:opacity-40"
           >
@@ -160,14 +218,13 @@ export default function AIEnhancePanel({
           </button>
           <button
             type="button"
-            onClick={() => {
-              onAccept(streamedText);
-              onClose();
-            }}
+            onClick={handleAccept}
             disabled={isStreaming || !streamedText}
             className="flex-1 px-3 py-2 rounded-lg bg-[var(--accent-violet)] text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
           >
-            Accept
+            {activeMode === "translate" && onAcceptTranslation
+              ? `Accept → ${activeTargetLocale.toUpperCase()}`
+              : "Accept"}
           </button>
         </div>
       </div>

--- a/components/admin/AIEnhancePanel.tsx
+++ b/components/admin/AIEnhancePanel.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useRef, useCallback, useEffect } from "react";
-
-type Style = "shorter" | "technical" | "friendlier" | null;
-type FieldKind = "bullet" | "paragraph" | "title";
+import { streamRewrite } from "@/lib/aiStream";
+import type { RewriteStyle, RewriteFieldKind } from "@/lib/types/ai";
 
 interface AIEnhancePanelProps {
   isOpen: boolean;
@@ -11,7 +10,7 @@ interface AIEnhancePanelProps {
   onAccept: (text: string) => void;
   sourceText: string;
   locale: "en" | "es";
-  fieldKind: FieldKind;
+  fieldKind: RewriteFieldKind;
   fieldLabel: string;
 }
 
@@ -27,71 +26,35 @@ export default function AIEnhancePanel({
   const [streamedText, setStreamedText] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedStyle, setSelectedStyle] = useState<Style>(null);
+  const [selectedStyle, setSelectedStyle] = useState<RewriteStyle | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   const startStream = useCallback(
-    async (style: Style) => {
-      if (abortRef.current) abortRef.current.abort();
+    (style: RewriteStyle | null) => {
+      abortRef.current?.abort();
       abortRef.current = new AbortController();
 
       setStreamedText("");
       setError(null);
       setIsStreaming(true);
 
-      try {
-        const res = await fetch("/api/ai/rewrite", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            text: sourceText,
-            locale,
-            field_kind: fieldKind,
-            style: style ?? undefined,
-          }),
-          signal: abortRef.current.signal,
-        });
-
-        if (!res.ok) {
-          const errText = await res.text();
-          setError(errText || "AI service unavailable — try again.");
-          return;
-        }
-
-        const reader = res.body?.getReader();
-        if (!reader) {
-          setError("No response stream.");
-          return;
-        }
-
-        const decoder = new TextDecoder();
-        let buffer = "";
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              const data = line.slice(6);
-              if (data === "[DONE]" || data === "[ERROR]") break;
-              setStreamedText((prev) => prev + data);
-            }
-          }
-        }
-      } catch (e: unknown) {
-        if (e instanceof Error && e.name === "AbortError") return;
-        setError("Connection lost — retry?");
-      } finally {
-        setIsStreaming(false);
-      }
+      streamRewrite({
+        text: sourceText,
+        locale,
+        fieldKind,
+        style,
+        signal: abortRef.current.signal,
+        onChunk: (chunk) => setStreamedText((prev) => prev + chunk),
+        onDone: () => setIsStreaming(false),
+        onError: (msg) => {
+          setError(msg);
+          setIsStreaming(false);
+        },
+      });
     },
     [sourceText, locale, fieldKind]
   );
 
-  // Auto-start stream when panel opens
   useEffect(() => {
     if (isOpen) {
       setStreamedText("");
@@ -104,12 +67,12 @@ export default function AIEnhancePanel({
     };
   }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleRegenerate = (style: Style) => {
+  const handleRegenerate = (style: RewriteStyle | null) => {
     setSelectedStyle(style);
     startStream(style);
   };
 
-  const handleAbort = () => {
+  const handleClose = () => {
     abortRef.current?.abort();
     setIsStreaming(false);
     onClose();
@@ -119,14 +82,8 @@ export default function AIEnhancePanel({
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-black/20"
-        onClick={handleAbort}
-        aria-hidden
-      />
+      <div className="fixed inset-0 z-40 bg-black/20" onClick={handleClose} aria-hidden />
 
-      {/* Panel */}
       <div className="fixed inset-y-0 right-0 w-96 bg-[var(--bg-elevated)] border-l border-[var(--border-default)] shadow-2xl z-50 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-default)]">
@@ -138,7 +95,7 @@ export default function AIEnhancePanel({
           </div>
           <button
             type="button"
-            onClick={handleAbort}
+            onClick={handleClose}
             className="text-[var(--text-muted)] hover:text-[var(--text-primary)] text-xl leading-none px-1"
             aria-label="Close"
           >

--- a/components/admin/AIEnhancePanel.tsx
+++ b/components/admin/AIEnhancePanel.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useState, useRef, useCallback, useEffect } from "react";
+
+type Style = "shorter" | "technical" | "friendlier" | null;
+type FieldKind = "bullet" | "paragraph" | "title";
+
+interface AIEnhancePanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAccept: (text: string) => void;
+  sourceText: string;
+  locale: "en" | "es";
+  fieldKind: FieldKind;
+  fieldLabel: string;
+}
+
+export default function AIEnhancePanel({
+  isOpen,
+  onClose,
+  onAccept,
+  sourceText,
+  locale,
+  fieldKind,
+  fieldLabel,
+}: AIEnhancePanelProps) {
+  const [streamedText, setStreamedText] = useState("");
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedStyle, setSelectedStyle] = useState<Style>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const startStream = useCallback(
+    async (style: Style) => {
+      if (abortRef.current) abortRef.current.abort();
+      abortRef.current = new AbortController();
+
+      setStreamedText("");
+      setError(null);
+      setIsStreaming(true);
+
+      try {
+        const res = await fetch("/api/ai/rewrite", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            text: sourceText,
+            locale,
+            field_kind: fieldKind,
+            style: style ?? undefined,
+          }),
+          signal: abortRef.current.signal,
+        });
+
+        if (!res.ok) {
+          const errText = await res.text();
+          setError(errText || "AI service unavailable — try again.");
+          return;
+        }
+
+        const reader = res.body?.getReader();
+        if (!reader) {
+          setError("No response stream.");
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6);
+              if (data === "[DONE]" || data === "[ERROR]") break;
+              setStreamedText((prev) => prev + data);
+            }
+          }
+        }
+      } catch (e: unknown) {
+        if (e instanceof Error && e.name === "AbortError") return;
+        setError("Connection lost — retry?");
+      } finally {
+        setIsStreaming(false);
+      }
+    },
+    [sourceText, locale, fieldKind]
+  );
+
+  // Auto-start stream when panel opens
+  useEffect(() => {
+    if (isOpen) {
+      setStreamedText("");
+      setError(null);
+      setSelectedStyle(null);
+      startStream(null);
+    }
+    return () => {
+      if (!isOpen) abortRef.current?.abort();
+    };
+  }, [isOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleRegenerate = (style: Style) => {
+    setSelectedStyle(style);
+    startStream(style);
+  };
+
+  const handleAbort = () => {
+    abortRef.current?.abort();
+    setIsStreaming(false);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/20"
+        onClick={handleAbort}
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <div className="fixed inset-y-0 right-0 w-96 bg-[var(--bg-elevated)] border-l border-[var(--border-default)] shadow-2xl z-50 flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-default)]">
+          <div className="flex items-center gap-2">
+            <span className="text-[var(--accent-violet)] text-base">✨</span>
+            <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+              AI Suggestion — {fieldLabel}
+            </h3>
+          </div>
+          <button
+            type="button"
+            onClick={handleAbort}
+            className="text-[var(--text-muted)] hover:text-[var(--text-primary)] text-xl leading-none px-1"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Stream area */}
+        <div className="flex-1 overflow-y-auto px-4 py-4">
+          {error ? (
+            <p className="text-sm text-[var(--color-error)]">{error}</p>
+          ) : streamedText ? (
+            <p className="text-sm text-[var(--text-primary)] whitespace-pre-wrap leading-relaxed">
+              {streamedText}
+              {isStreaming && (
+                <span className="inline-block w-0.5 h-4 bg-[var(--accent-violet)] ml-0.5 animate-pulse" />
+              )}
+            </p>
+          ) : (
+            <p className="text-sm text-[var(--text-muted)] animate-pulse">Thinking…</p>
+          )}
+        </div>
+
+        {/* Style hints */}
+        <div className="px-4 py-2 border-t border-[var(--border-default)]">
+          <p className="text-xs text-[var(--text-muted)] mb-2">Regenerate with hint:</p>
+          <div className="flex gap-2">
+            {(["shorter", "technical", "friendlier"] as const).map((s) => (
+              <button
+                key={s}
+                type="button"
+                disabled={isStreaming}
+                onClick={() => handleRegenerate(s)}
+                className={`px-2 py-1 rounded text-xs border transition-colors disabled:opacity-40 ${
+                  selectedStyle === s
+                    ? "border-[var(--accent-violet)] text-[var(--accent-violet)] bg-[var(--accent-violet)]/10"
+                    : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-violet)]"
+                }`}
+              >
+                {s}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="px-4 py-3 border-t border-[var(--border-default)] flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-3 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-base)] transition-colors"
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            onClick={() => handleRegenerate(selectedStyle)}
+            disabled={isStreaming}
+            className="flex-1 px-3 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-secondary)] hover:bg-[var(--bg-base)] transition-colors disabled:opacity-40"
+          >
+            Regenerate
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              onAccept(streamedText);
+              onClose();
+            }}
+            disabled={isStreaming || !streamedText}
+            className="flex-1 px-3 py-2 rounded-lg bg-[var(--accent-violet)] text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-40"
+          >
+            Accept
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/admin/AISuggestButton.tsx
+++ b/components/admin/AISuggestButton.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useRef } from "react";
+import { streamRewrite } from "@/lib/aiStream";
+
+interface AISuggestButtonProps {
+  sourceText: string;
+  label?: string;
+  mode?: "suggest" | "suggest_tags" | "suggest_skills";
+  availableSkills?: string[];
+  onAccept: (text: string) => void;
+}
+
+export default function AISuggestButton({
+  sourceText,
+  label = "Suggest",
+  mode = "suggest",
+  availableSkills,
+  onAccept,
+}: AISuggestButtonProps) {
+  const [status, setStatus] = useState<"idle" | "loading" | "done" | "error">("idle");
+  const [suggestion, setSuggestion] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const tooShort = sourceText.trim().length < 20;
+
+  const run = () => {
+    abortRef.current?.abort();
+    abortRef.current = new AbortController();
+    setStatus("loading");
+    setSuggestion("");
+
+    streamRewrite({
+      text: sourceText,
+      locale: "en",
+      fieldKind: "paragraph",
+      mode,
+      availableSkills,
+      signal: abortRef.current.signal,
+      onChunk: (chunk) => setSuggestion((prev) => prev + chunk),
+      onDone: () => setStatus("done"),
+      onError: () => setStatus("error"),
+    });
+  };
+
+  const handleAccept = () => {
+    onAccept(suggestion);
+    setStatus("idle");
+    setSuggestion("");
+  };
+
+  const handleDismiss = () => {
+    abortRef.current?.abort();
+    setStatus("idle");
+    setSuggestion("");
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <button
+        type="button"
+        disabled={tooShort || status === "loading"}
+        onClick={run}
+        title={tooShort ? "Add a description first (min 20 chars)" : "Suggest from description"}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs text-[var(--accent-violet)] border border-[var(--accent-violet)]/60 hover:bg-[var(--accent-violet)] hover:text-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+      >
+        <span aria-hidden>✨</span>
+        <span>{status === "loading" ? "Thinking…" : label}</span>
+      </button>
+
+      {(status === "loading" || status === "done") && suggestion && (
+        <div className="p-2 rounded-lg bg-[var(--bg-elevated)] border border-[var(--accent-violet)]/40 text-xs">
+          <p className="text-[var(--text-primary)] mb-2 font-mono">
+            {suggestion}
+            {status === "loading" && (
+              <span className="inline-block w-0.5 h-3 bg-[var(--accent-violet)] ml-0.5 animate-pulse" />
+            )}
+          </p>
+          {status === "done" && (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleAccept}
+                className="px-2 py-0.5 rounded bg-[var(--accent-violet)] text-white text-xs font-medium hover:opacity-90 transition-opacity"
+              >
+                Accept
+              </button>
+              <button
+                type="button"
+                onClick={handleDismiss}
+                className="px-2 py-0.5 rounded border border-[var(--border-default)] text-[var(--text-secondary)] text-xs hover:bg-[var(--bg-base)] transition-colors"
+              >
+                Dismiss
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {status === "error" && (
+        <p className="text-xs text-[var(--color-error)]">Failed — try again.</p>
+      )}
+    </div>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -2,20 +2,9 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { FiHome, FiLayout, FiBriefcase, FiAward, FiEdit3, FiLogOut, FiList, FiUser, FiMail, FiZap } from "react-icons/fi";
+import { FiLogOut } from "react-icons/fi";
 import { logoutAction } from "@/app/actions/auth";
-
-const navItems = [
-  { href: "/admin", label: "Dashboard", icon: FiHome },
-  { href: "/admin/profile", label: "Profile", icon: FiUser },
-  { href: "/admin/projects", label: "Projects", icon: FiLayout },
-  { href: "/admin/experience", label: "Experience", icon: FiBriefcase },
-  { href: "/admin/skills", label: "Skills", icon: FiList },
-  { href: "/admin/education", label: "Education", icon: FiAward },
-  { href: "/admin/blog", label: "Blog & AI", icon: FiEdit3 },
-  { href: "/admin/messages", label: "Inbox", icon: FiMail },
-  { href: "/admin/ai/usage", label: "AI Usage", icon: FiZap },
-];
+import { adminNavItems } from "@/lib/constants/adminNav";
 
 export default function AdminSidebar() {
   const pathname = usePathname();
@@ -35,15 +24,17 @@ export default function AdminSidebar() {
       </div>
 
       <nav className="flex-1 p-4 space-y-1">
-        {navItems.map((item) => {
-          const isActive = pathname === item.href || (item.href !== "/admin" && pathname.startsWith(item.href));
+        {adminNavItems.map((item) => {
+          const isActive =
+            pathname === item.href ||
+            (item.href !== "/admin" && pathname.startsWith(item.href));
           return (
             <Link
               key={item.href}
               href={item.href}
               className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                isActive 
-                  ? "bg-[var(--accent-violet)]/10 text-[var(--accent-violet)]" 
+                isActive
+                  ? "bg-[var(--accent-violet)]/10 text-[var(--accent-violet)]"
                   : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)]"
               }`}
             >

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { FiHome, FiLayout, FiBriefcase, FiAward, FiEdit3, FiLogOut, FiList, FiUser, FiMail } from "react-icons/fi";
+import { FiHome, FiLayout, FiBriefcase, FiAward, FiEdit3, FiLogOut, FiList, FiUser, FiMail, FiZap } from "react-icons/fi";
 import { logoutAction } from "@/app/actions/auth";
 
 const navItems = [
@@ -14,6 +14,7 @@ const navItems = [
   { href: "/admin/education", label: "Education", icon: FiAward },
   { href: "/admin/blog", label: "Blog & AI", icon: FiEdit3 },
   { href: "/admin/messages", label: "Inbox", icon: FiMail },
+  { href: "/admin/ai/usage", label: "AI Usage", icon: FiZap },
 ];
 
 export default function AdminSidebar() {

--- a/components/admin/forms/LocalizedListField.tsx
+++ b/components/admin/forms/LocalizedListField.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import AIEnhanceButton from "@/components/admin/AIEnhanceButton";
 
 interface LocalizedListFieldProps {
   name: string;
@@ -32,27 +33,39 @@ export default function LocalizedListField({
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
         <label className="text-sm font-medium text-[var(--text-secondary)]">{label}</label>
-        <div className="flex items-center gap-1">
-          {(["en", "es"] as const).map((loc) => {
-            const list = loc === "en" ? enList : esList;
-            return (
-              <button
-                key={loc}
-                type="button"
-                onClick={() => setActiveLocale(loc)}
-                className={`px-2 py-0.5 rounded text-xs font-bold uppercase transition-colors ${
-                  activeLocale === loc
-                    ? "bg-[var(--accent-violet)] text-white"
-                    : "bg-[var(--bg-elevated)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
-                }`}
-              >
-                {loc}
-                {list.filter(Boolean).length === 0 && (
-                  <span className="ml-1 text-[var(--color-warning)] text-[10px]">⚠</span>
-                )}
-              </button>
-            );
-          })}
+        <div className="flex items-center gap-2">
+          <AIEnhanceButton
+            sourceText={activeList.join("\n")}
+            locale={activeLocale}
+            fieldKind="bullet"
+            fieldLabel={label}
+            onAccept={(text) => {
+              const lines = text.split("\n").filter(Boolean);
+              setValue(`${name}.${activeLocale}`, lines, { shouldDirty: true });
+            }}
+          />
+          <div className="flex items-center gap-1">
+            {(["en", "es"] as const).map((loc) => {
+              const list = loc === "en" ? enList : esList;
+              return (
+                <button
+                  key={loc}
+                  type="button"
+                  onClick={() => setActiveLocale(loc)}
+                  className={`px-2 py-0.5 rounded text-xs font-bold uppercase transition-colors ${
+                    activeLocale === loc
+                      ? "bg-[var(--accent-violet)] text-white"
+                      : "bg-[var(--bg-elevated)] text-[var(--text-muted)] hover:text-[var(--text-secondary)]"
+                  }`}
+                >
+                  {loc}
+                  {list.filter(Boolean).length === 0 && (
+                    <span className="ml-1 text-[var(--color-warning)] text-[10px]">⚠</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
       <textarea

--- a/components/admin/forms/LocalizedListField.tsx
+++ b/components/admin/forms/LocalizedListField.tsx
@@ -43,6 +43,10 @@ export default function LocalizedListField({
               const lines = text.split("\n").filter(Boolean);
               setValue(`${name}.${activeLocale}`, lines, { shouldDirty: true });
             }}
+            onAcceptTranslation={(text, targetLocale) => {
+              const lines = text.split("\n").filter(Boolean);
+              setValue(`${name}.${targetLocale}`, lines, { shouldDirty: true });
+            }}
           />
           <div className="flex items-center gap-1">
             {(["en", "es"] as const).map((loc) => {

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
+import AIEnhanceButton from "@/components/admin/AIEnhanceButton";
 
 interface LocalizedTextFieldProps {
   name: string;
@@ -10,6 +11,7 @@ interface LocalizedTextFieldProps {
   rows?: number;
   placeholder?: { en?: string; es?: string };
   required?: boolean;
+  fieldKind?: "bullet" | "paragraph" | "title";
 }
 
 export default function LocalizedTextField({
@@ -19,10 +21,12 @@ export default function LocalizedTextField({
   rows = 3,
   placeholder = {},
   required = false,
+  fieldKind = "paragraph",
 }: LocalizedTextFieldProps) {
   const [activeLocale, setActiveLocale] = useState<"en" | "es">("en");
   const {
     register,
+    setValue,
     formState: { errors },
     watch,
   } = useFormContext();
@@ -43,7 +47,19 @@ export default function LocalizedTextField({
         <label className="text-sm font-medium text-[var(--text-secondary)]">
           {label}{required && " *"}
         </label>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
+          {multiline && (
+            <AIEnhanceButton
+              sourceText={activeLocale === "en" ? enValue : esValue}
+              locale={activeLocale}
+              fieldKind={fieldKind}
+              fieldLabel={label}
+              onAccept={(text) =>
+                setValue(`${name}.${activeLocale}`, text, { shouldDirty: true })
+              }
+            />
+          )}
+          <div className="flex items-center gap-1">
           {(["en", "es"] as const).map((loc) => {
             const val = loc === "en" ? enValue : esValue;
             return (
@@ -64,6 +80,7 @@ export default function LocalizedTextField({
               </button>
             );
           })}
+          </div>
         </div>
       </div>
 

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -22,8 +22,9 @@ export default function LocalizedTextField({
   rows = 3,
   placeholder = {},
   required = false,
-  fieldKind = "paragraph",
+  fieldKind,
 }: LocalizedTextFieldProps) {
+  const resolvedFieldKind: RewriteFieldKind = fieldKind ?? (multiline ? "paragraph" : "title");
   const [activeLocale, setActiveLocale] = useState<"en" | "es">("en");
   const {
     register,
@@ -49,14 +50,17 @@ export default function LocalizedTextField({
           {label}{required && " *"}
         </label>
         <div className="flex items-center gap-2">
-          {multiline && (
+          {(
             <AIEnhanceButton
               sourceText={activeLocale === "en" ? enValue : esValue}
               locale={activeLocale}
-              fieldKind={fieldKind}
+              fieldKind={resolvedFieldKind}
               fieldLabel={label}
               onAccept={(text) =>
                 setValue(`${name}.${activeLocale}`, text, { shouldDirty: true })
+              }
+              onAcceptTranslation={(text, targetLocale) =>
+                setValue(`${name}.${targetLocale}`, text, { shouldDirty: true })
               }
             />
           )}

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
 import AIEnhanceButton from "@/components/admin/AIEnhanceButton";
+import type { RewriteFieldKind } from "@/lib/types/ai";
 
 interface LocalizedTextFieldProps {
   name: string;
@@ -11,7 +12,7 @@ interface LocalizedTextFieldProps {
   rows?: number;
   placeholder?: { en?: string; es?: string };
   required?: boolean;
-  fieldKind?: "bullet" | "paragraph" | "title";
+  fieldKind?: RewriteFieldKind;
 }
 
 export default function LocalizedTextField({

--- a/lib/aiStream.ts
+++ b/lib/aiStream.ts
@@ -1,6 +1,6 @@
 import type { RewriteOptions } from "@/lib/types/ai";
 
-export type { RewriteFieldKind, RewriteStyle, RewriteOptions } from "@/lib/types/ai";
+export type { RewriteFieldKind, RewriteStyle, RewriteMode, RewriteOptions } from "@/lib/types/ai";
 
 /**
  * Streams a rewrite from the backend via the /api/ai/rewrite route handler.
@@ -11,6 +11,9 @@ export async function streamRewrite({
   locale,
   fieldKind,
   style,
+  mode,
+  targetLocale,
+  availableSkills,
   signal,
   onChunk,
   onDone,
@@ -26,6 +29,9 @@ export async function streamRewrite({
         locale,
         field_kind: fieldKind,
         style: style ?? undefined,
+        mode: mode ?? "rewrite",
+        target_locale: targetLocale,
+        available_skills: availableSkills,
       }),
       signal,
     });

--- a/lib/aiStream.ts
+++ b/lib/aiStream.ts
@@ -1,0 +1,76 @@
+import type { RewriteOptions } from "@/lib/types/ai";
+
+export type { RewriteFieldKind, RewriteStyle, RewriteOptions } from "@/lib/types/ai";
+
+/**
+ * Streams a rewrite from the backend via the /api/ai/rewrite route handler.
+ * Calls onChunk for each token, onDone on completion, onError on failure.
+ */
+export async function streamRewrite({
+  text,
+  locale,
+  fieldKind,
+  style,
+  signal,
+  onChunk,
+  onDone,
+  onError,
+}: RewriteOptions): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch("/api/ai/rewrite", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text,
+        locale,
+        field_kind: fieldKind,
+        style: style ?? undefined,
+      }),
+      signal,
+    });
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === "AbortError") return;
+    onError("Connection failed — try again.");
+    return;
+  }
+
+  if (!res.ok) {
+    const msg = await res.text().catch(() => "");
+    onError(msg || "AI service unavailable — try again.");
+    return;
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) {
+    onError("No response stream.");
+    return;
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data: ")) continue;
+        const data = line.slice(6);
+        if (data === "[DONE]" || data === "[ERROR]") {
+          onDone();
+          return;
+        }
+        onChunk(data);
+      }
+    }
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === "AbortError") return;
+    onError("Connection lost — retry?");
+  } finally {
+    onDone();
+  }
+}

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -2,6 +2,7 @@ import {
   FiAward,
   FiBriefcase,
   FiEdit3,
+  FiGlobe,
   FiHome,
   FiLayout,
   FiList,
@@ -22,5 +23,6 @@ export const adminNavItems: NavItem[] = [
   { href: "/admin/education",  label: "Education",  icon: FiAward },
   { href: "/admin/blog",       label: "Blog & AI",  icon: FiEdit3 },
   { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
-  { href: "/admin/ai/usage",   label: "AI Usage",   icon: FiZap },
+  { href: "/admin/translations", label: "Translations", icon: FiGlobe },
+  { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
 ];

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -1,0 +1,26 @@
+import {
+  FiAward,
+  FiBriefcase,
+  FiEdit3,
+  FiHome,
+  FiLayout,
+  FiList,
+  FiMail,
+  FiUser,
+  FiZap,
+} from "react-icons/fi";
+import type { NavItem } from "@/lib/types/admin";
+
+export type { NavItem } from "@/lib/types/admin";
+
+export const adminNavItems: NavItem[] = [
+  { href: "/admin",            label: "Dashboard",  icon: FiHome },
+  { href: "/admin/profile",    label: "Profile",    icon: FiUser },
+  { href: "/admin/projects",   label: "Projects",   icon: FiLayout },
+  { href: "/admin/experience", label: "Experience", icon: FiBriefcase },
+  { href: "/admin/skills",     label: "Skills",     icon: FiList },
+  { href: "/admin/education",  label: "Education",  icon: FiAward },
+  { href: "/admin/blog",       label: "Blog & AI",  icon: FiEdit3 },
+  { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
+  { href: "/admin/ai/usage",   label: "AI Usage",   icon: FiZap },
+];

--- a/lib/schemas/blog.ts
+++ b/lib/schemas/blog.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { LocalizedText } from "./_localized";
+
+export const BlogCreate = z.object({
+  title: LocalizedText,
+  slug: z.string().min(1, "Slug is required"),
+  excerpt: LocalizedText,
+  content: LocalizedText,
+  tags: z.string().default(""),
+  reading_time: z.string().default("5 min read"),
+  is_published: z.boolean().default(false),
+});
+
+export type BlogCreate = z.infer<typeof BlogCreate>;

--- a/lib/schemas/project.ts
+++ b/lib/schemas/project.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { LocalizedText } from "./_localized";
+
+export const ProjectCreate = z.object({
+  title: LocalizedText,
+  slug: z.string().min(1, "Slug is required"),
+  description: LocalizedText,
+  github_url: z.string().url("Must be a valid URL").or(z.literal("")).nullable().optional(),
+  live_url: z.string().url("Must be a valid URL").or(z.literal("")).nullable().optional(),
+  is_featured: z.boolean().default(false),
+  sort_order: z.number().int().default(0),
+});
+
+export type ProjectCreate = z.infer<typeof ProjectCreate>;

--- a/lib/types/admin.ts
+++ b/lib/types/admin.ts
@@ -1,0 +1,7 @@
+import type { IconType } from "react-icons";
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: IconType;
+}

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -1,11 +1,15 @@
 export type RewriteFieldKind = "bullet" | "paragraph" | "title";
 export type RewriteStyle = "shorter" | "technical" | "friendlier";
+export type RewriteMode = "rewrite" | "translate" | "suggest" | "suggest_tags" | "suggest_skills";
 
 export interface RewriteOptions {
   text: string;
   locale: "en" | "es";
   fieldKind: RewriteFieldKind;
   style?: RewriteStyle | null;
+  mode?: RewriteMode;
+  targetLocale?: "en" | "es";
+  availableSkills?: string[];
   signal?: AbortSignal;
   onChunk: (chunk: string) => void;
   onDone: () => void;

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -1,0 +1,28 @@
+export type RewriteFieldKind = "bullet" | "paragraph" | "title";
+export type RewriteStyle = "shorter" | "technical" | "friendlier";
+
+export interface RewriteOptions {
+  text: string;
+  locale: "en" | "es";
+  fieldKind: RewriteFieldKind;
+  style?: RewriteStyle | null;
+  signal?: AbortSignal;
+  onChunk: (chunk: string) => void;
+  onDone: () => void;
+  onError: (message: string) => void;
+}
+
+export interface AiCallRow {
+  feature: string;
+  provider: string;
+  model: string;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+  latency_ms: number | null;
+  succeeded: boolean;
+  created_at: string;
+}
+
+export interface AiUsageData {
+  calls: AiCallRow[];
+}

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -27,6 +27,18 @@ export interface AiCallRow {
   created_at: string;
 }
 
+export interface AiModelStat {
+  feature: string;
+  provider: string;
+  model: string;
+  call_count: number;
+  avg_latency_ms: number | null;
+  total_prompt_tokens: number;
+  total_completion_tokens: number;
+  total_tokens: number;
+}
+
 export interface AiUsageData {
   calls: AiCallRow[];
+  stats: AiModelStat[];
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -131,6 +131,18 @@
     "description": "The page you're looking for doesn't exist or has been moved. Let's get you back on track.",
     "backToHome": "Back to Home"
   },
+  "ai": {
+    "improveWithAI": "Improve with AI",
+    "accept": "Accept",
+    "reject": "Reject",
+    "regenerate": "Regenerate",
+    "regenerateShorter": "Shorter",
+    "regenerateTechnical": "Technical",
+    "regenerateFriendlier": "Friendlier",
+    "aiThinking": "Thinking…",
+    "aiUnavailable": "AI service unavailable — try again.",
+    "aiFieldTooShort": "Text too short for AI rewrite (min 20 chars)"
+  },
   "cta": {
     "afterProjects": {
       "headline": "Like What You See?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -131,6 +131,18 @@
     "description": "La página que buscas no existe o fue movida. Te ayudamos a retomar el camino.",
     "backToHome": "Volver al inicio"
   },
+  "ai": {
+    "improveWithAI": "Mejorar con IA",
+    "accept": "Aceptar",
+    "reject": "Rechazar",
+    "regenerate": "Regenerar",
+    "regenerateShorter": "Más corto",
+    "regenerateTechnical": "Técnico",
+    "regenerateFriendlier": "Más amigable",
+    "aiThinking": "Pensando…",
+    "aiUnavailable": "Servicio de IA no disponible — intenta de nuevo.",
+    "aiFieldTooShort": "Texto muy corto para reescribir con IA (mín. 20 caracteres)"
+  },
   "cta": {
     "afterProjects": {
       "headline": "¿Te gustó lo que viste?",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "diff": "^9.0.0",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.11.0",
         "next": "15.3.8",
@@ -24,6 +25,7 @@
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@tailwindcss/typography": "^0.5.16",
+        "@types/diff": "^7.0.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1898,6 +1900,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3206,6 +3215,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "diff": "^9.0.0",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.11.0",
     "next": "15.3.8",
@@ -40,6 +41,7 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@tailwindcss/typography": "^0.5.16",
+    "@types/diff": "^7.0.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
## Summary

- **Translation queue page** (`/admin/translations`): bidirectional EN↔ES queue streaming live tokens via SSE. Entity filter tabs, skip/keep-as-is actions, auto-resizing textareas capped at `max-h-64`.
- **AI enhance panel**: translate, suggest-tags, and suggest-skills modes added to the rewrite panel.
- **AI usage dashboard** (`/admin/ai/usage`): redesigned with a per-model summary table (total calls, avg latency, in/out token counts) above the last-100-calls detail log. Token counts use tiktoken for OpenAI/Groq and google-genai `count_tokens` for Gemini.
- **Keep as-is button**: single-word source texts get an amber hint and a highlighted "Keep as-is" button to skip the AI call for terms that are the same in both languages.

## Fixes included

- Both locales always sent on save — prevents JSONB partial-overwrite wiping the source locale
- List fields (`experience.description`) split back to arrays before PATCH
- Pydantic error arrays safely stringified to avoid React child crash
- English-only locale labels throughout the queue UI
- Source text panel and translation textarea both capped at `max-h-64`, scroll beyond that
- `TypeError` on AI usage page when `stats` field missing from old cached response

## Migration required

```
alembic upgrade head   # creates translation_drafts table (additive, no existing data touched)
```

## Test plan

- [ ] Apply migration, confirm `translation_drafts` table exists
- [ ] `/admin/translations` loads queue, filter tabs work when multiple entity types present
- [ ] Translate a title field — result is short, word-order correct
- [ ] Translate a bio/paragraph — streams live, textarea grows then caps at 256 px
- [ ] Translate an experience description (list field) — save does not wipe English
- [ ] Save a Spanish translation — English source locale is preserved in the DB
- [ ] Single-word source shows amber "Single word — try Keep as-is" badge + amber button
- [ ] "Keep as-is" copies source to target textarea without an AI call
- [ ] Skip removes the item from the queue
- [ ] `/admin/ai/usage` loads without crashing; summary table shows totals row
- [ ] After a translate call, in/out token counts appear in the calls table

🤖 Generated with [Claude Code](https://claude.ai/claude-code)