### PR TITLE
fix(imports): unblock LinkedIn save + sane Merge defaults

### DIFF
--- a/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
+++ b/app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx
@@ -351,24 +351,35 @@ export default function LinkedInImportClient() {
 
                       {/* Action selector */}
                       <div className="flex items-center gap-2 flex-shrink-0">
-                        {(["create", "merge", "skip"] as Action[]).map((a) => (
-                          <button
-                            key={a}
-                            disabled={!isEnabled || !!row.parse_error}
-                            onClick={() => setAction(row.row_id, a)}
-                            className={`px-2.5 py-1 rounded text-xs font-medium transition-colors ${
-                              act?.action === a
-                                ? a === "create"
-                                  ? "bg-[var(--accent-violet)]/20 text-[var(--accent-violet)] ring-1 ring-[var(--accent-violet)]/40"
-                                  : a === "merge"
-                                  ? "bg-[var(--accent-cyan)]/20 text-[var(--accent-cyan)] ring-1 ring-[var(--accent-cyan)]/40"
-                                  : "bg-[var(--bg-elevated)] text-[var(--text-muted)] ring-1 ring-[var(--border-subtle)]"
-                                : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
-                            }`}
-                          >
-                            {a === "create" ? "✚ Create" : a === "merge" ? "↻ Merge" : "— Skip"}
-                          </button>
-                        ))}
+                        {(["create", "merge", "skip"] as Action[]).map((a) => {
+                          // Merge requires at least one match candidate.
+                          const noTargetForMerge = a === "merge" && row.matches.length === 0;
+                          const buttonDisabled =
+                            !isEnabled || !!row.parse_error || noTargetForMerge;
+                          return (
+                            <button
+                              key={a}
+                              disabled={buttonDisabled}
+                              title={
+                                noTargetForMerge
+                                  ? "No existing record to merge with — use Create"
+                                  : undefined
+                              }
+                              onClick={() => setAction(row.row_id, a)}
+                              className={`px-2.5 py-1 rounded text-xs font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                                act?.action === a
+                                  ? a === "create"
+                                    ? "bg-[var(--accent-violet)]/20 text-[var(--accent-violet)] ring-1 ring-[var(--accent-violet)]/40"
+                                    : a === "merge"
+                                    ? "bg-[var(--accent-cyan)]/20 text-[var(--accent-cyan)] ring-1 ring-[var(--accent-cyan)]/40"
+                                    : "bg-[var(--bg-elevated)] text-[var(--text-muted)] ring-1 ring-[var(--border-subtle)]"
+                                  : "text-[var(--text-muted)] hover:text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)]"
+                              }`}
+                            >
+                              {a === "create" ? "✚ Create" : a === "merge" ? "↻ Merge" : "— Skip"}
+                            </button>
+                          );
+                        })}
 
                         {/* Target selector for merge */}
                         {act?.action === "merge" && row.matches.length > 1 && (


### PR DESCRIPTION
## Summary

Pairs with the backend fix at zergcore/portfolio_backend (see branch \`fix/linkedin-import-apply\` there). Disables the **Merge** action button on any preview row that has no existing record to merge with, so users can't pick an action that the backend would reject.

## What changes

- \`app/admin/(dashboard)/imports/linkedin/LinkedInImportClient.tsx\` — Merge button is disabled (with a tooltip "No existing record to merge with — use Create") when \`row.matches.length === 0\`. Create and Skip stay active.

## Pairs with backend

Backend fix on the same branch name:

- Apply endpoint now uses per-row SAVEPOINTs, so a single failure doesn't roll back the whole import (previously: skills defaulting to merge-without-target caused every Apply click to discard everything).
- Preview build now flips a no-match merge default to Create automatically, so this UI fix becomes belt-and-braces.

Merge both together.

## Test plan

- [ ] \`npx tsc --noEmit\` passes
- [ ] Upload a fresh LinkedIn ZIP at /admin/imports/linkedin
- [ ] A skill row with no existing match shows Create as the default; Merge button is greyed and not clickable; tooltip shown on hover
- [ ] A position or skill row with a match shows Merge as default and the target selector
- [ ] Click Apply — successful rows persist; rows with errors are listed in the errors panel; sucessful rows are NOT rolled back