### PR TITLE
feat(chunk-11): job-finder admin UI — /jobs kanban + sources

### DIFF
--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -1,0 +1,135 @@
+"use server";
+import { cookies } from "next/headers";
+import { revalidatePath } from "next/cache";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000/api/v1";
+
+async function authHeaders() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+export async function updateJobAction(
+  id: string,
+  data: { status?: string; cover_letter_text?: string | null; notes?: string | null },
+) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/${id}`, {
+      method: "PATCH",
+      headers: await authHeaders(),
+      body: JSON.stringify(data),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to update job" };
+    revalidatePath("/admin/jobs");
+    revalidatePath(`/admin/jobs/${id}`);
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function generateJobCvAction(
+  id: string,
+  body: {
+    locale?: "auto" | "en" | "es";
+    bullets_per_role?: number;
+    page_size?: "Letter" | "A4";
+    mode?: "full" | "one_page";
+    ai_rewrite?: boolean;
+  } = {},
+) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/${id}/generate-cv`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify(body),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to generate CV" };
+    revalidatePath(`/admin/jobs/${id}`);
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function generateJobCoverLetterAction(
+  id: string,
+  body: { locale?: "auto" | "en" | "es"; page_size?: "Letter" | "A4" } = {},
+) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/${id}/generate-cover-letter`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify(body),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to generate cover letter" };
+    revalidatePath(`/admin/jobs/${id}`);
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function createJobSourceAction(data: {
+  platform: string;
+  identifier: string;
+  enabled?: boolean;
+}) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/sources`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify(data),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to create source" };
+    revalidatePath("/admin/jobs/sources");
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function updateJobSourceAction(
+  id: string,
+  data: { identifier?: string; enabled?: boolean },
+) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/sources/${id}`, {
+      method: "PATCH",
+      headers: await authHeaders(),
+      body: JSON.stringify(data),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to update source" };
+    revalidatePath("/admin/jobs/sources");
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function deleteJobSourceAction(id: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/sources/${id}`, {
+      method: "DELETE",
+      headers: await authHeaders(),
+    });
+    if (!res.ok && res.status !== 204) {
+      const json = await res.json().catch(() => ({}));
+      return { error: json.detail || "Failed to delete source" };
+    }
+    revalidatePath("/admin/jobs/sources");
+    return { success: true };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
+import { updateJobAction } from "@/app/actions/jobs";
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  prospected: "Prospected",
+  tailored: "Tailored",
+  applied: "Applied",
+  interviewing: "Interviewing",
+  offer: "Offer",
+  rejected: "Rejected",
+};
+
+const STATUS_ACCENT: Record<JobStatus, string> = {
+  prospected: "border-[var(--border-strong)]",
+  tailored: "border-[var(--accent-violet)]/60",
+  applied: "border-[var(--accent-cyan)]/60",
+  interviewing: "border-yellow-500/60",
+  offer: "border-emerald-500/60",
+  rejected: "border-red-500/60",
+};
+
+function scoreBadge(score: number): string {
+  if (score >= 0.7) return "bg-emerald-500/15 text-emerald-300";
+  if (score >= 0.4) return "bg-yellow-500/15 text-yellow-300";
+  return "bg-red-500/15 text-red-300";
+}
+
+export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
+  const router = useRouter();
+  const [jobs, setJobs] = useState<ApiJob[]>(initialJobs);
+  const [minScore, setMinScore] = useState(0);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const grouped = useMemo(() => {
+    const out: Record<JobStatus, ApiJob[]> = {
+      prospected: [], tailored: [], applied: [],
+      interviewing: [], offer: [], rejected: [],
+    };
+    for (const j of jobs) {
+      if (j.match_score < minScore) continue;
+      out[j.status]?.push(j);
+    }
+    return out;
+  }, [jobs, minScore]);
+
+  async function handleStatusChange(job: ApiJob, next: JobStatus) {
+    if (next === job.status) return;
+    setBusyId(job.id);
+    setError(null);
+    const res = await updateJobAction(job.id, { status: next });
+    setBusyId(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    setJobs(prev => prev.map(j => (j.id === job.id ? { ...j, status: next } : j)));
+    router.refresh();
+  }
+
+  return (
+    <>
+      <div className="mb-6 flex items-center gap-3">
+        <label className="text-sm text-[var(--text-secondary)]">
+          Min match score:&nbsp;
+          <span className="text-[var(--text-primary)] font-medium">
+            {minScore.toFixed(2)}
+          </span>
+        </label>
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.05}
+          value={minScore}
+          onChange={(e) => setMinScore(parseFloat(e.target.value))}
+          className="w-64"
+        />
+        <span className="ml-auto text-sm text-[var(--text-secondary)]">
+          {jobs.length} total
+        </span>
+      </div>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/40 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {JOB_STATUSES.map((status) => (
+          <section
+            key={status}
+            className={`rounded-xl border ${STATUS_ACCENT[status]} bg-[var(--bg-surface)] p-4`}
+          >
+            <header className="flex items-center justify-between mb-3">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-primary)]">
+                {STATUS_LABELS[status]}
+              </h2>
+              <span className="text-xs text-[var(--text-secondary)]">
+                {grouped[status].length}
+              </span>
+            </header>
+
+            <div className="space-y-3 max-h-[70vh] overflow-y-auto pr-1">
+              {grouped[status].length === 0 ? (
+                <p className="text-xs text-[var(--text-secondary)] italic">
+                  No jobs in this column.
+                </p>
+              ) : (
+                grouped[status].map((job) => (
+                  <article
+                    key={job.id}
+                    className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-3"
+                  >
+                    <Link
+                      href={`/admin/jobs/${job.id}`}
+                      className="block group"
+                    >
+                      <div className="flex items-start gap-2">
+                        <h3 className="text-sm font-semibold text-[var(--text-primary)] group-hover:text-[var(--accent-cyan)] transition-colors flex-1 line-clamp-2">
+                          {job.title}
+                        </h3>
+                        <span
+                          className={`shrink-0 inline-flex items-center text-xs px-2 py-0.5 rounded-full ${scoreBadge(
+                            job.match_score
+                          )}`}
+                        >
+                          {(job.match_score * 100).toFixed(0)}%
+                        </span>
+                      </div>
+                      <p className="text-xs text-[var(--text-secondary)] mt-1">
+                        {job.company}
+                        {job.location ? ` · ${job.location}` : ""}
+                      </p>
+                      {job.match_explanation && (
+                        <p className="text-xs text-[var(--text-secondary)] mt-2 italic line-clamp-2">
+                          {job.match_explanation}
+                        </p>
+                      )}
+                    </Link>
+
+                    <div className="mt-3 flex items-center gap-2">
+                      <select
+                        value={job.status}
+                        onChange={(e) =>
+                          handleStatusChange(job, e.target.value as JobStatus)
+                        }
+                        disabled={busyId === job.id}
+                        className="flex-1 text-xs px-2 py-1 rounded-md bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-primary)] disabled:opacity-50"
+                      >
+                        {JOB_STATUSES.map((s) => (
+                          <option key={s} value={s}>
+                            → {STATUS_LABELS[s]}
+                          </option>
+                        ))}
+                      </select>
+                      <a
+                        href={job.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs px-2 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)] transition-colors"
+                        title="Open job posting"
+                      >
+                        ↗
+                      </a>
+                    </div>
+                  </article>
+                ))
+              )}
+            </div>
+          </section>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
+import {
+  generateJobCoverLetterAction,
+  generateJobCvAction,
+  updateJobAction,
+} from "@/app/actions/jobs";
+
+export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) {
+  const router = useRouter();
+  const [job, setJob] = useState<ApiJob>(initialJob);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+  const [notes, setNotes] = useState(job.notes ?? "");
+  const [coverLetter, setCoverLetter] = useState(job.cover_letter_text ?? "");
+
+  async function save(data: Parameters<typeof updateJobAction>[1]) {
+    setBusy("save");
+    setError(null);
+    setInfo(null);
+    const res = await updateJobAction(job.id, data);
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    if (res.data) {
+      setJob(res.data as ApiJob);
+      setInfo("Saved.");
+      router.refresh();
+    }
+  }
+
+  async function runGenerateCv() {
+    setBusy("cv");
+    setError(null);
+    setInfo(null);
+    const res = await generateJobCvAction(job.id, { locale: "auto" });
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    setInfo(`CV generated. cv_version_id: ${res.data?.cv_version_id}`);
+    router.refresh();
+  }
+
+  async function runGenerateCoverLetter() {
+    setBusy("cl");
+    setError(null);
+    setInfo(null);
+    const res = await generateJobCoverLetterAction(job.id, { locale: "auto" });
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    if (res.data) {
+      // Backend mirrors the rendered cover letter onto job.cover_letter_text;
+      // re-fetch is unnecessary because the next router.refresh() repaints,
+      // but populate the textarea so the admin can edit immediately.
+      setInfo(`Cover letter generated. cv_version_id: ${res.data.cv_version_id}`);
+    }
+    router.refresh();
+  }
+
+  return (
+    <div className="mt-4 space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)]">{job.title}</h1>
+        <p className="text-[var(--text-secondary)]">
+          {job.company}
+          {job.location ? ` · ${job.location}` : ""}
+        </p>
+        <a
+          href={job.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-[var(--accent-cyan)] hover:underline"
+        >
+          Open posting ↗
+        </a>
+      </header>
+
+      <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
+          <div className="text-xs uppercase tracking-wide text-[var(--text-secondary)] mb-1">
+            Match score
+          </div>
+          <div className="text-2xl font-bold text-[var(--text-primary)]">
+            {(job.match_score * 100).toFixed(0)}%
+          </div>
+          {job.match_explanation && (
+            <p className="mt-2 text-xs italic text-[var(--text-secondary)]">
+              {job.match_explanation}
+            </p>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
+          <label className="block text-xs uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+            Status
+          </label>
+          <select
+            value={job.status}
+            onChange={(e) => save({ status: e.target.value as JobStatus })}
+            disabled={busy === "save"}
+            className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)]"
+          >
+            {JOB_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          {job.applied_at && (
+            <p className="text-xs text-[var(--text-secondary)] mt-2">
+              Applied {new Date(job.applied_at).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
+          <div className="text-xs uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+            Generate
+          </div>
+          <div className="flex flex-col gap-2">
+            <button
+              onClick={runGenerateCv}
+              disabled={busy === "cv"}
+              className="px-3 py-2 rounded-md border border-[var(--border-strong)] text-sm text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] disabled:opacity-50"
+            >
+              {busy === "cv" ? "Generating CV…" : "Generate tailored CV"}
+            </button>
+            <button
+              onClick={runGenerateCoverLetter}
+              disabled={busy === "cl"}
+              className="px-3 py-2 rounded-md border border-[var(--border-strong)] text-sm text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] disabled:opacity-50"
+            >
+              {busy === "cl" ? "Generating cover letter…" : "Generate cover letter"}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {error && (
+        <div className="px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/40 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+      {info && !error && (
+        <div className="px-4 py-3 rounded-lg bg-emerald-500/10 border border-emerald-500/40 text-sm text-emerald-300">
+          {info}
+        </div>
+      )}
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+          Notes
+        </h2>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          onBlur={() => {
+            if (notes !== (job.notes ?? "")) save({ notes });
+          }}
+          rows={4}
+          className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+          placeholder="Private notes — recruiter contact, interview prep, follow-up dates…"
+        />
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+          Cover letter
+        </h2>
+        <textarea
+          value={coverLetter}
+          onChange={(e) => setCoverLetter(e.target.value)}
+          onBlur={() => {
+            if (coverLetter !== (job.cover_letter_text ?? ""))
+              save({ cover_letter_text: coverLetter });
+          }}
+          rows={12}
+          className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm font-mono"
+          placeholder="Generate one with the button above, then edit before sending."
+        />
+      </section>
+
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+          Job description
+        </h2>
+        <pre className="whitespace-pre-wrap text-sm text-[var(--text-primary)] bg-[var(--bg-elevated)] rounded-md p-4 border border-[var(--border-subtle)] max-h-96 overflow-y-auto">
+          {job.jd_text}
+        </pre>
+      </section>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/[id]/page.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getAdminJob } from "@/lib/adminApi";
+import { ApiJob } from "@/lib/api";
+import JobDetailClient from "./JobDetailClient";
+
+export const revalidate = 0;
+
+export default async function AdminJobDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const job = (await getAdminJob(id)) as ApiJob | null;
+  if (!job) notFound();
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <Link
+        href="/admin/jobs"
+        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors"
+      >
+        ← Back to pipeline
+      </Link>
+      <JobDetailClient initialJob={job} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/page.tsx
+++ b/app/admin/(dashboard)/jobs/page.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { getAdminJobs } from "@/lib/adminApi";
+import { ApiJob } from "@/lib/api";
+import JobsClient from "./JobsClient";
+
+export const revalidate = 0;
+
+export default async function AdminJobsPage() {
+  const jobs = (await getAdminJobs({ limit: 500 })) as ApiJob[];
+
+  return (
+    <div className="max-w-7xl mx-auto">
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-[var(--text-primary)]">
+            Job Pipeline
+          </h1>
+          <p className="text-[var(--text-secondary)] mt-2">
+            Jobs found by the daily poller, scored against your profile. Move them
+            through the pipeline and generate tailored applications.
+          </p>
+        </div>
+        <Link
+          href="/admin/jobs/sources"
+          className="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+        >
+          Manage sources
+        </Link>
+      </div>
+
+      <JobsClient initialJobs={jobs} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiJobPlatform, ApiJobSource } from "@/lib/api";
+import {
+  createJobSourceAction,
+  deleteJobSourceAction,
+  updateJobSourceAction,
+} from "@/app/actions/jobs";
+
+export default function SourcesClient({
+  initialSources,
+  platforms,
+}: {
+  initialSources: ApiJobSource[];
+  platforms: ApiJobPlatform[];
+}) {
+  const router = useRouter();
+  const [sources, setSources] = useState<ApiJobSource[]>(initialSources);
+  const [platform, setPlatform] = useState<string>(platforms[0]?.code ?? "");
+  const [identifier, setIdentifier] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onCreate(e: FormEvent) {
+    e.preventDefault();
+    if (!platform || !identifier.trim()) return;
+    setBusy("create");
+    setError(null);
+    const res = await createJobSourceAction({
+      platform,
+      identifier: identifier.trim(),
+      enabled: true,
+    });
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    if (res.data) {
+      setSources((prev) => [...prev, res.data as ApiJobSource]);
+      setIdentifier("");
+      router.refresh();
+    }
+  }
+
+  async function toggleEnabled(src: ApiJobSource) {
+    setBusy(src.id);
+    setError(null);
+    const res = await updateJobSourceAction(src.id, { enabled: !src.enabled });
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    if (res.data) {
+      setSources((prev) =>
+        prev.map((s) => (s.id === src.id ? (res.data as ApiJobSource) : s))
+      );
+      router.refresh();
+    }
+  }
+
+  async function onDelete(src: ApiJobSource) {
+    if (!confirm(`Delete source ${src.platform}/${src.identifier}? Its poll history will also be removed.`))
+      return;
+    setBusy(src.id);
+    setError(null);
+    const res = await deleteJobSourceAction(src.id);
+    setBusy(null);
+    if (res.error) {
+      setError(res.error);
+      return;
+    }
+    setSources((prev) => prev.filter((s) => s.id !== src.id));
+    router.refresh();
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={onCreate}
+        className="mb-6 flex flex-col md:flex-row gap-3 p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)]"
+      >
+        <select
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value)}
+          className="px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+        >
+          {platforms.length === 0 ? (
+            <option value="">(no platforms — seed job_platforms first)</option>
+          ) : (
+            platforms.map((p) => (
+              <option key={p.code} value={p.code} disabled={!p.enabled}>
+                {p.display_name}
+                {p.enabled ? "" : " (disabled)"}
+              </option>
+            ))
+          )}
+        </select>
+        <input
+          type="text"
+          value={identifier}
+          onChange={(e) => setIdentifier(e.target.value)}
+          placeholder="board slug or tag (e.g. stripe / python)"
+          className="flex-1 px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+        />
+        <button
+          type="submit"
+          disabled={busy === "create" || !platform || !identifier.trim()}
+          className="px-4 py-2 rounded-md bg-[var(--accent-violet)] text-white text-sm font-medium hover:bg-[var(--accent-violet)]/90 disabled:opacity-50"
+        >
+          {busy === "create" ? "Adding…" : "Add source"}
+        </button>
+      </form>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/40 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-[var(--bg-elevated)] text-[var(--text-secondary)] text-xs uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-2 text-left">Platform</th>
+              <th className="px-4 py-2 text-left">Identifier</th>
+              <th className="px-4 py-2 text-left">Enabled</th>
+              <th className="px-4 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sources.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-[var(--text-secondary)] italic">
+                  No sources configured yet. Add one above to start polling.
+                </td>
+              </tr>
+            ) : (
+              sources.map((s) => (
+                <tr key={s.id} className="border-t border-[var(--border-subtle)]">
+                  <td className="px-4 py-2 text-[var(--text-primary)]">{s.platform}</td>
+                  <td className="px-4 py-2 text-[var(--text-primary)] font-mono">{s.identifier}</td>
+                  <td className="px-4 py-2">
+                    <button
+                      onClick={() => toggleEnabled(s)}
+                      disabled={busy === s.id}
+                      className={`text-xs px-2 py-0.5 rounded-full ${
+                        s.enabled
+                          ? "bg-emerald-500/15 text-emerald-300"
+                          : "bg-red-500/15 text-red-300"
+                      } disabled:opacity-50`}
+                    >
+                      {s.enabled ? "enabled" : "disabled"}
+                    </button>
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <button
+                      onClick={() => onDelete(s)}
+                      disabled={busy === s.id}
+                      className="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/app/admin/(dashboard)/jobs/sources/page.tsx
+++ b/app/admin/(dashboard)/jobs/sources/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { getAdminJobPlatforms, getAdminJobSources } from "@/lib/adminApi";
+import { ApiJobPlatform, ApiJobSource } from "@/lib/api";
+import SourcesClient from "./SourcesClient";
+
+export const revalidate = 0;
+
+export default async function AdminJobSourcesPage() {
+  const [sources, platforms] = await Promise.all([
+    getAdminJobSources(),
+    getAdminJobPlatforms(),
+  ]);
+
+  return (
+    <div className="max-w-4xl mx-auto">
+      <Link
+        href="/admin/jobs"
+        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors"
+      >
+        ← Back to pipeline
+      </Link>
+      <div className="mb-8 mt-4">
+        <h1 className="text-3xl font-bold text-[var(--text-primary)]">Job Sources</h1>
+        <p className="text-[var(--text-secondary)] mt-2">
+          Configure which public job boards the daily poller fetches from.
+          Each row is one (platform, identifier) pair — for Greenhouse/Lever
+          the identifier is the company&apos;s board slug; for RemoteOK it&apos;s
+          a tag (e.g. <code>python</code>).
+        </p>
+      </div>
+
+      <SourcesClient
+        initialSources={sources as ApiJobSource[]}
+        platforms={platforms as ApiJobPlatform[]}
+      />
+    </div>
+  );
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -347,6 +347,52 @@ export async function generateCv(payload: CvGenerateRequest): Promise<CvGenerate
   return res.json();
 }
 
+export async function getAdminJobs(params?: {
+  status?: string;
+  minScore?: number;
+  limit?: number;
+}) {
+  const url = new URL(`${API_BASE_URL}/jobs`);
+  if (params?.status) url.searchParams.set("status", params.status);
+  if (params?.minScore !== undefined)
+    url.searchParams.set("min_score", String(params.minScore));
+  if (params?.limit !== undefined)
+    url.searchParams.set("limit", String(params.limit));
+  const res = await fetch(url.toString(), {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function getAdminJob(id: string) {
+  const res = await fetch(`${API_BASE_URL}/jobs/${id}`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getAdminJobSources() {
+  const res = await fetch(`${API_BASE_URL}/jobs/sources`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function getAdminJobPlatforms() {
+  const res = await fetch(`${API_BASE_URL}/jobs/platforms`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
 export async function renderCvPdf(cvVersionId: string): Promise<{ pdf_url: string }> {
   const res = await fetch(`${API_BASE_URL}/cv/${cvVersionId}/render-pdf`, {
     method: "POST",

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -175,6 +175,60 @@ export interface ApiSkillGroup {
   skills: ApiSkill[];
 }
 
+// --- Job Finder ---
+
+export type JobStatus =
+  | "prospected"
+  | "tailored"
+  | "applied"
+  | "interviewing"
+  | "offer"
+  | "rejected";
+
+export const JOB_STATUSES: JobStatus[] = [
+  "prospected",
+  "tailored",
+  "applied",
+  "interviewing",
+  "offer",
+  "rejected",
+];
+
+export interface ApiJob {
+  id: string;
+  source: string;
+  source_id: string;
+  url: string;
+  title: string;
+  company: string;
+  location: string | null;
+  posted_at: string | null;
+  jd_text: string;
+  jd_structured: Record<string, unknown>;
+  match_score: number;
+  match_explanation: string;
+  status: JobStatus;
+  cover_letter_text: string | null;
+  notes: string | null;
+  applied_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ApiJobSource {
+  id: string;
+  platform: string;
+  identifier: string;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface ApiJobPlatform {
+  code: string;
+  display_name: string;
+  enabled: boolean;
+}
+
 // --- Helpers ---
 
 function formatDateRange(

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -1,6 +1,7 @@
 import {
   FiAward,
   FiBriefcase,
+  FiCompass,
   FiEdit3,
   FiFileText,
   FiGlobe,
@@ -28,5 +29,6 @@ export const adminNavItems: NavItem[] = [
   { href: "/admin/translations", label: "Translations", icon: FiGlobe },
   { href: "/admin/imports/linkedin", label: "LinkedIn Import", icon: FiUploadCloud },
   { href: "/admin/cv/generate", label: "CV & Cover Letter", icon: FiFileText },
+  { href: "/admin/jobs",        label: "Jobs",        icon: FiCompass },
   { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
 ];


### PR DESCRIPTION
## Summary

Frontend half of Chunk 11. Connects to the new `/api/v1/jobs/*` endpoints landing in the parallel backend PR (`portfolio_backend#23`). **Merge that one first** — this PR will 404 on those endpoints until it's deployed.

## What ships

### `/admin/jobs` — pipeline kanban
- 6 columns (prospected → tailored → applied → interviewing → offer / rejected) per `docs/plan/10-job-finder-agent.md §7`.
- Each card: title, company · location, color-coded match-score badge (green ≥0.7 / yellow ≥0.4 / red <0.4), the JD-locale `match_explanation`, link to the original posting.
- Status select on each card moves the job between columns; the backend automatically stamps `applied_at` on the prospected→applied transition.
- Min-score slider trims low-quality matches.

### `/admin/jobs/[id]` — detail
- Match score + explanation panel.
- Status select, notes textarea (auto-saves on blur), cover-letter editor (auto-saves on blur), full JD scroll panel.
- Generate buttons:
  - **Generate tailored CV** → `POST /jobs/{id}/generate-cv` (locale=auto). Server returns the new `cv_version_id` linked to this job.
  - **Generate cover letter** → `POST /jobs/{id}/generate-cover-letter`. Backend mirrors the rendered body onto `job.cover_letter_text` so it appears in the editor here.
- Both auto-transition the row from `prospected` → `tailored` on first success.

### `/admin/jobs/sources` — source CRUD
- List existing `(platform, identifier)` pairs.
- Add new sources via a small inline form. The platform dropdown reads from `GET /jobs/platforms` — adding a 4th platform on the backend (insert into `job_platforms`) is zero-frontend work.
- Per-row enable/disable toggle and delete.

### Plumbing

- `lib/api.ts`: `ApiJob`, `ApiJobSource`, `ApiJobPlatform`, `JobStatus` literal, `JOB_STATUSES` const.
- `lib/adminApi.ts`: 4 cookie-auth getters.
- `app/actions/jobs.ts`: 6 server actions with `revalidatePath` after each mutation.
- `lib/constants/adminNav.ts`: "Jobs" nav entry (FiCompass) between **CV & Cover Letter** and **AI Usage**.

## Verification

- [x] `npx tsc --noEmit` → clean.
- [x] `npm run lint` → no new warnings on the new files (pre-existing warnings in `app/admin/(dashboard)/cv/generate/page.tsx` unchanged).
- [x] `npm run build` → clean. Three new dynamic admin routes appear in the output: `/admin/jobs`, `/admin/jobs/[id]`, `/admin/jobs/sources`.

## Test plan (after backend deploys)

- [ ] Sign in to `/admin`, see the Jobs nav entry.
- [ ] `/admin/jobs/sources` loads with the three seeded platforms in the dropdown; add a Greenhouse board, toggle, delete.
- [ ] Trigger a poll on the backend (`POST /jobs/poll-now` with the token, or run the GitHub Actions workflow manually); refresh `/admin/jobs` and confirm cards appear in the "Prospected" column with non-zero match scores.
- [ ] Move a card through all 6 statuses via the per-card select; verify `applied_at` shows on the detail page after the applied transition.
- [ ] On a job's detail page, click **Generate tailored CV** → expect a success banner with a `cv_version_id`. Hit `/api/v1/cv/{cv_version_id}/render-pdf` (existing endpoint) and confirm a PDF URL comes back.
- [ ] Click **Generate cover letter** → the editor populates with the rendered body; edit + blur to confirm the autosave.

## Out of scope

- Drag-and-drop on the kanban (status select covers the DoD; drag-drop is a v1.5 polish).
- Browser extension (Chunk 12).
- i18n on the admin (per CLAUDE.md, admin is EN-only).