### PR TITLE
feat(imports): LinkedIn import admin UI with how-to instructions

### DIFF
--- a/app/actions/imports.ts
+++ b/app/actions/imports.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { linkedinPreview, linkedinApply } from "@/lib/adminApi";
+
+export async function previewLinkedInZip(formData: FormData) {
+  return linkedinPreview(formData);
+}
+
+export async function applyLinkedInImport(payload: {
+  import_session_id: string;
+  actions: { row_id: string; action: "create" | "merge" | "skip"; target_id?: string }[];
+}) {
+  return linkedinApply(payload);
+}

--- a/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
+++ b/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, useState, useTransition } from "react";
+import { FiUploadCloud, FiAlertTriangle, FiCheckCircle, FiLoader } from "react-icons/fi";
+import { previewLinkedInZip, applyLinkedInImport } from "@/app/actions/imports";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type Action = "create" | "merge" | "skip";
+
+interface MatchCandidate {
+  id: string;
+  label: string;
+}
+
+interface PreviewRow {
+  row_id: string;
+  parsed: Record<string, unknown>;
+  matches: MatchCandidate[];
+  default_action: Action;
+  parse_error?: string | null;
+}
+
+interface PreviewCategory {
+  rows: PreviewRow[];
+}
+
+interface PreviewResponse {
+  import_session_id: string;
+  expires_at: string;
+  categories: Record<string, PreviewCategory>;
+  warnings: string[];
+}
+
+interface RowAction {
+  row_id: string;
+  action: Action;
+  target_id?: string;
+}
+
+// ─── Category labels ─────────────────────────────────────────────────────────
+
+const CAT_LABELS: Record<string, string> = {
+  positions: "Work Positions",
+  education: "Education (Degrees)",
+  certifications: "Certifications",
+  honors: "Honors & Awards",
+  skills: "Skills",
+  projects: "Projects",
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function rowLabel(catKey: string, parsed: Record<string, unknown>): string {
+  if (catKey === "positions") {
+    const role = (parsed.role as Record<string, string> | undefined)?.en ?? "";
+    return `${role} @ ${parsed.company ?? "?"}`;
+  }
+  if (catKey === "education" || catKey === "certifications" || catKey === "honors") {
+    const degree = (parsed.degree as Record<string, string> | undefined)?.en ?? "";
+    return `${degree} — ${parsed.institution ?? "?"}`;
+  }
+  if (catKey === "skills") return String(parsed.name ?? "?");
+  if (catKey === "projects") {
+    const title = (parsed.title as Record<string, string> | undefined)?.en ?? "";
+    return title || String(parsed.slug ?? "?");
+  }
+  return JSON.stringify(parsed).slice(0, 60);
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export default function LinkedInImportClient() {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [isPending, startTransition] = useTransition();
+
+  // Upload phase
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  // Preview phase
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [enabledCats, setEnabledCats] = useState<Set<string>>(new Set());
+  const [rowActions, setRowActions] = useState<Map<string, RowAction>>(new Map());
+
+  // Apply phase
+  const [applyResult, setApplyResult] = useState<{
+    created: number;
+    merged: number;
+    skipped: number;
+    errors: string[];
+  } | null>(null);
+
+  // ─── Upload handler ────────────────────────────────────────────────────────
+
+  function handleUpload() {
+    const file = fileRef.current?.files?.[0];
+    if (!file) return;
+    setUploadError(null);
+    setPreview(null);
+    setApplyResult(null);
+
+    const fd = new FormData();
+    fd.append("file", file);
+
+    startTransition(async () => {
+      try {
+        const data: PreviewResponse = await previewLinkedInZip(fd);
+        setPreview(data);
+
+        // Enable all categories that have at least one row
+        const cats = new Set(
+          Object.entries(data.categories)
+            .filter(([, cat]) => cat.rows.length > 0)
+            .map(([k]) => k)
+        );
+        setEnabledCats(cats);
+
+        // Initialise row actions from defaults
+        const actions = new Map<string, RowAction>();
+        for (const [, cat] of Object.entries(data.categories)) {
+          for (const row of cat.rows) {
+            actions.set(row.row_id, {
+              row_id: row.row_id,
+              action: row.default_action,
+              target_id: row.matches[0]?.id,
+            });
+          }
+        }
+        setRowActions(actions);
+      } catch (e: unknown) {
+        setUploadError(e instanceof Error ? e.message : "Upload failed.");
+      }
+    });
+  }
+
+  // ─── Apply handler ─────────────────────────────────────────────────────────
+
+  function handleApply() {
+    if (!preview) return;
+
+    // Collect only actions for enabled categories
+    const actions: RowAction[] = [];
+    for (const [catKey, cat] of Object.entries(preview.categories)) {
+      if (!enabledCats.has(catKey)) continue;
+      for (const row of cat.rows) {
+        const a = rowActions.get(row.row_id);
+        if (a) actions.push(a);
+      }
+    }
+
+    startTransition(async () => {
+      try {
+        const result = await applyLinkedInImport({
+          import_session_id: preview.import_session_id,
+          actions,
+        });
+        setApplyResult(result);
+        setPreview(null);
+      } catch (e: unknown) {
+        setUploadError(e instanceof Error ? e.message : "Apply failed.");
+      }
+    });
+  }
+
+  // ─── Row action helpers ────────────────────────────────────────────────────
+
+  function setAction(rowId: string, action: Action) {
+    setRowActions((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(rowId);
+      next.set(rowId, { ...existing!, row_id: rowId, action });
+      return next;
+    });
+  }
+
+  function setTarget(rowId: string, targetId: string) {
+    setRowActions((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(rowId);
+      next.set(rowId, { ...existing!, row_id: rowId, target_id: targetId });
+      return next;
+    });
+  }
+
+  function toggleCat(cat: string) {
+    setEnabledCats((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  }
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  // Apply result
+  if (applyResult) {
+    return (
+      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6 space-y-4">
+        <div className="flex items-center gap-3 text-[var(--color-success)]">
+          <FiCheckCircle className="w-6 h-6" />
+          <h2 className="text-lg font-semibold">Import complete</h2>
+        </div>
+        <ul className="text-sm text-[var(--text-secondary)] space-y-1">
+          <li>
+            <span className="font-medium text-[var(--text-primary)]">{applyResult.created}</span>{" "}
+            records created
+          </li>
+          <li>
+            <span className="font-medium text-[var(--text-primary)]">{applyResult.merged}</span>{" "}
+            records merged
+          </li>
+          <li>
+            <span className="font-medium text-[var(--text-primary)]">{applyResult.skipped}</span>{" "}
+            skipped
+          </li>
+        </ul>
+        {applyResult.errors.length > 0 && (
+          <div className="rounded-lg bg-[var(--color-error)]/10 border border-[var(--color-error)]/30 px-4 py-3 space-y-1">
+            <p className="text-xs font-semibold text-[var(--color-error)]">Errors</p>
+            {applyResult.errors.map((e, i) => (
+              <p key={i} className="text-xs text-[var(--color-error)]">
+                {e}
+              </p>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-[var(--text-muted)]">
+          ES translations for imported EN content will appear in the{" "}
+          <Link href="/admin/translations" className="underline text-[var(--accent-cyan)]">
+            Translation Queue
+          </Link>{" "}
+          once you run{" "}
+          <code className="text-[var(--accent-cyan)]">python -m app.tools.translate_seed</code>.
+        </p>
+        <button
+          onClick={() => {
+            setApplyResult(null);
+            if (fileRef.current) fileRef.current.value = "";
+          }}
+          className="text-sm text-[var(--accent-violet)] underline"
+        >
+          Import another ZIP
+        </button>
+      </div>
+    );
+  }
+
+  // Preview phase
+  if (preview) {
+    const totalRows = Object.values(preview.categories).reduce(
+      (s, c) => s + c.rows.length,
+      0
+    );
+    return (
+      <div className="space-y-6">
+        {/* Warnings */}
+        {preview.warnings.length > 0 && (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 space-y-1">
+            <div className="flex items-center gap-2 text-amber-500 text-sm font-semibold">
+              <FiAlertTriangle className="w-4 h-4" />
+              Parse warnings
+            </div>
+            {preview.warnings.map((w, i) => (
+              <p key={i} className="text-xs text-amber-400">
+                {w}
+              </p>
+            ))}
+          </div>
+        )}
+
+        {/* Summary + category toggles */}
+        <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-5 space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-base font-semibold text-[var(--text-primary)]">
+              {totalRows} rows parsed — choose categories to import
+            </h2>
+            <span className="text-xs text-[var(--text-muted)]">
+              Expires{" "}
+              {new Date(preview.expires_at).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </span>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {Object.entries(preview.categories)
+              .filter(([, cat]) => cat.rows.length > 0)
+              .map(([key, cat]) => (
+                <label
+                  key={key}
+                  className="flex items-center gap-2 cursor-pointer select-none text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={enabledCats.has(key)}
+                    onChange={() => toggleCat(key)}
+                    className="accent-[var(--accent-violet)]"
+                  />
+                  <span className="text-[var(--text-secondary)]">
+                    {CAT_LABELS[key] ?? key}{" "}
+                    <span className="text-[var(--text-muted)]">({cat.rows.length})</span>
+                  </span>
+                </label>
+              ))}
+          </div>
+        </div>
+
+        {/* Per-category rows */}
+        {Object.entries(preview.categories).map(([catKey, cat]) => {
+          if (cat.rows.length === 0) return null;
+          const isEnabled = enabledCats.has(catKey);
+          return (
+            <div
+              key={catKey}
+              className={`rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden transition-opacity ${
+                isEnabled ? "opacity-100" : "opacity-40"
+              }`}
+            >
+              <div className="px-5 py-3 border-b border-[var(--border-subtle)] flex items-center justify-between">
+                <h3 className="text-sm font-semibold text-[var(--text-primary)]">
+                  {CAT_LABELS[catKey] ?? catKey}
+                </h3>
+                <span className="text-xs text-[var(--text-muted)]">{cat.rows.length} rows</span>
+              </div>
+
+              <div className="divide-y divide-[var(--border-subtle)]">
+                {cat.rows.map((row) => {
+                  const act = rowActions.get(row.row_id);
+                  return (
+                    <div key={row.row_id} className="px-5 py-3 flex flex-col gap-2 sm:flex-row sm:items-start sm:gap-4">
+                      {/* Label + parse error */}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-[var(--text-primary)] truncate">
+                          {row.parse_error ? (
+                            <span className="text-amber-400">
+                              ⚠ {row.parse_error}
+                            </span>
+                          ) : (
+                            rowLabel(catKey, row.parsed)
+                          )}
+                        </p>
+                        {row.matches.length > 0 && (
+                          <p className="text-xs text-[var(--text-muted)] mt-0.5">
+                            Existing match: {row.matches[0].label}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Action selector */}
+                      <div className="flex items-center gap-2 flex-shrink-0">
+                        {(["create", "merge", "skip"] as Action[]).map((a) => (
+                          <button
+                            key={a}
+                            disabled={!isEnabled || !!row.parse_error}
+                            onClick={() => setAction(row.row_id, a)}
+                            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
+                              act?.action === a
+                                ? a === "create"
+                                  ? "bg-[var(--accent-violet)]/20 text-[var(--accent-violet)] ring-1 ring-[var(--accent-violet)]/40"
+                                  : a === "merge"
+                                  ? "bg-[var(--accent-cyan)]/20 text-[var(--accent-cyan)] ring-1 ring-[var(--accent-cyan)]/40"
+                                  : "bg-[var(--bg-elevated)] text-[var(--text-muted)] ring-1 ring-[var(--border-subtle)]"
+                                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+                            }`}
+                          >
+                            {a === "create" ? "✚ Create" : a === "merge" ? "↻ Merge" : "— Skip"}
+                          </button>
+                        ))}
+
+                        {/* Target selector for merge */}
+                        {act?.action === "merge" && row.matches.length > 1 && (
+                          <select
+                            value={act.target_id ?? ""}
+                            onChange={(e) => setTarget(row.row_id, e.target.value)}
+                            className="text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-secondary)] px-2 py-1"
+                          >
+                            {row.matches.map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.label}
+                              </option>
+                            ))}
+                          </select>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Apply / cancel buttons */}
+        <div className="flex items-center gap-4 pt-2">
+          <button
+            onClick={handleApply}
+            disabled={isPending || enabledCats.size === 0}
+            className="px-5 py-2.5 rounded-lg bg-[var(--accent-violet)] text-white text-sm font-semibold disabled:opacity-50 hover:opacity-90 transition-opacity flex items-center gap-2"
+          >
+            {isPending && <FiLoader className="w-4 h-4 animate-spin" />}
+            Apply changes
+          </button>
+          <button
+            onClick={() => {
+              setPreview(null);
+              if (fileRef.current) fileRef.current.value = "";
+            }}
+            className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Upload phase
+  return (
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6 space-y-5">
+      <h2 className="text-base font-semibold text-[var(--text-primary)]">Upload ZIP file</h2>
+
+      <label className="flex flex-col items-center justify-center gap-3 border-2 border-dashed border-[var(--border-subtle)] rounded-xl p-10 cursor-pointer hover:border-[var(--accent-violet)]/50 transition-colors group">
+        <FiUploadCloud className="w-10 h-10 text-[var(--text-muted)] group-hover:text-[var(--accent-violet)] transition-colors" />
+        <span className="text-sm text-[var(--text-secondary)] text-center">
+          Click to select your LinkedIn export <strong>.zip</strong>
+          <br />
+          <span className="text-xs text-[var(--text-muted)]">Max 50 MB</span>
+        </span>
+        <input
+          ref={fileRef}
+          type="file"
+          accept=".zip,application/zip"
+          className="sr-only"
+          onChange={handleUpload}
+        />
+      </label>
+
+      {isPending && (
+        <div className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
+          <FiLoader className="w-4 h-4 animate-spin text-[var(--accent-violet)]" />
+          Parsing ZIP — this usually takes a few seconds…
+        </div>
+      )}
+
+      {uploadError && (
+        <div className="rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 px-4 py-3 text-sm text-[var(--color-error)]">
+          {uploadError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/imports/linkedin/page.tsx
+++ b/app/admin/(dashboard)/imports/linkedin/page.tsx
@@ -1,0 +1,99 @@
+import LinkedInImportClient from "./LinkedInImportClient";
+
+export default function LinkedInImportPage() {
+  return (
+    <div className="max-w-3xl space-y-8">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)]">LinkedIn Import</h1>
+        <p className="text-sm text-[var(--text-muted)] mt-1">
+          Upload your LinkedIn data-export ZIP to import positions, education, certifications, skills,
+          and projects as draft records you confirm before they go live.
+        </p>
+      </div>
+
+      {/* How-to instructions */}
+      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6 space-y-4">
+        <h2 className="text-base font-semibold text-[var(--text-primary)]">
+          How to get your LinkedIn export ZIP
+        </h2>
+        <ol className="space-y-3 text-sm text-[var(--text-secondary)]">
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              1
+            </span>
+            <span>
+              Go to{" "}
+              <strong className="text-[var(--text-primary)]">LinkedIn.com</strong> → click your
+              profile picture → <strong className="text-[var(--text-primary)]">Settings &amp; Privacy</strong>.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              2
+            </span>
+            <span>
+              In the left sidebar, click{" "}
+              <strong className="text-[var(--text-primary)]">Data privacy</strong> → then{" "}
+              <strong className="text-[var(--text-primary)]">Get a copy of your data</strong>.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              3
+            </span>
+            <span>
+              Select{" "}
+              <strong className="text-[var(--text-primary)]">
+                &quot;Want something in particular?&quot;
+              </strong>{" "}
+              (not the full archive — that&apos;s much larger and takes days).
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              4
+            </span>
+            <span>
+              Check at minimum:{" "}
+              <strong className="text-[var(--text-primary)]">
+                Profile, Positions, Education, Certifications, Skills, Projects
+              </strong>
+              . Then click <strong className="text-[var(--text-primary)]">Request archive</strong>.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              5
+            </span>
+            <span>
+              LinkedIn will email you a download link within{" "}
+              <strong className="text-[var(--text-primary)]">10 minutes</strong> (sometimes up to
+              24 h for large accounts). Download and keep the{" "}
+              <strong className="text-[var(--text-primary)]">.zip</strong> file.
+            </span>
+          </li>
+          <li className="flex gap-3">
+            <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--accent-violet)]/15 text-[var(--accent-violet)] text-xs font-bold flex items-center justify-center">
+              6
+            </span>
+            <span>
+              Upload it below. The ZIP is parsed in memory and{" "}
+              <strong className="text-[var(--text-primary)]">deleted immediately</strong> — it is
+              never stored on the server.
+            </span>
+          </li>
+        </ol>
+
+        <div className="mt-4 rounded-lg bg-[var(--bg-elevated)] border border-[var(--border-subtle)] px-4 py-3 text-xs text-[var(--text-muted)]">
+          <strong className="text-[var(--text-secondary)]">Privacy note:</strong> Only the parsed
+          fields (titles, dates, company names) are stored temporarily for up to 1 hour while you
+          review the preview. The raw ZIP is never saved. Row counts are the only things logged.
+        </div>
+      </div>
+
+      {/* Upload + preview client component */}
+      <LinkedInImportClient />
+    </div>
+  );
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -103,3 +103,40 @@ export async function replyToContact(id: string, message: string) {
   }
   return res.json();
 }
+
+export async function linkedinPreview(formData: FormData) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  const res = await fetch(`${API_BASE_URL}/imports/linkedin/preview`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+    body: formData,
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `Preview failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function linkedinApply(payload: {
+  import_session_id: string;
+  actions: { row_id: string; action: "create" | "merge" | "skip"; target_id?: string }[];
+}) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  const res = await fetch(`${API_BASE_URL}/imports/linkedin/apply`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `Apply failed (${res.status})`);
+  }
+  return res.json();
+}
+

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -7,6 +7,7 @@ import {
   FiLayout,
   FiList,
   FiMail,
+  FiUploadCloud,
   FiUser,
   FiZap,
 } from "react-icons/fi";
@@ -24,5 +25,6 @@ export const adminNavItems: NavItem[] = [
   { href: "/admin/blog",       label: "Blog & AI",  icon: FiEdit3 },
   { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
   { href: "/admin/translations", label: "Translations", icon: FiGlobe },
+  { href: "/admin/imports/linkedin", label: "LinkedIn Import", icon: FiUploadCloud },
   { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
 ];


### PR DESCRIPTION
## Summary

- Adds `/admin/imports/linkedin` page with a 6-step how-to guide explaining how to obtain the LinkedIn export ZIP (Settings & Privacy → Data privacy → Get a copy → "Want something in particular?" → select CSVs)
- Upload dropzone → preview screen (category toggles + per-row create/merge/skip buttons + match candidate dropdowns) → apply result summary with link to Translation Queue
- Adds server actions `previewLinkedInZip` and `applyLinkedInImport` wiring to backend
- Adds "LinkedIn Import" nav item to AdminSidebar

## Depends on

Backend PR: https://github.com/zergcore/portfolio_backend/pull/13 (migration must be applied first)

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npm run lint` clean
- [ ] Navigate to `/admin/imports/linkedin` — how-to instructions visible
- [ ] Upload `backend/tests/fixtures/linkedin_export.zip` — preview loads with all 7 categories
- [ ] Toggle a category checkbox — rows grey out
- [ ] Change a row action — button highlights correctly
- [ ] Click Apply — result screen shows created/merged/skipped counts
- [ ] Click "Import another ZIP" — returns to upload screen
- [ ] Full smoke test pending with real LinkedIn export ZIP

## Acceptance criteria

- [x] How-to instructions present on upload page
- [x] Per-row create / merge / skip selectors
- [x] Category checkboxes for selective import
- [x] Result screen with translation queue link
- [x] No TypeScript errors, no ESLint warnings