### PR TITLE
feat(cv): Chunk 10 — unified CV & cover letter generator UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,155 +1,121 @@
-# Software Engineer Zaidibeth Ramos - Portfolio
+# Zergcore Portfolio — Frontend
 
-#Project Description
-This project is a modern, accessible portfolio website built with Next.js, TypeScript, and Tailwind CSS.
+Next.js 15 frontend for the Zergcore portfolio. App Router, React 19, TypeScript, Tailwind CSS 4, next-intl (EN/ES), and a full admin CMS backed by the FastAPI backend.
 
-## 🚀 Features
+## Tech stack
 
-- **Modern Design**: Clean, responsive layout with gradient text effects
-- **Accessibility**: WCAG compliant with proper ARIA labels and semantic HTML
-- **Performance**: Optimized with Next.js 15 and Turbopack
-- **TypeScript**: Full type safety throughout the application
-- **Error Handling**: Graceful error boundaries and loading states
-- **SEO Optimized**: Proper meta tags and structured data
+| Area | Choice |
+|---|---|
+| Framework | Next.js 15 (App Router) |
+| Language | TypeScript |
+| Styling | Tailwind CSS 4 |
+| i18n | next-intl — path-based routing (`/en/…`, `/es/…`) |
+| Forms | react-hook-form + zod |
+| AI streaming | Server-Sent Events via `/api/ai/rewrite/route.ts` |
+| Images | Cloudinary |
+| E2E tests | Playwright |
 
-## 🛠️ Tech Stack
+## Prerequisites
 
-### Frontend
+- Node.js 20+
+- The [backend](../backend/README.md) running on port 8000 (required for admin features and public data)
 
-- **Framework**: Next.js 15 with App Router
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS
-- **Icons**: Material-UI Icons
-- **Fonts**: Geist Sans & Roboto
-- **Analytics**: Metricool integration
+## Getting started
 
-### Backend
+```bash
+cd frontend
 
-   - **Python**: primary language for services and tooling
-   - **FastAPI**: async REST APIs
-   - **Supabase and PostgreSQL**:  managed database, auth, and storage
-   - **Docker**: reproducible local/dev/prod environments
+npm install
 
-## Architecture
-
-### Module map
-```mermaid
-graph LR
-  %% Nodes outside the app subgraph
-  U[User] --> B[Browser]
-  B --> NextApp
-
-  %% App subgraph
-  subgraph NextApp["Next.js App (App Router)"]
-    L["app/layout.tsx\n- global CSS\n- fonts\n- MetricoolScript\n- LinkedInScript"]
-    P["app/page.tsx\n- composition & layout"]
-    C1["components/typography\n- GradientText\n- TypingEffect\n- UnderlinedGradientText"]
-    C2["components/buttons/MediaButtons"]
-    C3["components/badges/LinkedInBadge"]
-    PUB["public/* static assets"]
-
-    L --> P
-    P --> C1
-    P --> C2
-    P -. optional .-> C3
-    P --> PUB
-  end
-
-  Ext1[Metricool] -. |beacon| .-> L
-  Ext2[LinkedIn Badge SDK] -. |script| .-> L
+cp .env.example .env.local   # fill in NEXT_PUBLIC_API_URL at minimum
 ```
 
-### Request/interaction flow
-```mermaid
-sequenceDiagram
-  participant User
-  participant Browser
-  participant NextJS as Next.js (App Router)
-  participant Scripts as Third-party Scripts
-  participant ExtA as Metricool
-  participant ExtB as LinkedIn
+**Minimum env vars for local dev:**
 
-  User->>Browser: Navigate to /
-  Browser->>NextJS: Request /
-  NextJS-->>Browser: HTML (layout + page) + CSS
-  Browser->>Scripts: Load MetricoolScript, LinkedInScript
-  Scripts-->>ExtA: Send analytics beacons
-  Scripts-->>ExtB: Load badge SDK (if badge rendered)
-  User->>Browser: Click social link (MediaButtons)
-  Browser-->>User: Open external target (new tab)
+| Variable | Value |
+|---|---|
+| `NEXT_PUBLIC_API_URL` | `http://127.0.0.1:8000/api/v1` |
+| `REVALIDATION_SECRET` | Match the backend's `REVALIDATION_SECRET` |
+
+```bash
+npm run dev      # http://localhost:3000
 ```
 
+Admin panel: `http://localhost:3000/admin` (login with the credentials set in the backend `.env`).
 
-## 📁 Project Structure
+## Available scripts
 
-```
-portfolio/
-├── app/                    # Next.js app directory
-│   ├── layout.tsx         # Root layout with metadata
-│   ├── page.tsx           # Main portfolio page
-│   └── globals.css        # Global styles
-├── components/            # Reusable components
-│   ├── badges/           # Badge components
-│   ├── buttons/          # Button components
-│   ├── scripts/          # Third-party script components
-│   └── typography/       # Text and animation components
-├── providers/            # Context providers
-└── public/              # Static assets
+```bash
+npm run dev        # Dev server (Turbopack)
+npm run build      # Production build
+npm run lint       # ESLint
+npx tsc --noEmit   # TypeScript check (run before merge)
+npx playwright test  # E2E tests (requires backend + frontend running)
 ```
 
-## 🎨 Components
+## Project structure
 
-### Core Components
-- **GradientText**: Animated gradient text with accessibility support
-- **CyclingTypingEffect**: Dynamic typing animation for professional roles
-- **MediaButtons**: Social media and contact links with hover effects
-- **LinkedInBadge**: LinkedIn profile integration
-- **ErrorBoundary**: Graceful error handling
-- **LoadingSpinner**: Loading state component
+```
+app/
+  [locale]/          Public site (EN + ES via next-intl)
+    page.tsx         Homepage
+    projects/        Projects listing + case studies
+    contact/         Contact page
+  admin/
+    (dashboard)/     Admin CMS (English-only)
+      profile/       Profile editor
+      experience/    Experience entries
+      education/     Education & certifications
+      projects/      Project entries
+      skills/        Skills & categories
+      blog/          Blog posts + AI enhance
+      translations/  EN→ES translation queue
+      imports/       LinkedIn ZIP import
+      cv/generate/   CV generator (JD → ATS-friendly PDF)
+      ai/usage/      AI token usage dashboard
+      messages/      Contact inbox
+  api/
+    ai/rewrite/      SSE streaming route for AI rewrite
+    revalidate/      On-demand ISR webhook
 
-## 🚀 Getting Started
+components/
+  admin/             Admin-only components (forms, AI panel, sidebar)
+  sections/          Public site sections (Hero, Experience, Projects…)
+  ui/                Shared UI primitives
 
-1. **Clone the repository**
-   ```bash
-   git clone https://github.com/zergcore/portfolio.git
-   cd portfolio
-   ```
+lib/
+  api.ts             Public read-only API client
+  adminApi.ts        Admin write API client (JWT from cookies)
+  schemas/           Zod schemas (mirror of backend Pydantic schemas)
+  constants/         adminNav, etc.
 
-2. **Install dependencies**
-   ```bash
-   npm install
-   ```
+messages/
+  en.json            English UI strings
+  es.json            Spanish UI strings
+```
 
-3. **Run the development server**
-   ```bash
-   npm run dev
-   ```
+## i18n
 
-4. **Open your browser**
-   Navigate to [http://localhost:3000](http://localhost:3000)
+- All public routes live under `/[locale]/` where `locale ∈ {en, es}`.
+- Locale detection: Vercel `geo` headers (LATAM countries → ES, else EN). Cookie `NEXT_LOCALE` overrides.
+- Admin section is English-only.
+- Every new user-facing string must be added to both `messages/en.json` and `messages/es.json`.
 
-## 🎯 Key Features
+## Admin CMS
 
-- **Responsive Design**: Works seamlessly on all device sizes
-- **Fast Loading**: Optimized for performance with Next.js 15
-- **SEO Ready**: Proper meta tags and structured data
-- **Accessible**: WCAG 2.1 AA compliant
-- **Modern**: Built with the latest web technologies
+The admin panel at `/admin` provides:
 
-## 📊 Analytics
+- **Profile** — bio, social links, meeting URL
+- **Experience / Education / Skills / Projects / Blog** — full CRUD with AI-enhance (✨) on text fields
+- **LinkedIn Import** — upload a LinkedIn data export ZIP and preview/confirm import
+- **CV Generator** — paste a job description (text or URL) → AI-tailored ATS-friendly PDF
+- **Translation Queue** — review AI-drafted ES translations before publishing
+- **AI Usage** — token counts and cost dashboard per feature
 
-The portfolio includes integration with:
-- **Metricool**: For analytics and performance tracking
-- **LinkedIn**: For professional networking integration
+## CV Generator (Chunk 10)
 
-## 🤝 Contributing
+Admin route: `/admin/cv/generate`
 
-This is a personal portfolio project, but suggestions and feedback are welcome!
+Paste a job description or enter a URL → the backend fetches and parses the JD, selects the most relevant profile bullets via cosine similarity on Gemini embeddings, renders a single-column ATS-friendly HTML/PDF, and uploads it to Cloudinary.
 
-## 📄 License
-
-This project is private and proprietary.
-
----
-
-**Built with ❤️ by Zaidibeth Ramos**
+Requires the backend to have `GEMINI_API_KEY` and `CLOUDINARY_URL` configured.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Next.js 15 frontend for the Zergcore portfolio. App Router, React 19, TypeScript
 | Forms | react-hook-form + zod |
 | AI streaming | Server-Sent Events via `/api/ai/rewrite/route.ts` |
 | Images | Cloudinary |
+| Analytics | Metricool (tracker script in `components/scripts/MetricoolScript.tsx`) |
 | E2E tests | Playwright |
 
 ## Prerequisites
@@ -111,6 +112,25 @@ The admin panel at `/admin` provides:
 - **CV Generator** — paste a job description (text or URL) → AI-tailored ATS-friendly PDF
 - **Translation Queue** — review AI-drafted ES translations before publishing
 - **AI Usage** — token counts and cost dashboard per feature
+
+## LinkedIn Import
+
+Admin route: `/admin/imports/linkedin`
+
+### How to export the right ZIP from LinkedIn
+
+LinkedIn currently offers two archive options. The importer needs files (`Positions.csv`, `Education.csv`, `Skills.csv`, `Projects.csv`, `Certifications.csv`, `Honors.csv`) that are **only included in the larger archive** — the "Want something in particular?" picker no longer lists those categories (as of 2026).
+
+1. Go to **LinkedIn → Me → Settings & Privacy → Data Privacy → Get a copy of your data**.
+2. Select the **first option**: *"Download larger data archive, including connections, verifications, contacts, account history, and information we infer about you based on your profile and activity."*
+3. Click **Request archive** and verify your password.
+4. LinkedIn emails the ZIP. Small accounts arrive in 10–60 minutes; LinkedIn officially says up to **24 hours**.
+
+> **LinkedIn rate-limits export requests.** After requesting one export you must wait roughly **2–4 hours** before you can request another. Plan ahead — if your archive is missing data, you'll have to wait the cooldown out before re-requesting.
+
+The "Want something in particular?" picker currently only offers Articles, Invitations, Profile, Recommendations, and Registration. None of those produce the CSVs the importer reads, so don't waste a request on it.
+
+Upload the larger archive at `/admin/imports/linkedin` to preview and confirm the import.
 
 ## CV Generator (Chunk 10)
 

--- a/app/actions/cv.ts
+++ b/app/actions/cv.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import {
+  analyzeJd,
+  confirmCvSkills,
+  generateCoverLetter,
+  generateCv,
+  renderCoverLetterPdf,
+  renderCvPdf,
+  type CoverLetterRequest,
+  type CoverLetterResponse,
+  type CvAnalyzeRequest,
+  type CvAnalyzeResponse,
+  type CvConfirmSkillsResponse,
+  type CvGenerateRequest,
+  type CvGenerateResponse,
+} from "@/lib/adminApi";
+
+export async function generateCoverLetterAction(
+  payload: CoverLetterRequest
+): Promise<CoverLetterResponse> {
+  return generateCoverLetter(payload);
+}
+
+export async function renderCoverLetterPdfAction(
+  clId: string
+): Promise<{ pdf_url: string }> {
+  return renderCoverLetterPdf(clId);
+}
+
+export async function analyzeJdAction(payload: CvAnalyzeRequest): Promise<CvAnalyzeResponse> {
+  return analyzeJd(payload);
+}
+
+export async function confirmCvSkillsAction(
+  skills: string[]
+): Promise<CvConfirmSkillsResponse> {
+  return confirmCvSkills(skills);
+}
+
+export async function generateCvAction(payload: CvGenerateRequest): Promise<CvGenerateResponse> {
+  return generateCv(payload);
+}
+
+export async function renderCvPdfAction(cvVersionId: string): Promise<{ pdf_url: string }> {
+  return renderCvPdf(cvVersionId);
+}

--- a/app/admin/(dashboard)/cv/generate/page.tsx
+++ b/app/admin/(dashboard)/cv/generate/page.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { useState } from "react";
+import { generateCv, renderCvPdf, type CvGenerateResponse } from "@/lib/adminApi";
+
+type Step = "idle" | "fetching_jd" | "parsing_jd" | "matching" | "done" | "error";
+
+const STEPS: Record<string, string> = {
+  fetching_jd: "Fetching JD…",
+  parsing_jd: "Extracting keywords…",
+  matching: "Selecting bullets…",
+  done: "Done",
+};
+
+export default function CvGeneratePage() {
+  const [jdText, setJdText] = useState("");
+  const [jdUrl, setJdUrl] = useState("");
+  const [locale, setLocale] = useState<"en" | "es">("en");
+  const [bulletsPerRole, setBulletsPerRole] = useState(3);
+
+  const [step, setStep] = useState<Step>("idle");
+  const [result, setResult] = useState<CvGenerateResponse | null>(null);
+  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
+  const [pdfLoading, setPdfLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleGenerate() {
+    if (!jdText.trim() && !jdUrl.trim()) return;
+    setStep(jdUrl.trim() ? "fetching_jd" : "parsing_jd");
+    setError(null);
+    setResult(null);
+    setPdfUrl(null);
+
+    try {
+      setStep("parsing_jd");
+      // Brief artificial step transition so the user sees progress labels
+      await new Promise((r) => setTimeout(r, 100));
+      setStep("matching");
+      const data = await generateCv({
+        jd_text: jdText.trim() || undefined,
+        jd_url: jdUrl.trim() || undefined,
+        locale,
+        bullets_per_role: bulletsPerRole,
+      });
+      setResult(data);
+      setStep("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setStep("error");
+    }
+  }
+
+  async function handleRenderPdf() {
+    if (!result) return;
+    setPdfLoading(true);
+    try {
+      const { pdf_url } = await renderCvPdf(result.cv_version_id);
+      setPdfUrl(pdf_url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "PDF render failed");
+    } finally {
+      setPdfLoading(false);
+    }
+  }
+
+  const isLoading = step !== "idle" && step !== "done" && step !== "error";
+  const stepLabel = step !== "idle" && step !== "done" && step !== "error"
+    ? STEPS[step]
+    : "";
+
+  return (
+    <div className="p-6 max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">CV Generator</h1>
+        <p className="text-sm text-[var(--text-muted)]">
+          Paste a job description (text or URL) and get a tailored, ATS-friendly CV.
+        </p>
+      </div>
+
+      {/* ── Form ──────────────────────────────────────────────────── */}
+      <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-5 space-y-4">
+        <div>
+          <label className="block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-1">
+            Job Description
+          </label>
+          <textarea
+            rows={8}
+            value={jdText}
+            onChange={(e) => setJdText(e.target.value)}
+            placeholder="Paste the job description here…"
+            disabled={isLoading}
+            className="w-full bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50 resize-y"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-[var(--text-muted)]">
+          <div className="h-px flex-1 bg-[var(--border-default)]" />
+          <span>or</span>
+          <div className="h-px flex-1 bg-[var(--border-default)]" />
+        </div>
+
+        <div>
+          <label className="block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-1">
+            JD URL
+          </label>
+          <input
+            type="url"
+            value={jdUrl}
+            onChange={(e) => setJdUrl(e.target.value)}
+            placeholder="https://boards.greenhouse.io/…"
+            disabled={isLoading}
+            className="w-full bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+              Output Language
+            </label>
+            <select
+              value={locale}
+              onChange={(e) => setLocale(e.target.value as "en" | "es")}
+              disabled={isLoading}
+              className="bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
+            >
+              <option value="en">English</option>
+              <option value="es">Español</option>
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+              Bullets per role
+            </label>
+            <select
+              value={bulletsPerRole}
+              onChange={(e) => setBulletsPerRole(Number(e.target.value))}
+              disabled={isLoading}
+              className="bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
+            >
+              {[2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>{n}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleGenerate}
+            disabled={isLoading || (!jdText.trim() && !jdUrl.trim())}
+            className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-40 transition-opacity flex items-center gap-2"
+          >
+            {isLoading ? (
+              <>
+                <span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />
+                {stepLabel}
+              </>
+            ) : (
+              "Generate CV"
+            )}
+          </button>
+
+          {result && !isLoading && (
+            <button
+              onClick={handleGenerate}
+              className="px-4 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
+            >
+              Regenerate
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* ── Error ─────────────────────────────────────────────────── */}
+      {step === "error" && error && (
+        <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl p-4 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* ── Result ────────────────────────────────────────────────── */}
+      {result && step === "done" && (
+        <div className="space-y-4">
+          {result.warning && (
+            <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800 rounded-xl p-3 text-sm text-yellow-700 dark:text-yellow-400">
+              <span className="font-semibold">Note: </span>{result.warning}
+            </div>
+          )}
+
+          {/* Detected keywords summary */}
+          {(result.jd_structured as Record<string, string[]>).must_have_skills?.length > 0 && (
+            <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-4">
+              <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-2">
+                Detected JD Signals
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {((result.jd_structured as Record<string, string[]>).must_have_skills ?? []).map(
+                  (s) => (
+                    <span
+                      key={s}
+                      className="px-2 py-0.5 rounded-full bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] text-xs font-medium"
+                    >
+                      {s}
+                    </span>
+                  )
+                )}
+                {((result.jd_structured as Record<string, string[]>).nice_to_have_skills ?? []).map(
+                  (s) => (
+                    <span
+                      key={s}
+                      className="px-2 py-0.5 rounded-full bg-[var(--border-default)] text-[var(--text-muted)] text-xs"
+                    >
+                      {s}
+                    </span>
+                  )
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* PDF download */}
+          <div className="flex items-center gap-3">
+            {pdfUrl ? (
+              <a
+                href={pdfUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 transition-opacity"
+              >
+                Download PDF
+              </a>
+            ) : (
+              <button
+                onClick={handleRenderPdf}
+                disabled={pdfLoading}
+                className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2"
+              >
+                {pdfLoading ? (
+                  <>
+                    <span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />
+                    Rendering PDF…
+                  </>
+                ) : (
+                  "Download PDF"
+                )}
+              </button>
+            )}
+            <span className="text-xs text-[var(--text-muted)]">
+              ID: <code className="text-[var(--accent-cyan)] text-xs">{result.cv_version_id}</code>
+            </span>
+          </div>
+
+          {/* HTML preview */}
+          <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-hidden">
+            <div className="px-4 py-2 border-b border-[var(--border-default)]">
+              <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                CV Preview
+              </p>
+            </div>
+            <iframe
+              srcDoc={result.html}
+              title="CV Preview"
+              className="w-full h-[700px] bg-white"
+              sandbox="allow-same-origin"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/cv/generate/page.tsx
+++ b/app/admin/(dashboard)/cv/generate/page.tsx
@@ -1,83 +1,306 @@
 "use client";
 
 import { useState } from "react";
-import { generateCv, renderCvPdf, type CvGenerateResponse } from "@/lib/adminApi";
+import {
+  analyzeJdAction,
+  confirmCvSkillsAction,
+  generateCoverLetterAction,
+  generateCvAction,
+  renderCoverLetterPdfAction,
+  renderCvPdfAction,
+} from "@/app/actions/cv";
+import type {
+  CoverLetterResponse,
+  CvAnalyzeResponse,
+  CvGenerateResponse,
+} from "@/lib/adminApi";
 
-type Step = "idle" | "fetching_jd" | "parsing_jd" | "matching" | "done" | "error";
+type Stage = "idle" | "analyzing" | "analyzed" | "generating" | "done" | "error";
 
-const STEPS: Record<string, string> = {
-  fetching_jd: "Fetching JD…",
-  parsing_jd: "Extracting keywords…",
-  matching: "Selecting bullets…",
+type Want = "cv" | "cover_letter" | "both";
+
+const STAGE_LABELS: Record<Stage, string> = {
+  idle: "",
+  analyzing: "Analyzing JD…",
+  analyzed: "Confirm and generate",
+  generating: "Generating…",
   done: "Done",
+  error: "",
 };
 
+const LOCALE_LABEL: Record<"en" | "es", string> = { en: "English", es: "Español" };
+
 export default function CvGeneratePage() {
+  // Stage 1 inputs
   const [jdText, setJdText] = useState("");
   const [jdUrl, setJdUrl] = useState("");
-  const [locale, setLocale] = useState<"en" | "es">("en");
   const [bulletsPerRole, setBulletsPerRole] = useState(3);
+  const [mode, setMode] = useState<"full" | "one_page">("full");
+  const [aiRewrite, setAiRewrite] = useState(false);
+  const [want, setWant] = useState<Want>("cv");
 
-  const [step, setStep] = useState<Step>("idle");
-  const [result, setResult] = useState<CvGenerateResponse | null>(null);
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [pdfLoading, setPdfLoading] = useState(false);
+  // Stage 2 inputs
+  const [locale, setLocale] = useState<"en" | "es">("en");
+  const [haveKeyword, setHaveKeyword] = useState<Record<string, boolean>>({});
+  const [saveKeyword, setSaveKeyword] = useState<Record<string, boolean>>({});
+
+  // State machine
+  const [stage, setStage] = useState<Stage>("idle");
+  const [analysis, setAnalysis] = useState<CvAnalyzeResponse | null>(null);
+  const [cvResult, setCvResult] = useState<CvGenerateResponse | null>(null);
+  const [clResult, setClResult] = useState<CoverLetterResponse | null>(null);
+  const [cvPdfUrl, setCvPdfUrl] = useState<string | null>(null);
+  const [clPdfUrl, setClPdfUrl] = useState<string | null>(null);
+  const [cvPdfLoading, setCvPdfLoading] = useState(false);
+  const [clPdfLoading, setClPdfLoading] = useState(false);
+  const [followupLoading, setFollowupLoading] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
   const [error, setError] = useState<string | null>(null);
 
-  async function handleGenerate() {
-    if (!jdText.trim() && !jdUrl.trim()) return;
-    setStep(jdUrl.trim() ? "fetching_jd" : "parsing_jd");
-    setError(null);
-    setResult(null);
-    setPdfUrl(null);
+  function resetResults() {
+    setCvResult(null);
+    setClResult(null);
+    setCvPdfUrl(null);
+    setClPdfUrl(null);
+    setCopyStatus("idle");
+  }
 
+  async function runAnalyze(): Promise<CvAnalyzeResponse | null> {
     try {
-      setStep("parsing_jd");
-      // Brief artificial step transition so the user sees progress labels
-      await new Promise((r) => setTimeout(r, 100));
-      setStep("matching");
-      const data = await generateCv({
+      const data = await analyzeJdAction({
         jd_text: jdText.trim() || undefined,
         jd_url: jdUrl.trim() || undefined,
-        locale,
-        bullets_per_role: bulletsPerRole,
       });
-      setResult(data);
-      setStep("done");
+      setAnalysis(data);
+      setLocale(data.detected_language);
+      return data;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
-      setStep("error");
+      setStage("error");
+      return null;
     }
   }
 
-  async function handleRenderPdf() {
-    if (!result) return;
-    setPdfLoading(true);
+  async function handleAnalyze() {
+    if (!jdText.trim() && !jdUrl.trim()) return;
+    setStage("analyzing");
+    setError(null);
+    setAnalysis(null);
+    resetResults();
+    setHaveKeyword({});
+    setSaveKeyword({});
+    const data = await runAnalyze();
+    if (data) setStage("analyzed");
+  }
+
+  async function generateArtifacts(opts: {
+    jdText: string;
+    chosenLocale: "en" | "es";
+    confirmedKeywords: string[];
+    wantSel: Want;
+  }) {
+    const wantCv = opts.wantSel === "cv" || opts.wantSel === "both";
+    const wantCl = opts.wantSel === "cover_letter" || opts.wantSel === "both";
+
+    if (wantCv) {
+      const data = await generateCvAction({
+        jd_text: opts.jdText,
+        locale: opts.chosenLocale,
+        bullets_per_role: bulletsPerRole,
+        mode,
+        ai_rewrite: aiRewrite,
+        confirmed_keywords: opts.confirmedKeywords,
+      });
+      setCvResult(data);
+    }
+    if (wantCl) {
+      const data = await generateCoverLetterAction({
+        jd_text: opts.jdText,
+        locale: opts.chosenLocale,
+        confirmed_keywords: opts.confirmedKeywords,
+      });
+      setClResult(data);
+    }
+  }
+
+  async function handleGenerate() {
+    if (!analysis) return;
+    setStage("generating");
+    setError(null);
     try {
-      const { pdf_url } = await renderCvPdf(result.cv_version_id);
-      setPdfUrl(pdf_url);
+      const skillsToSave = Object.entries(saveKeyword)
+        .filter(([, v]) => v)
+        .map(([k]) => k);
+      if (skillsToSave.length > 0) {
+        try {
+          await confirmCvSkillsAction(skillsToSave);
+        } catch (err) {
+          console.warn("Failed to save some skills:", err);
+        }
+      }
+      const confirmedKeywords = aiRewrite
+        ? Object.entries(haveKeyword).filter(([, v]) => v).map(([k]) => k)
+        : [];
+      await generateArtifacts({
+        jdText: analysis.jd_text,
+        chosenLocale: locale,
+        confirmedKeywords,
+        wantSel: want,
+      });
+      setStage("done");
     } catch (err) {
-      setError(err instanceof Error ? err.message : "PDF render failed");
-    } finally {
-      setPdfLoading(false);
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setStage("error");
     }
   }
 
-  const isLoading = step !== "idle" && step !== "done" && step !== "error";
-  const stepLabel = step !== "idle" && step !== "done" && step !== "error"
-    ? STEPS[step]
-    : "";
+  async function handleLucky() {
+    if (!jdText.trim() && !jdUrl.trim()) return;
+    setStage("analyzing");
+    setError(null);
+    setAnalysis(null);
+    resetResults();
+    setHaveKeyword({});
+    setSaveKeyword({});
+
+    const analyzed = await runAnalyze();
+    if (!analyzed) return;
+
+    setStage("generating");
+    try {
+      await generateArtifacts({
+        jdText: analyzed.jd_text,
+        chosenLocale: analyzed.detected_language,
+        confirmedKeywords: [],
+        wantSel: want,
+      });
+      setStage("done");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+      setStage("error");
+    }
+  }
+
+  async function downloadCvPdf() {
+    if (!cvResult) return;
+    setCvPdfLoading(true);
+    try {
+      const { pdf_url } = await renderCvPdfAction(cvResult.cv_version_id);
+      setCvPdfUrl(pdf_url);
+      triggerDownload(pdf_url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "CV PDF render failed");
+    } finally {
+      setCvPdfLoading(false);
+    }
+  }
+
+  async function downloadCoverLetterPdf() {
+    if (!clResult) return;
+    setClPdfLoading(true);
+    try {
+      const { pdf_url } = await renderCoverLetterPdfAction(clResult.cover_letter_id);
+      setClPdfUrl(pdf_url);
+      triggerDownload(pdf_url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Cover letter PDF render failed");
+    } finally {
+      setClPdfLoading(false);
+    }
+  }
+
+  function triggerDownload(url: string) {
+    const a = document.createElement("a");
+    a.href = url;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }
+
+  async function handleCopyCoverLetter() {
+    if (!clResult?.body) return;
+    try {
+      await navigator.clipboard.writeText(clResult.body);
+      setCopyStatus("copied");
+      setTimeout(() => setCopyStatus("idle"), 1500);
+    } catch {
+      // fallback: select textarea so user can Ctrl+C
+    }
+  }
+
+  // Follow-up: generate the artifact that wasn't generated, reusing the analyzed JD
+  async function handleFollowupAddCoverLetter() {
+    if (!analysis) return;
+    setFollowupLoading(true);
+    setError(null);
+    try {
+      const data = await generateCoverLetterAction({
+        jd_text: analysis.jd_text,
+        locale,
+        confirmed_keywords: [],
+      });
+      setClResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Cover letter generation failed");
+    } finally {
+      setFollowupLoading(false);
+    }
+  }
+
+  async function handleFollowupAddCv() {
+    if (!analysis) return;
+    setFollowupLoading(true);
+    setError(null);
+    try {
+      const data = await generateCvAction({
+        jd_text: analysis.jd_text,
+        locale,
+        bullets_per_role: bulletsPerRole,
+        mode,
+        ai_rewrite: aiRewrite,
+        confirmed_keywords: [],
+      });
+      setCvResult(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "CV generation failed");
+    } finally {
+      setFollowupLoading(false);
+    }
+  }
+
+  function handleStartOver() {
+    setStage("idle");
+    setAnalysis(null);
+    resetResults();
+    setError(null);
+  }
+
+  function toggleHave(kw: string) {
+    setHaveKeyword((m) => ({ ...m, [kw]: !m[kw] }));
+  }
+  function toggleSave(kw: string) {
+    setSaveKeyword((m) => ({ ...m, [kw]: !m[kw] }));
+  }
+
+  const inputsLocked = stage !== "idle" && stage !== "error";
+  const busy = stage === "analyzing" || stage === "generating";
+  const detectedLang = analysis?.detected_language ?? null;
+  const jdStructured = (analysis?.jd_structured ?? cvResult?.jd_structured ?? clResult?.jd_structured) as
+    | Record<string, string[]>
+    | undefined;
 
   return (
     <div className="p-6 max-w-4xl space-y-6">
       <div>
-        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">CV Generator</h1>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">CV & Cover Letter</h1>
         <p className="text-sm text-[var(--text-muted)]">
-          Paste a job description (text or URL) and get a tailored, ATS-friendly CV.
+          One JD in, your choice of CV, cover letter, or both. Each is a distinct artifact with its own PDF.
         </p>
       </div>
 
-      {/* ── Form ──────────────────────────────────────────────────── */}
+      {/* Stage 1: JD input + options */}
       <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-5 space-y-4">
         <div>
           <label className="block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-1">
@@ -88,7 +311,7 @@ export default function CvGeneratePage() {
             value={jdText}
             onChange={(e) => setJdText(e.target.value)}
             placeholder="Paste the job description here…"
-            disabled={isLoading}
+            disabled={inputsLocked}
             className="w-full bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50 resize-y"
           />
         </div>
@@ -108,166 +331,364 @@ export default function CvGeneratePage() {
             value={jdUrl}
             onChange={(e) => setJdUrl(e.target.value)}
             placeholder="https://boards.greenhouse.io/…"
-            disabled={isLoading}
+            disabled={inputsLocked}
             className="w-full bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
           />
         </div>
 
-        <div className="flex flex-wrap gap-4">
-          <div className="flex flex-col gap-1">
-            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-              Output Language
-            </label>
-            <select
-              value={locale}
-              onChange={(e) => setLocale(e.target.value as "en" | "es")}
-              disabled={isLoading}
-              className="bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
-            >
-              <option value="en">English</option>
-              <option value="es">Español</option>
-            </select>
-          </div>
-
-          <div className="flex flex-col gap-1">
-            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-              Bullets per role
-            </label>
-            <select
-              value={bulletsPerRole}
-              onChange={(e) => setBulletsPerRole(Number(e.target.value))}
-              disabled={isLoading}
-              className="bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50"
-            >
-              {[2, 3, 4, 5].map((n) => (
-                <option key={n} value={n}>{n}</option>
-              ))}
-            </select>
+        {/* What do you need? */}
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+            What do you need?
+          </label>
+          <div className="grid grid-cols-3 gap-2">
+            {([
+              { v: "cv", label: "CV only", hint: "PDF tailored to this JD" },
+              { v: "cover_letter", label: "Cover letter only", hint: "PDF + copy-paste text" },
+              { v: "both", label: "Both", hint: "Two separate artifacts" },
+            ] as { v: Want; label: string; hint: string }[]).map((opt) => (
+              <button
+                key={opt.v}
+                type="button"
+                onClick={() => setWant(opt.v)}
+                disabled={inputsLocked}
+                className={`px-3 py-2.5 rounded-lg border text-left transition-colors disabled:opacity-50 ${
+                  want === opt.v
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 text-[var(--text-primary)]"
+                    : "border-[var(--border-default)] bg-[var(--bg-input)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                }`}
+              >
+                <div className="text-sm font-semibold">{opt.label}</div>
+                <div className="text-xs mt-0.5 opacity-75">{opt.hint}</div>
+              </button>
+            ))}
           </div>
         </div>
 
-        <div className="flex items-center gap-3">
-          <button
-            onClick={handleGenerate}
-            disabled={isLoading || (!jdText.trim() && !jdUrl.trim())}
-            className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-40 transition-opacity flex items-center gap-2"
-          >
-            {isLoading ? (
-              <>
-                <span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />
-                {stepLabel}
-              </>
-            ) : (
-              "Generate CV"
-            )}
-          </button>
+        {/* CV-specific options (greyed when only cover letter selected) */}
+        <div className={want === "cover_letter" ? "opacity-40 pointer-events-none" : ""}>
+          <div className="flex flex-col gap-2">
+            <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+              CV Format
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              <button type="button" onClick={() => setMode("full")} disabled={inputsLocked}
+                className={`px-4 py-3 rounded-lg border text-left transition-colors disabled:opacity-50 ${
+                  mode === "full"
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 text-[var(--text-primary)]"
+                    : "border-[var(--border-default)] bg-[var(--bg-input)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                }`}>
+                <div className="text-sm font-semibold">Full CV</div>
+                <div className="text-xs mt-0.5 opacity-75">All experiences, JD-relevant bullets per role</div>
+              </button>
+              <button type="button" onClick={() => setMode("one_page")} disabled={inputsLocked}
+                className={`px-4 py-3 rounded-lg border text-left transition-colors disabled:opacity-50 ${
+                  mode === "one_page"
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 text-[var(--text-primary)]"
+                    : "border-[var(--border-default)] bg-[var(--bg-input)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                }`}>
+                <div className="text-sm font-semibold">1-Page CV</div>
+                <div className="text-xs mt-0.5 opacity-75">Top experiences for this JD, 2 bullets each</div>
+              </button>
+            </div>
+          </div>
 
-          {result && !isLoading && (
-            <button
-              onClick={handleGenerate}
-              className="px-4 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] transition-colors"
-            >
-              Regenerate
+          <div className="flex flex-wrap gap-4 items-end mt-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+                Bullets per role {mode === "one_page" && <span className="normal-case">(capped at 2)</span>}
+              </label>
+              <select value={bulletsPerRole} onChange={(e) => setBulletsPerRole(Number(e.target.value))}
+                disabled={inputsLocked || mode === "one_page"}
+                className="bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--accent-primary)] disabled:opacity-50">
+                {[2, 3, 4, 5].map((n) => (<option key={n} value={n}>{n}</option>))}
+              </select>
+            </div>
+            <label className="flex items-start gap-2 cursor-pointer select-none">
+              <input type="checkbox" checked={aiRewrite} onChange={(e) => setAiRewrite(e.target.checked)}
+                disabled={inputsLocked}
+                className="mt-1 accent-[var(--accent-primary)] disabled:opacity-50" />
+              <span className="flex flex-col">
+                <span className="text-sm font-semibold text-[var(--text-primary)]">AI-rewrite bullets for this JD</span>
+                <span className="text-xs text-[var(--text-muted)]">Each selected bullet gets one Gemini call. Strict no-fabrication rules.</span>
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          {stage === "idle" || stage === "error" ? (
+            <>
+              <button onClick={handleAnalyze} disabled={!jdText.trim() && !jdUrl.trim()}
+                className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-40 transition-opacity">
+                Analyze JD
+              </button>
+              <button onClick={handleLucky} disabled={!jdText.trim() && !jdUrl.trim()}
+                title="Detect language and generate selected artifacts in one click"
+                className="px-5 py-2 rounded-lg border border-[var(--accent-primary)] text-[var(--accent-primary)] text-sm font-semibold hover:bg-[var(--accent-primary)]/10 disabled:opacity-40 transition-colors">
+                I&apos;m feeling lucky
+              </button>
+            </>
+          ) : (
+            <button onClick={handleStartOver} disabled={busy}
+              className="px-4 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-muted)] hover:text-[var(--text-primary)] disabled:opacity-50 transition-colors">
+              Start over
             </button>
+          )}
+          {busy && (
+            <span className="flex items-center gap-2 text-sm text-[var(--text-muted)]">
+              <span className="animate-spin inline-block w-3 h-3 border-2 border-[var(--accent-primary)] border-t-transparent rounded-full" />
+              {STAGE_LABELS[stage]}
+            </span>
           )}
         </div>
       </div>
 
-      {/* ── Error ─────────────────────────────────────────────────── */}
-      {step === "error" && error && (
+      {stage === "error" && error && (
         <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-800 rounded-xl p-4 text-sm text-red-700 dark:text-red-400">
           {error}
         </div>
       )}
 
-      {/* ── Result ────────────────────────────────────────────────── */}
-      {result && step === "done" && (
-        <div className="space-y-4">
-          {result.warning && (
-            <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800 rounded-xl p-3 text-sm text-yellow-700 dark:text-yellow-400">
-              <span className="font-semibold">Note: </span>{result.warning}
-            </div>
-          )}
+      {/* Stage 2 */}
+      {analysis && (stage === "analyzed" || stage === "generating") && (
+        <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--accent-primary)]/40 p-5 space-y-4">
+          <div>
+            <h2 className="text-base font-semibold text-[var(--text-primary)] mb-1">Confirm output language</h2>
+            <p className="text-xs text-[var(--text-muted)]">
+              We detected the JD is in{" "}
+              <span className="font-semibold text-[var(--text-primary)]">
+                {detectedLang ? LOCALE_LABEL[detectedLang] : "—"}
+              </span>. Override below if needed.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {(["en", "es"] as const).map((lng) => (
+              <button key={lng} type="button" onClick={() => setLocale(lng)} disabled={stage === "generating"}
+                className={`px-4 py-3 rounded-lg border text-left transition-colors disabled:opacity-50 ${
+                  locale === lng
+                    ? "border-[var(--accent-primary)] bg-[var(--accent-primary)]/10 text-[var(--text-primary)]"
+                    : "border-[var(--border-default)] bg-[var(--bg-input)] text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+                }`}>
+                <div className="text-sm font-semibold flex items-center gap-2">
+                  {LOCALE_LABEL[lng]}
+                  {lng === detectedLang && (
+                    <span className="text-[10px] font-medium uppercase tracking-wider text-[var(--accent-primary)]">detected</span>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
 
-          {/* Detected keywords summary */}
-          {(result.jd_structured as Record<string, string[]>).must_have_skills?.length > 0 && (
-            <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-4">
-              <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-2">
-                Detected JD Signals
-              </p>
+          {jdStructured?.must_have_skills && jdStructured.must_have_skills.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-2">JD signals</p>
               <div className="flex flex-wrap gap-1.5">
-                {((result.jd_structured as Record<string, string[]>).must_have_skills ?? []).map(
-                  (s) => (
-                    <span
-                      key={s}
-                      className="px-2 py-0.5 rounded-full bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] text-xs font-medium"
-                    >
-                      {s}
-                    </span>
-                  )
-                )}
-                {((result.jd_structured as Record<string, string[]>).nice_to_have_skills ?? []).map(
-                  (s) => (
-                    <span
-                      key={s}
-                      className="px-2 py-0.5 rounded-full bg-[var(--border-default)] text-[var(--text-muted)] text-xs"
-                    >
-                      {s}
-                    </span>
-                  )
-                )}
+                {(jdStructured.must_have_skills ?? []).map((s) => (
+                  <span key={s} className="px-2 py-0.5 rounded-full bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] text-xs font-medium">{s}</span>
+                ))}
+                {(jdStructured.nice_to_have_skills ?? []).map((s) => (
+                  <span key={s} className="px-2 py-0.5 rounded-full bg-[var(--border-default)] text-[var(--text-muted)] text-xs">{s}</span>
+                ))}
               </div>
             </div>
           )}
 
-          {/* PDF download */}
-          <div className="flex items-center gap-3">
-            {pdfUrl ? (
-              <a
-                href={pdfUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 transition-opacity"
-              >
-                Download PDF
-              </a>
-            ) : (
-              <button
-                onClick={handleRenderPdf}
-                disabled={pdfLoading}
-                className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2"
-              >
-                {pdfLoading ? (
-                  <>
-                    <span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />
-                    Rendering PDF…
-                  </>
-                ) : (
-                  "Download PDF"
-                )}
-              </button>
-            )}
-            <span className="text-xs text-[var(--text-muted)]">
-              ID: <code className="text-[var(--accent-cyan)] text-xs">{result.cv_version_id}</code>
-            </span>
-          </div>
-
-          {/* HTML preview */}
-          <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-hidden">
-            <div className="px-4 py-2 border-b border-[var(--border-default)]">
-              <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
-                CV Preview
+          {aiRewrite && analysis.missing_keywords.length > 0 && want !== "cover_letter" && (
+            <div className="border-t border-[var(--border-default)] pt-4">
+              <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-1">Skills coverage</h3>
+              <p className="text-xs text-[var(--text-muted)] mb-3">
+                These JD keywords don&apos;t appear in your profile. Check the ones you have so the rewriter is allowed to mention them.
               </p>
+              <div className="border border-[var(--border-default)] rounded-lg divide-y divide-[var(--border-default)] max-h-64 overflow-y-auto">
+                {analysis.missing_keywords.map((kw) => (
+                  <div key={kw} className="px-3 py-2 flex items-center justify-between gap-3">
+                    <span className="text-sm text-[var(--text-primary)] truncate">{kw}</span>
+                    <div className="flex items-center gap-4 flex-shrink-0">
+                      <label className="flex items-center gap-1.5 cursor-pointer select-none text-xs text-[var(--text-secondary)]">
+                        <input type="checkbox" checked={!!haveKeyword[kw]} onChange={() => toggleHave(kw)}
+                          disabled={stage === "generating"} className="accent-[var(--accent-primary)]" />
+                        I have this
+                      </label>
+                      <label className={`flex items-center gap-1.5 select-none text-xs ${haveKeyword[kw] ? "cursor-pointer text-[var(--text-secondary)]" : "cursor-not-allowed text-[var(--text-muted)] opacity-50"}`}>
+                        <input type="checkbox" checked={!!saveKeyword[kw]} onChange={() => toggleSave(kw)}
+                          disabled={!haveKeyword[kw] || stage === "generating"} className="accent-[var(--accent-cyan)]" />
+                        Save to Skills
+                      </label>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-            <iframe
-              srcDoc={result.html}
-              title="CV Preview"
-              className="w-full h-[700px] bg-white"
-              sandbox="allow-same-origin"
-            />
+          )}
+
+          <div className="flex items-center gap-3 pt-2">
+            <button onClick={handleGenerate} disabled={stage === "generating"}
+              className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2">
+              {stage === "generating" ? (
+                <><span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />Generating…</>
+              ) : (
+                want === "both" ? "Generate both" : want === "cv" ? "Generate CV" : "Generate cover letter"
+              )}
+            </button>
           </div>
         </div>
       )}
+
+      {/* Result */}
+      {stage === "done" && (cvResult || clResult) && (
+        <div className="space-y-6">
+          {cvResult && (
+            <ArtifactCard
+              kind="cv"
+              title="CV"
+              locale={locale}
+              detectedLanguage={cvResult.detected_language}
+              identifier={cvResult.cv_version_id}
+              html={cvResult.html}
+              warning={cvResult.warning ?? null}
+              pdfUrl={cvPdfUrl}
+              pdfLoading={cvPdfLoading}
+              onDownload={downloadCvPdf}
+            />
+          )}
+          {clResult && (
+            <ArtifactCard
+              kind="cover_letter"
+              title="Cover Letter"
+              locale={locale}
+              detectedLanguage={clResult.detected_language}
+              identifier={clResult.cover_letter_id}
+              html={clResult.html}
+              warning={null}
+              pdfUrl={clPdfUrl}
+              pdfLoading={clPdfLoading}
+              onDownload={downloadCoverLetterPdf}
+              body={clResult.body}
+              copyStatus={copyStatus}
+              onCopy={handleCopyCoverLetter}
+            />
+          )}
+
+          {/* Follow-up banner */}
+          {(cvResult && !clResult) || (!cvResult && clResult) ? (
+            <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)] p-4 flex items-center justify-between gap-3">
+              <div className="text-sm text-[var(--text-secondary)]">
+                {cvResult && !clResult && "Need a cover letter for this JD too?"}
+                {!cvResult && clResult && "Need a CV for this JD too?"}
+              </div>
+              <button
+                onClick={cvResult && !clResult ? handleFollowupAddCoverLetter : handleFollowupAddCv}
+                disabled={followupLoading}
+                className="px-4 py-2 rounded-lg border border-[var(--accent-primary)] text-[var(--accent-primary)] text-sm font-semibold hover:bg-[var(--accent-primary)]/10 disabled:opacity-50 transition-colors flex items-center gap-2"
+              >
+                {followupLoading && (
+                  <span className="animate-spin inline-block w-3 h-3 border-2 border-[var(--accent-primary)] border-t-transparent rounded-full" />
+                )}
+                {cvResult && !clResult ? "Add cover letter" : "Add CV"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Result card for a single artifact ────────────────────────────────
+
+interface ArtifactCardProps {
+  kind: "cv" | "cover_letter";
+  title: string;
+  locale: "en" | "es";
+  detectedLanguage: string;
+  identifier: string;
+  html: string;
+  warning: string | null;
+  pdfUrl: string | null;
+  pdfLoading: boolean;
+  onDownload: () => void;
+  body?: string; // cover letter only
+  copyStatus?: "idle" | "copied";
+  onCopy?: () => void;
+}
+
+const LANG_LABEL: Record<"en" | "es", string> = { en: "English", es: "Español" };
+
+function ArtifactCard(p: ArtifactCardProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <h2 className="text-lg font-semibold text-[var(--text-primary)]">{p.title}</h2>
+        <div className="text-xs text-[var(--text-muted)] flex items-center gap-2 flex-wrap">
+          <span className="px-2 py-0.5 rounded-full bg-[var(--accent-primary)]/10 text-[var(--accent-primary)] font-medium">
+            Output: {LANG_LABEL[p.locale]}
+          </span>
+          <span>•</span>
+          <span>Detected: {LANG_LABEL[p.detectedLanguage as "en" | "es"] ?? p.detectedLanguage}</span>
+          <span>•</span>
+          <code className="text-[var(--accent-cyan)]">{p.identifier.slice(0, 8)}</code>
+        </div>
+      </div>
+
+      {p.warning && (
+        <div className="bg-yellow-50 dark:bg-yellow-950/30 border border-yellow-200 dark:border-yellow-800 rounded-xl p-3 text-sm text-yellow-700 dark:text-yellow-400">
+          <span className="font-semibold">Note: </span>{p.warning}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 flex-wrap">
+        {p.pdfUrl ? (
+          <a href={p.pdfUrl} target="_blank" rel="noopener noreferrer"
+            className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 transition-opacity">
+            Download PDF
+          </a>
+        ) : (
+          <button onClick={p.onDownload} disabled={p.pdfLoading}
+            className="px-5 py-2 rounded-lg bg-[var(--accent-primary)] text-white text-sm font-semibold hover:opacity-90 disabled:opacity-50 transition-opacity flex items-center gap-2">
+            {p.pdfLoading ? (
+              <><span className="animate-spin inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full" />Rendering PDF…</>
+            ) : "Download PDF"}
+          </button>
+        )}
+        {p.kind === "cover_letter" && p.onCopy && (
+          <button onClick={p.onCopy}
+            className="px-4 py-2 rounded-lg border border-[var(--border-default)] text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors">
+            {p.copyStatus === "copied" ? "✓ Copied" : "Copy text"}
+          </button>
+        )}
+      </div>
+
+      {/* Cover-letter copy-paste textarea */}
+      {p.kind === "cover_letter" && p.body && (
+        <div>
+          <label className="block text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider mb-1">
+            Plain text (for messages, email body, etc.)
+          </label>
+          <textarea
+            readOnly
+            rows={Math.min(14, Math.max(6, p.body.split("\n").length + 2))}
+            value={p.body}
+            onFocus={(e) => e.currentTarget.select()}
+            className="w-full bg-[var(--bg-input)] border border-[var(--border-default)] rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] font-mono"
+          />
+        </div>
+      )}
+
+      {/* HTML preview */}
+      <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] overflow-hidden">
+        <div className="px-4 py-2 border-b border-[var(--border-default)]">
+          <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wider">
+            {p.title} preview
+          </p>
+        </div>
+        <iframe
+          srcDoc={p.html}
+          title={`${p.title} preview`}
+          className="w-full h-[600px] bg-white"
+          sandbox="allow-same-origin"
+        />
+      </div>
     </div>
   );
 }

--- a/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
+++ b/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
@@ -422,6 +422,24 @@ export default function LinkedInImportClient() {
     <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6 space-y-5">
       <h2 className="text-base font-semibold text-[var(--text-primary)]">Upload ZIP file</h2>
 
+      {/* Export instructions */}
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] px-4 py-3 space-y-2 text-sm text-[var(--text-secondary)]">
+        <p className="font-medium text-[var(--text-primary)]">How to get the correct ZIP from LinkedIn</p>
+        <ol className="list-decimal list-inside space-y-1 text-xs">
+          <li>Go to <strong>LinkedIn → Settings &amp; Privacy → Data Privacy → Get a copy of your data</strong></li>
+          <li>Choose the <strong>first option</strong>: <em>&quot;Download larger data archive…&quot;</em></li>
+          <li>Click <strong>Request archive</strong> and verify your password</li>
+          <li>LinkedIn emails the ZIP &mdash; small accounts in 10&ndash;60 minutes, up to 24 hours officially</li>
+        </ol>
+        <p className="text-xs text-[var(--text-muted)] pt-1">
+          Don&apos;t use <em>&quot;Want something in particular?&quot;</em> &mdash; it no longer offers Positions, Education, Skills, Projects, Certifications, or Honors. Those CSVs only ship with the larger archive.
+        </p>
+        <p className="text-xs text-amber-400 flex items-start gap-1.5 pt-1">
+          <FiAlertTriangle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          LinkedIn rate-limits export requests. After requesting, you must wait <strong>2&ndash;4 hours</strong> before you can request another.
+        </p>
+      </div>
+
       <label className="flex flex-col items-center justify-center gap-3 border-2 border-dashed border-[var(--border-subtle)] rounded-xl p-10 cursor-pointer hover:border-[var(--accent-violet)]/50 transition-colors group">
         <FiUploadCloud className="w-10 h-10 text-[var(--text-muted)] group-hover:text-[var(--accent-violet)] transition-colors" />
         <span className="text-sm text-[var(--text-secondary)] text-center">

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -140,3 +140,48 @@ export async function linkedinApply(payload: {
   return res.json();
 }
 
+
+// ── CV Generator ────────────────────────────────────────────────────────────
+
+export interface CvGenerateRequest {
+  jd_text?: string;
+  jd_url?: string;
+  locale: "en" | "es";
+  bullets_per_role?: number;
+  page_size?: "Letter" | "A4";
+}
+
+export interface CvGenerateResponse {
+  cv_version_id: string;
+  html: string;
+  jd_structured: Record<string, unknown>;
+  warning?: string | null;
+}
+
+export async function generateCv(payload: CvGenerateRequest): Promise<CvGenerateResponse> {
+  const res = await fetch(`${API_BASE_URL}/cv/generate`, {
+    method: "POST",
+    headers: {
+      ...(await getAuthHeader()),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `CV generation failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function renderCvPdf(cvVersionId: string): Promise<{ pdf_url: string }> {
+  const res = await fetch(`${API_BASE_URL}/cv/${cvVersionId}/render-pdf`, {
+    method: "POST",
+    headers: await getAuthHeader(),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `PDF render failed (${res.status})`);
+  }
+  return res.json();
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -149,13 +149,111 @@ export interface CvGenerateRequest {
   locale: "en" | "es";
   bullets_per_role?: number;
   page_size?: "Letter" | "A4";
+  mode?: "full" | "one_page";
+  ai_rewrite?: boolean;
+  confirmed_keywords?: string[];
 }
 
 export interface CvGenerateResponse {
   cv_version_id: string;
   html: string;
   jd_structured: Record<string, unknown>;
+  detected_language: string;
   warning?: string | null;
+}
+
+export interface CvAnalyzeRequest {
+  jd_text?: string;
+  jd_url?: string;
+}
+
+export interface CvAnalyzeResponse {
+  jd_text: string;
+  jd_structured: Record<string, unknown>;
+  detected_language: "en" | "es";
+  missing_keywords: string[];
+  present_keywords: string[];
+}
+
+export interface CvConfirmSkillsResponse {
+  created: string[];
+  already_existed: string[];
+}
+
+export async function analyzeJd(payload: CvAnalyzeRequest): Promise<CvAnalyzeResponse> {
+  const res = await fetch(`${API_BASE_URL}/cv/analyze-jd`, {
+    method: "POST",
+    headers: {
+      ...(await getAuthHeader()),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `JD analysis failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export interface CoverLetterRequest {
+  jd_text?: string;
+  jd_url?: string;
+  locale: "en" | "es";
+  page_size?: "Letter" | "A4";
+  confirmed_keywords?: string[];
+}
+
+export interface CoverLetterResponse {
+  cover_letter_id: string;
+  html: string;
+  jd_structured: Record<string, unknown>;
+  detected_language: string;
+  body: string;
+}
+
+export async function generateCoverLetter(payload: CoverLetterRequest): Promise<CoverLetterResponse> {
+  const res = await fetch(`${API_BASE_URL}/cv/cover-letter/generate`, {
+    method: "POST",
+    headers: {
+      ...(await getAuthHeader()),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `Cover letter generation failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function renderCoverLetterPdf(clId: string): Promise<{ pdf_url: string }> {
+  const res = await fetch(`${API_BASE_URL}/cv/cover-letter/${clId}/render-pdf`, {
+    method: "POST",
+    headers: await getAuthHeader(),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `PDF render failed (${res.status})`);
+  }
+  return res.json();
+}
+
+export async function confirmCvSkills(skills: string[]): Promise<CvConfirmSkillsResponse> {
+  const res = await fetch(`${API_BASE_URL}/cv/confirm-skills`, {
+    method: "POST",
+    headers: {
+      ...(await getAuthHeader()),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ skills }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `Confirm skills failed (${res.status})`);
+  }
+  return res.json();
 }
 
 export async function generateCv(payload: CvGenerateRequest): Promise<CvGenerateResponse> {

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -2,6 +2,7 @@ import {
   FiAward,
   FiBriefcase,
   FiEdit3,
+  FiFileText,
   FiGlobe,
   FiHome,
   FiLayout,
@@ -26,5 +27,6 @@ export const adminNavItems: NavItem[] = [
   { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
   { href: "/admin/translations", label: "Translations", icon: FiGlobe },
   { href: "/admin/imports/linkedin", label: "LinkedIn Import", icon: FiUploadCloud },
+  { href: "/admin/cv/generate", label: "CV Generator", icon: FiFileText },
   { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
 ];

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -27,6 +27,6 @@ export const adminNavItems: NavItem[] = [
   { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
   { href: "/admin/translations", label: "Translations", icon: FiGlobe },
   { href: "/admin/imports/linkedin", label: "LinkedIn Import", icon: FiUploadCloud },
-  { href: "/admin/cv/generate", label: "CV Generator", icon: FiFileText },
+  { href: "/admin/cv/generate", label: "CV & Cover Letter", icon: FiFileText },
   { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
 ];

--- a/messages/en.json
+++ b/messages/en.json
@@ -143,6 +143,29 @@
     "aiUnavailable": "AI service unavailable — try again.",
     "aiFieldTooShort": "Text too short for AI rewrite (min 20 chars)"
   },
+  "cv": {
+    "pageTitle": "CV Generator",
+    "pageDescription": "Paste a job description and generate a tailored, ATS-friendly CV.",
+    "jdLabel": "Job Description",
+    "jdPlaceholder": "Paste the job description here…",
+    "jdUrlLabel": "Or enter JD URL",
+    "jdUrlPlaceholder": "https://boards.greenhouse.io/...",
+    "localeLabel": "Output Language",
+    "bulletsLabel": "Bullets per role",
+    "generateButton": "Generate CV",
+    "generating": "Generating…",
+    "fetchingJd": "Fetching JD…",
+    "extractingKeywords": "Extracting keywords…",
+    "selectingBullets": "Selecting bullets…",
+    "renderingPdf": "Rendering PDF…",
+    "downloadPdf": "Download PDF",
+    "regenerate": "Regenerate",
+    "previewTitle": "CV Preview",
+    "warningPrefix": "Note:",
+    "errorFetch": "Couldn't fetch the URL — paste the JD as text instead.",
+    "errorRobots": "This site disallows automated access. Paste the JD as text.",
+    "errorGeneric": "Something went wrong. Please try again."
+  },
   "cta": {
     "afterProjects": {
       "headline": "Like What You See?",

--- a/messages/es.json
+++ b/messages/es.json
@@ -143,6 +143,29 @@
     "aiUnavailable": "Servicio de IA no disponible — intenta de nuevo.",
     "aiFieldTooShort": "Texto muy corto para reescribir con IA (mín. 20 caracteres)"
   },
+  "cv": {
+    "pageTitle": "Generador de CV",
+    "pageDescription": "Pega una descripción de puesto y genera un CV personalizado, optimizado para ATS.",
+    "jdLabel": "Descripción del puesto",
+    "jdPlaceholder": "Pega aquí la descripción del puesto…",
+    "jdUrlLabel": "O ingresa la URL del puesto",
+    "jdUrlPlaceholder": "https://boards.greenhouse.io/...",
+    "localeLabel": "Idioma del CV",
+    "bulletsLabel": "Bullets por rol",
+    "generateButton": "Generar CV",
+    "generating": "Generando…",
+    "fetchingJd": "Descargando puesto…",
+    "extractingKeywords": "Extrayendo palabras clave…",
+    "selectingBullets": "Seleccionando bullets…",
+    "renderingPdf": "Renderizando PDF…",
+    "downloadPdf": "Descargar PDF",
+    "regenerate": "Regenerar",
+    "previewTitle": "Vista previa del CV",
+    "warningPrefix": "Nota:",
+    "errorFetch": "No se pudo acceder a la URL — pega el puesto como texto.",
+    "errorRobots": "Este sitio no permite acceso automatizado. Pega el puesto como texto.",
+    "errorGeneric": "Algo salió mal. Por favor, inténtalo de nuevo."
+  },
   "cta": {
     "afterProjects": {
       "headline": "¿Te gustó lo que viste?",

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,12 @@ import createNextIntlPlugin from "next-intl/plugin";
 const withNextIntl = createNextIntlPlugin("./lib/i18n/request.ts");
 
 const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: {
+      // LinkedIn ZIP exports can exceed the 1 MB default limit
+      bodySizeLimit: "20mb",
+    },
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary

Frontend half of Chunk 10. Single admin page at `/admin/cv/generate` that produces either a CV, a cover letter, or both — each as a **distinct artifact** with its own PDF download. Two-stage flow with locale auto-detection (override possible) and JD skills-coverage gap detection when AI rewrite is on.

## What's new

- **Unified generator page** — "What do you need?" picker (CV only / Cover letter only / Both); CV-specific options grey out when only cover letter is selected
- **Two-stage flow**: Analyze JD → confirm locale + skills coverage → Generate. "I'm feeling lucky" button skips stage 2 using the detected language
- **Distinct artifacts**: separate cards stack vertically — CV first, cover letter below. Each has its own preview iframe and Download PDF; cover letter additionally shows the plain-text body in a read-only textarea with a one-click Copy button
- **Follow-up banner**: when only one of the two is generated, the result panel offers to add the other one using the cached analysis
- **LinkedIn import flow**: `next.config.ts` now sets `experimental.serverActions.bodySizeLimit = "20mb"` so ZIP uploads larger than 1 MB actually reach the server action (previously rejected at the transport layer with the generic "Server Components render" error). UI instructions updated since LinkedIn's "Want something in particular?" no longer lists the relevant categories — users now have to request the larger archive
- Deletes the standalone `/admin/cv/cover-letter` route; nav item renamed to "CV & Cover Letter"

## Pairs with backend PR

zergcore/portfolio_backend#14 — both must merge together because this UI calls `analyze-jd`, `confirm-skills`, `cover-letter/generate`, and the updated `generate` endpoint.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] Upload a >1 MB LinkedIn ZIP at `/admin/imports/linkedin` — preview should render (no "Server Components render" error)
- [ ] Paste an English JD at `/admin/cv/generate`, pick "CV only", click Analyze JD → confirm locale card shows "English (detected)" → Generate → CV preview + PDF download
- [ ] Same flow with a Spanish JD — locale card should show "Español (detected)"
- [ ] Pick "Cover letter only" + click "I'm feeling lucky" → skips stage 2, returns cover letter card with body textarea + Copy button → Copy actually puts the text on the clipboard
- [ ] Pick "Both" → two separate artifact cards appear, CV first; download both PDFs independently
- [ ] Generate CV only, then click "Add cover letter" in the follow-up banner → cover letter card appears below without re-running the JD analysis