### PR TITLE
feat(jobs): career-ops improvements — sources UX, analytics, follow-up, poll button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ REVALIDATION_SECRET=
 # contact page link. Example: 584241234567
 NEXT_PUBLIC_WHATSAPP_NUMBER=
 
+# ── Job Pipeline ─────────────────────────────────────────────────────────────
+# Must match JOBS_POLL_TOKEN in the backend .env and the GitHub Actions secret.
+# Required for the "Poll now" button in /admin/jobs to work.
+# Generate with: openssl rand -hex 32
+JOBS_POLL_TOKEN=
+
 # ── Feature Flags ────────────────────────────────────────────────────────────
 # Set to "true" to render the Blog section on the homepage.
 NEXT_PUBLIC_SHOW_BLOG=false

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -55,6 +55,48 @@ export async function updateJobAction(
   }
 }
 
+export async function getJobAction(id: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/${id}`, {
+      headers: await authHeaders(),
+      cache: "no-store",
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to fetch job" };
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function renderCvPdfAction(cvVersionId: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/cv/${cvVersionId}/render-pdf`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to render PDF" };
+    return { success: true, data: json as { pdf_url: string } };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function renderCoverLetterPdfAction(cvVersionId: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/cv/cover-letter/${cvVersionId}/render-pdf`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to render cover letter PDF" };
+    return { success: true, data: json as { pdf_url: string } };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function generateJobCvAction(
   id: string,
   body: {
@@ -99,6 +141,24 @@ export async function generateJobCoverLetterAction(
   }
 }
 
+export async function qaJobAction(
+  id: string,
+  body: { question: string; hint?: string; locale?: "auto" | "en" | "es" },
+) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/${id}/qa`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ locale: "auto", hint: "", ...body }),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to generate answer" };
+    return { success: true, data: json as { question: string; answer: string } };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function createJobSourceAction(data: {
   platform: string;
   identifier: string;
@@ -121,7 +181,7 @@ export async function createJobSourceAction(data: {
 
 export async function updateJobSourceAction(
   id: string,
-  data: { identifier?: string; enabled?: boolean },
+  data: { platform?: string; identifier?: string; enabled?: boolean },
 ) {
   try {
     const res = await fetch(`${API_BASE_URL}/jobs/sources/${id}`, {

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -14,9 +14,30 @@ async function authHeaders() {
   };
 }
 
+export async function pollJobsAction() {
+  const token = process.env.JOBS_POLL_TOKEN;
+  if (!token) return { error: "JOBS_POLL_TOKEN is not configured on the server." };
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/poll-now`, {
+      method: "POST",
+      headers: {
+        "X-Jobs-Poll-Token": token,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Poll failed" };
+    revalidatePath("/admin/jobs");
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function updateJobAction(
   id: string,
-  data: { status?: string; cover_letter_text?: string | null; notes?: string | null },
+  data: { status?: string; cover_letter_text?: string | null; notes?: string | null; follow_up_at?: string | null },
 ) {
   try {
     const res = await fetch(`${API_BASE_URL}/jobs/${id}`, {

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -1,10 +1,19 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
 import { pollJobsAction, updateJobAction } from "@/app/actions/jobs";
+
+// How long (ms) the "Poll now" button stays disabled after a successful poll.
+const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
+const POLL_LS_KEY = "jobs_last_poll_ts";
+
+function msToHuman(ms: number): string {
+  const m = Math.ceil(ms / 60_000);
+  return m >= 60 ? `${Math.ceil(m / 60)}h` : `${m}m`;
+}
 
 const STATUS_LABELS: Record<JobStatus, string> = {
   prospected: "Prospected",
@@ -43,6 +52,28 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const [error, setError] = useState<string | null>(null);
   const [pollInfo, setPollInfo] = useState<string | null>(null);
   const [isPollPending, startPollTransition] = useTransition();
+  const [pollCooldownMs, setPollCooldownMs] = useState(0);
+
+  // Hydrate cooldown from localStorage on mount.
+  useEffect(() => {
+    const raw = localStorage.getItem(POLL_LS_KEY);
+    if (raw) {
+      const remaining = POLL_COOLDOWN_MS - (Date.now() - Number(raw));
+      if (remaining > 0) setPollCooldownMs(remaining);
+    }
+  }, []);
+
+  // Tick down the cooldown every 30 s.
+  useEffect(() => {
+    if (pollCooldownMs <= 0) return;
+    const id = setInterval(() => {
+      setPollCooldownMs((prev) => {
+        const next = prev - 30_000;
+        return next > 0 ? next : 0;
+      });
+    }, 30_000);
+    return () => clearInterval(id);
+  }, [pollCooldownMs]);
 
   const grouped = useMemo(() => {
     const out: Record<JobStatus, ApiJob[]> = {
@@ -73,6 +104,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   }
 
   function handlePollNow() {
+    if (pollCooldownMs > 0 || isPollPending) return;
     setError(null);
     setPollInfo(null);
     startPollTransition(async () => {
@@ -83,6 +115,8 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
         `Poll complete — ${d.new_jobs} new job${d.new_jobs === 1 ? "" : "s"} from ${d.sources_polled} source${d.sources_polled === 1 ? "" : "s"}.` +
         (d.failures.length ? ` ${d.failures.length} source(s) failed.` : ""),
       );
+      localStorage.setItem(POLL_LS_KEY, String(Date.now()));
+      setPollCooldownMs(POLL_COOLDOWN_MS);
       router.refresh();
     });
   }
@@ -115,10 +149,15 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
           </Link>
           <button
             onClick={handlePollNow}
-            disabled={isPollPending}
+            disabled={isPollPending || pollCooldownMs > 0}
+            title={pollCooldownMs > 0 ? `Available again in ${msToHuman(pollCooldownMs)}` : "Fetch new jobs from all sources"}
             className="text-xs px-3 py-1.5 rounded-md bg-[var(--accent-violet)] text-white hover:bg-[var(--accent-violet)]/90 disabled:opacity-50 transition-colors"
           >
-            {isPollPending ? "Polling…" : "Poll now"}
+            {isPollPending
+              ? "Polling…"
+              : pollCooldownMs > 0
+              ? `Poll (${msToHuman(pollCooldownMs)})`
+              : "Poll now"}
           </button>
         </span>
       </div>

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
-import { updateJobAction } from "@/app/actions/jobs";
+import { pollJobsAction, updateJobAction } from "@/app/actions/jobs";
 
 const STATUS_LABELS: Record<JobStatus, string> = {
   prospected: "Prospected",
@@ -30,12 +30,19 @@ function scoreBadge(score: number): string {
   return "bg-red-500/15 text-red-300";
 }
 
+function isOverdue(followUpAt: string | null, status: JobStatus): boolean {
+  if (!followUpAt || status === "offer" || status === "rejected") return false;
+  return new Date(followUpAt) < new Date(new Date().toDateString());
+}
+
 export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const router = useRouter();
   const [jobs, setJobs] = useState<ApiJob[]>(initialJobs);
   const [minScore, setMinScore] = useState(0);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pollInfo, setPollInfo] = useState<string | null>(null);
+  const [isPollPending, startPollTransition] = useTransition();
 
   const grouped = useMemo(() => {
     const out: Record<JobStatus, ApiJob[]> = {
@@ -49,46 +56,81 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     return out;
   }, [jobs, minScore]);
 
+  const overdueCount = useMemo(
+    () => jobs.filter((j) => isOverdue(j.follow_up_at, j.status)).length,
+    [jobs],
+  );
+
   async function handleStatusChange(job: ApiJob, next: JobStatus) {
     if (next === job.status) return;
     setBusyId(job.id);
     setError(null);
     const res = await updateJobAction(job.id, { status: next });
     setBusyId(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     setJobs(prev => prev.map(j => (j.id === job.id ? { ...j, status: next } : j)));
     router.refresh();
   }
 
+  function handlePollNow() {
+    setError(null);
+    setPollInfo(null);
+    startPollTransition(async () => {
+      const res = await pollJobsAction();
+      if (res.error) { setError(res.error); return; }
+      const d = res.data as { sources_polled: number; new_jobs: number; failures: string[] };
+      setPollInfo(
+        `Poll complete — ${d.new_jobs} new job${d.new_jobs === 1 ? "" : "s"} from ${d.sources_polled} source${d.sources_polled === 1 ? "" : "s"}.` +
+        (d.failures.length ? ` ${d.failures.length} source(s) failed.` : ""),
+      );
+      router.refresh();
+    });
+  }
+
   return (
     <>
-      <div className="mb-6 flex items-center gap-3">
+      <div className="mb-6 flex flex-wrap items-center gap-3">
         <label className="text-sm text-[var(--text-secondary)]">
           Min match score:&nbsp;
-          <span className="text-[var(--text-primary)] font-medium">
-            {minScore.toFixed(2)}
-          </span>
+          <span className="text-[var(--text-primary)] font-medium">{minScore.toFixed(2)}</span>
         </label>
         <input
-          type="range"
-          min={0}
-          max={1}
-          step={0.05}
-          value={minScore}
+          type="range" min={0} max={1} step={0.05} value={minScore}
           onChange={(e) => setMinScore(parseFloat(e.target.value))}
-          className="w-64"
+          className="w-48"
         />
-        <span className="ml-auto text-sm text-[var(--text-secondary)]">
-          {jobs.length} total
+
+        <span className="ml-auto flex items-center gap-3">
+          {overdueCount > 0 && (
+            <span className="text-xs px-2 py-1 rounded-full bg-orange-500/15 text-orange-300">
+              {overdueCount} follow-up{overdueCount > 1 ? "s" : ""} overdue
+            </span>
+          )}
+          <span className="text-sm text-[var(--text-secondary)]">{jobs.length} total</span>
+          <Link
+            href="/admin/jobs/stats"
+            className="text-xs px-3 py-1.5 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)] transition-colors"
+          >
+            Stats →
+          </Link>
+          <button
+            onClick={handlePollNow}
+            disabled={isPollPending}
+            className="text-xs px-3 py-1.5 rounded-md bg-[var(--accent-violet)] text-white hover:bg-[var(--accent-violet)]/90 disabled:opacity-50 transition-colors"
+          >
+            {isPollPending ? "Polling…" : "Poll now"}
+          </button>
         </span>
       </div>
 
       {error && (
         <div className="mb-4 px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/40 text-sm text-red-300">
           {error}
+        </div>
+      )}
+      {pollInfo && !error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-emerald-500/10 border border-emerald-500/40 text-sm text-emerald-300">
+          {pollInfo}
         </div>
       )}
 
@@ -102,76 +144,70 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
               <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-primary)]">
                 {STATUS_LABELS[status]}
               </h2>
-              <span className="text-xs text-[var(--text-secondary)]">
-                {grouped[status].length}
-              </span>
+              <span className="text-xs text-[var(--text-secondary)]">{grouped[status].length}</span>
             </header>
 
             <div className="space-y-3 max-h-[70vh] overflow-y-auto pr-1">
               {grouped[status].length === 0 ? (
-                <p className="text-xs text-[var(--text-secondary)] italic">
-                  No jobs in this column.
-                </p>
+                <p className="text-xs text-[var(--text-secondary)] italic">No jobs in this column.</p>
               ) : (
-                grouped[status].map((job) => (
-                  <article
-                    key={job.id}
-                    className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-3"
-                  >
-                    <Link
-                      href={`/admin/jobs/${job.id}`}
-                      className="block group"
+                grouped[status].map((job) => {
+                  const overdue = isOverdue(job.follow_up_at, job.status);
+                  return (
+                    <article
+                      key={job.id}
+                      className={`rounded-lg border bg-[var(--bg-elevated)] p-3 ${
+                        overdue ? "border-orange-500/50" : "border-[var(--border-subtle)]"
+                      }`}
                     >
-                      <div className="flex items-start gap-2">
-                        <h3 className="text-sm font-semibold text-[var(--text-primary)] group-hover:text-[var(--accent-cyan)] transition-colors flex-1 line-clamp-2">
-                          {job.title}
-                        </h3>
-                        <span
-                          className={`shrink-0 inline-flex items-center text-xs px-2 py-0.5 rounded-full ${scoreBadge(
-                            job.match_score
-                          )}`}
-                        >
-                          {(job.match_score * 100).toFixed(0)}%
-                        </span>
-                      </div>
-                      <p className="text-xs text-[var(--text-secondary)] mt-1">
-                        {job.company}
-                        {job.location ? ` · ${job.location}` : ""}
-                      </p>
-                      {job.match_explanation && (
-                        <p className="text-xs text-[var(--text-secondary)] mt-2 italic line-clamp-2">
-                          {job.match_explanation}
+                      <Link href={`/admin/jobs/${job.id}`} className="block group">
+                        <div className="flex items-start gap-2">
+                          <h3 className="text-sm font-semibold text-[var(--text-primary)] group-hover:text-[var(--accent-cyan)] transition-colors flex-1 line-clamp-2">
+                            {job.title}
+                          </h3>
+                          <span className={`shrink-0 inline-flex items-center text-xs px-2 py-0.5 rounded-full ${scoreBadge(job.match_score)}`}>
+                            {(job.match_score * 100).toFixed(0)}%
+                          </span>
+                        </div>
+                        <p className="text-xs text-[var(--text-secondary)] mt-1">
+                          {job.company}{job.location ? ` · ${job.location}` : ""}
                         </p>
-                      )}
-                    </Link>
+                        {job.match_explanation && (
+                          <p className="text-xs text-[var(--text-secondary)] mt-2 italic line-clamp-2">
+                            {job.match_explanation}
+                          </p>
+                        )}
+                        {overdue && (
+                          <p className="text-xs text-orange-300 mt-1">
+                            Follow-up overdue · {new Date(job.follow_up_at!).toLocaleDateString()}
+                          </p>
+                        )}
+                      </Link>
 
-                    <div className="mt-3 flex items-center gap-2">
-                      <select
-                        value={job.status}
-                        onChange={(e) =>
-                          handleStatusChange(job, e.target.value as JobStatus)
-                        }
-                        disabled={busyId === job.id}
-                        className="flex-1 text-xs px-2 py-1 rounded-md bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-primary)] disabled:opacity-50"
-                      >
-                        {JOB_STATUSES.map((s) => (
-                          <option key={s} value={s}>
-                            → {STATUS_LABELS[s]}
-                          </option>
-                        ))}
-                      </select>
-                      <a
-                        href={job.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs px-2 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)] transition-colors"
-                        title="Open job posting"
-                      >
-                        ↗
-                      </a>
-                    </div>
-                  </article>
-                ))
+                      <div className="mt-3 flex items-center gap-2">
+                        <select
+                          value={job.status}
+                          onChange={(e) => handleStatusChange(job, e.target.value as JobStatus)}
+                          disabled={busyId === job.id}
+                          className="flex-1 text-xs px-2 py-1 rounded-md bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-primary)] disabled:opacity-50"
+                        >
+                          {JOB_STATUSES.map((s) => (
+                            <option key={s} value={s}>→ {STATUS_LABELS[s]}</option>
+                          ))}
+                        </select>
+                        <a
+                          href={job.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs px-2 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)] transition-colors"
+                          title="Open job posting"
+                        >
+                          ↗
+                        </a>
+                      </div>
+                    </article>
+                  );
+                })
               )}
             </div>
           </section>

--- a/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
@@ -2,14 +2,39 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
+import { ApiCvVersion, ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
 import {
   generateJobCoverLetterAction,
   generateJobCvAction,
+  getJobAction,
+  qaJobAction,
+  renderCoverLetterPdfAction,
+  renderCvPdfAction,
   updateJobAction,
 } from "@/app/actions/jobs";
 
-export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) {
+const DOC_LABELS: Record<string, { label: string; color: string }> = {
+  cv:           { label: "Tailored CV",    color: "bg-[var(--accent-violet)]/15 text-[var(--accent-violet)]" },
+  cv_one_page:  { label: "One-Page CV",    color: "bg-yellow-500/15 text-yellow-300" },
+  cover_letter: { label: "Cover Letter",   color: "bg-[var(--accent-cyan)]/15 text-[var(--accent-cyan)]" },
+};
+
+function DocKindLabel({ kind }: { kind: string }) {
+  const { label, color } = DOC_LABELS[kind] ?? { label: kind, color: "bg-[var(--border-subtle)] text-[var(--text-secondary)]" };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${color}`}>
+      {label}
+    </span>
+  );
+}
+
+export default function JobDetailClient({
+  initialJob,
+  initialCvVersions,
+}: {
+  initialJob: ApiJob;
+  initialCvVersions: ApiCvVersion[];
+}) {
   const router = useRouter();
   const [job, setJob] = useState<ApiJob>(initialJob);
   const [busy, setBusy] = useState<string | null>(null);
@@ -18,6 +43,13 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
   const [notes, setNotes] = useState(job.notes ?? "");
   const [coverLetter, setCoverLetter] = useState(job.cover_letter_text ?? "");
   const [followUpAt, setFollowUpAt] = useState(job.follow_up_at ?? "");
+  const [copied, setCopied] = useState(false);
+  // Document history — server-loaded, then augmented by in-session generations
+  const [cvVersions, setCvVersions] = useState<ApiCvVersion[]>(initialCvVersions);
+  // QA state
+  const [qaQuestion, setQaQuestion] = useState("");
+  const [qaHint, setQaHint] = useState("");
+  const [qaHistory, setQaHistory] = useState<{ question: string; hint: string; answer: string }[]>([]);
 
   async function save(data: Parameters<typeof updateJobAction>[1]) {
     setBusy("save");
@@ -25,15 +57,23 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
     setInfo(null);
     const res = await updateJobAction(job.id, data);
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     if (res.data) {
       setJob(res.data as ApiJob);
       setInfo("Saved.");
       router.refresh();
     }
+  }
+
+  // Prepend a new version (pdf_url null) and return the inserted item so callers can use it
+  function addCvVersion(id: string, kind: ApiCvVersion["kind"], locale: string): ApiCvVersion {
+    const item: ApiCvVersion = { id, kind, locale, pdf_url: null, created_at: new Date().toISOString() };
+    setCvVersions((prev) => [item, ...prev]);
+    return item;
+  }
+
+  function setCvVersionPdfUrl(id: string, pdf_url: string) {
+    setCvVersions((prev) => prev.map((v) => (v.id === id ? { ...v, pdf_url } : v)));
   }
 
   async function runGenerateCv() {
@@ -42,11 +82,25 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
     setInfo(null);
     const res = await generateJobCvAction(job.id, { locale: "auto" });
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      addCvVersion(res.data.cv_version_id, "cv", res.data.locale);
+      setInfo("CV generated — click \"Render PDF\" in the Documents section to download.");
     }
-    setInfo(`CV generated. cv_version_id: ${res.data?.cv_version_id}`);
+    router.refresh();
+  }
+
+  async function runGenerateCvOnePage() {
+    setBusy("cv-one");
+    setError(null);
+    setInfo(null);
+    const res = await generateJobCvAction(job.id, { locale: "auto", mode: "one_page" });
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      addCvVersion(res.data.cv_version_id, "cv_one_page", res.data.locale);
+      setInfo("One-page CV generated — click \"Render PDF\" in the Documents section to download.");
+    }
     router.refresh();
   }
 
@@ -56,17 +110,99 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
     setInfo(null);
     const res = await generateJobCoverLetterAction(job.id, { locale: "auto" });
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     if (res.data) {
-      // Backend mirrors the rendered cover letter onto job.cover_letter_text;
-      // re-fetch is unnecessary because the next router.refresh() repaints,
-      // but populate the textarea so the admin can edit immediately.
-      setInfo(`Cover letter generated. cv_version_id: ${res.data.cv_version_id}`);
+      addCvVersion(res.data.cv_version_id, "cover_letter", res.data.locale);
+    }
+    // Refetch so the cover letter textarea gets populated immediately.
+    const jobRes = await getJobAction(job.id);
+    if (jobRes.data) {
+      const updated = jobRes.data as ApiJob;
+      setJob(updated);
+      setCoverLetter(updated.cover_letter_text ?? "");
+    }
+    setInfo("Cover letter generated — review and edit it in the Cover letter section below. Click \"Render PDF\" in Documents to download.");
+    router.refresh();
+  }
+
+  async function runGenerateBoth() {
+    setBusy("both");
+    setError(null);
+    setInfo(null);
+    const [cvRes, clRes] = await Promise.all([
+      generateJobCvAction(job.id, { locale: "auto" }),
+      generateJobCoverLetterAction(job.id, { locale: "auto" }),
+    ]);
+    setBusy(null);
+
+    if (cvRes.data) addCvVersion(cvRes.data.cv_version_id, "cv", cvRes.data.locale);
+    if (clRes.data) addCvVersion(clRes.data.cv_version_id, "cover_letter", clRes.data.locale);
+
+    // Refetch to sync cover letter text.
+    const jobRes = await getJobAction(job.id);
+    if (jobRes.data) {
+      const updated = jobRes.data as ApiJob;
+      setJob(updated);
+      setCoverLetter(updated.cover_letter_text ?? "");
+    }
+
+    const errors = [cvRes.error, clRes.error].filter(Boolean);
+    if (errors.length === 2) {
+      setError(errors.join(" | "));
+    } else if (errors.length === 1) {
+      setError(errors[0]!);
+      setInfo(cvRes.error ? "Cover letter generated." : "CV generated.");
+    } else {
+      setInfo("CV and cover letter generated — see Documents below to render PDFs.");
     }
     router.refresh();
+  }
+
+  async function handleRenderPdf(doc: ApiCvVersion) {
+    setBusy(`pdf-${doc.id}`);
+    setError(null);
+    const res = doc.kind === "cv"
+      ? await renderCvPdfAction(doc.id)
+      : await renderCoverLetterPdfAction(doc.id);
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data?.pdf_url) setCvVersionPdfUrl(doc.id, res.data.pdf_url);
+  }
+
+  async function handleAskQa() {
+    if (!qaQuestion.trim()) return;
+    setBusy("qa");
+    setError(null);
+    setInfo(null);
+    const res = await qaJobAction(job.id, { question: qaQuestion.trim(), hint: qaHint.trim() });
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      setQaHistory((prev) => [{ ...res.data!, hint: qaHint.trim() }, ...prev]);
+      setQaQuestion("");
+      // Hint is kept so the user can reuse it for the next question.
+    }
+  }
+
+  async function handleRegenerateQa(index: number) {
+    const item = qaHistory[index];
+    if (!item) return;
+    setBusy(`qa-regen-${index}`);
+    setError(null);
+    const res = await qaJobAction(job.id, { question: item.question, hint: item.hint });
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      setQaHistory((prev) =>
+        prev.map((h, i) => (i === index ? { question: item.question, hint: item.hint, answer: res.data!.answer } : h))
+      );
+    }
+  }
+
+  async function handleCopyCoverLetter() {
+    await navigator.clipboard.writeText(coverLetter);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
   }
 
   return (
@@ -87,6 +223,7 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
         </a>
       </header>
 
+      {/* ── Top cards ── */}
       <section className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
           <div className="text-xs uppercase tracking-wide text-[var(--text-secondary)] mb-1">
@@ -113,9 +250,7 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
             className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)]"
           >
             {JOB_STATUSES.map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
+              <option key={s} value={s}>{s}</option>
             ))}
           </select>
           {job.applied_at && (
@@ -132,17 +267,31 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
           <div className="flex flex-col gap-2">
             <button
               onClick={runGenerateCv}
-              disabled={busy === "cv"}
+              disabled={!!busy}
               className="px-3 py-2 rounded-md border border-[var(--border-strong)] text-sm text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] disabled:opacity-50"
             >
               {busy === "cv" ? "Generating CV…" : "Generate tailored CV"}
             </button>
             <button
+              onClick={runGenerateCvOnePage}
+              disabled={!!busy}
+              className="px-3 py-2 rounded-md border border-yellow-500/50 text-sm text-yellow-300 hover:border-yellow-400 hover:text-yellow-200 disabled:opacity-50 transition-colors"
+            >
+              {busy === "cv-one" ? "Generating…" : "Generate one-page CV"}
+            </button>
+            <button
               onClick={runGenerateCoverLetter}
-              disabled={busy === "cl"}
+              disabled={!!busy}
               className="px-3 py-2 rounded-md border border-[var(--border-strong)] text-sm text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] disabled:opacity-50"
             >
               {busy === "cl" ? "Generating cover letter…" : "Generate cover letter"}
+            </button>
+            <button
+              onClick={runGenerateBoth}
+              disabled={!!busy}
+              className="px-3 py-2 rounded-md bg-[var(--accent-violet)] text-white text-sm hover:bg-[var(--accent-violet)]/90 disabled:opacity-50 transition-colors"
+            >
+              {busy === "both" ? "Generating both…" : "Generate CV + cover letter"}
             </button>
           </div>
         </div>
@@ -159,6 +308,134 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
         </div>
       )}
 
+      {/* ── Documents history ── */}
+      <section>
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-3">
+          Documents
+        </h2>
+        {cvVersions.length === 0 ? (
+          <p className="text-xs text-[var(--text-secondary)] italic">
+            No documents yet — use the Generate buttons above to create a tailored CV or cover letter.
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {cvVersions.map((doc) => (
+              <div
+                key={doc.id}
+                className="flex items-center gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] px-3 py-2"
+              >
+                <DocKindLabel kind={doc.kind} />
+                <span className="text-xs text-[var(--text-secondary)] uppercase">{doc.locale}</span>
+                <span className="text-xs text-[var(--text-secondary)]">
+                  {new Date(doc.created_at).toLocaleString()}
+                </span>
+                <div className="ml-auto flex items-center gap-2">
+                  {doc.pdf_url ? (
+                    <a
+                      href={doc.pdf_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs px-3 py-1 rounded-md bg-emerald-600 text-white hover:bg-emerald-500 transition-colors"
+                    >
+                      Download PDF ↗
+                    </a>
+                  ) : (
+                    <button
+                      onClick={() => handleRenderPdf(doc)}
+                      disabled={busy === `pdf-${doc.id}`}
+                      className="text-xs px-3 py-1 rounded-md bg-[var(--accent-cyan)] text-[var(--bg-base)] hover:opacity-90 disabled:opacity-50 transition-colors"
+                    >
+                      {busy === `pdf-${doc.id}` ? "Rendering…" : "Render PDF"}
+                    </button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        <p className="text-xs text-[var(--text-secondary)] mt-2">
+          Re-rendering a PDF from a saved document is free — it re-runs WeasyPrint on the stored HTML without calling the AI again.
+        </p>
+      </section>
+
+      {/* ── Application Q&A ── */}
+      <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4 space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+          Application Q&amp;A
+        </h2>
+        <p className="text-xs text-[var(--text-secondary)]">
+          Paste an employer application question and get a grounded first-person answer
+          based on your real experience. Edit the answer before submitting.
+        </p>
+        <textarea
+          value={qaQuestion}
+          onChange={(e) => setQaQuestion(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleAskQa();
+          }}
+          rows={3}
+          placeholder="e.g. Why do you want to work here? What's your biggest strength?"
+          className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm resize-none"
+        />
+        <div className="flex gap-2">
+          <div className="relative flex-1">
+            <input
+              type="text"
+              value={qaHint}
+              onChange={(e) => setQaHint(e.target.value)}
+              placeholder="Optional hint — e.g. mention TypeScript, keep under 200 words"
+              className="w-full px-3 py-2 pr-8 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+            />
+            {qaHint && (
+              <button
+                onClick={() => setQaHint("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-secondary)] hover:text-[var(--text-primary)] text-sm leading-none"
+                title="Clear hint"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+          <button
+            onClick={handleAskQa}
+            disabled={busy === "qa" || !qaQuestion.trim()}
+            className="px-4 py-2 rounded-md bg-[var(--accent-violet)] text-white text-sm hover:bg-[var(--accent-violet)]/90 disabled:opacity-50 transition-colors whitespace-nowrap"
+          >
+            {busy === "qa" ? "Generating…" : "Ask (⌘↵)"}
+          </button>
+        </div>
+        {qaHistory.length > 0 && (
+          <div className="space-y-4 pt-2">
+            {qaHistory.map((item, i) => (
+              <div
+                key={i}
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-elevated)] p-3 space-y-2"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="space-y-1 flex-1">
+                    <p className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wide">Q</p>
+                    <p className="text-sm text-[var(--text-primary)]">{item.question}</p>
+                    {item.hint && (
+                      <p className="text-xs text-[var(--text-secondary)] italic">Hint: {item.hint}</p>
+                    )}
+                  </div>
+                  <button
+                    onClick={() => handleRegenerateQa(i)}
+                    disabled={!!busy}
+                    className="shrink-0 text-xs px-2.5 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)] disabled:opacity-40 transition-colors"
+                  >
+                    {busy === `qa-regen-${i}` ? "Regenerating…" : "Regenerate"}
+                  </button>
+                </div>
+                <p className="text-xs font-semibold text-[var(--accent-cyan)] uppercase tracking-wide">A</p>
+                <p className="text-sm text-[var(--text-primary)] whitespace-pre-wrap">{item.answer}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Follow-up + applied date ── */}
       <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
@@ -188,6 +465,7 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
         )}
       </section>
 
+      {/* ── Notes ── */}
       <section>
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
           Notes
@@ -204,10 +482,26 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
         />
       </section>
 
+      {/* ── Cover letter ── */}
       <section>
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
-          Cover letter
-        </h2>
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)]">
+            Cover letter
+          </h2>
+          {coverLetter && (
+            <button
+              onClick={handleCopyCoverLetter}
+              className="text-xs px-3 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:border-[var(--border-strong)] transition-colors"
+            >
+              {copied ? "Copied ✓" : "Copy text"}
+            </button>
+          )}
+        </div>
+        {!coverLetter && (
+          <p className="text-xs text-[var(--text-secondary)] mb-2 italic">
+            No cover letter yet — use the Generate button above to create one.
+          </p>
+        )}
         <textarea
           value={coverLetter}
           onChange={(e) => setCoverLetter(e.target.value)}
@@ -219,8 +513,12 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
           className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm font-mono"
           placeholder="Generate one with the button above, then edit before sending."
         />
+        <p className="text-xs text-[var(--text-secondary)] mt-1">
+          Edits auto-save on blur. To download as PDF, use the Render PDF button in the Documents section above.
+        </p>
       </section>
 
+      {/* ── Job description ── */}
       <section>
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
           Job description

--- a/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
@@ -17,6 +17,7 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
   const [info, setInfo] = useState<string | null>(null);
   const [notes, setNotes] = useState(job.notes ?? "");
   const [coverLetter, setCoverLetter] = useState(job.cover_letter_text ?? "");
+  const [followUpAt, setFollowUpAt] = useState(job.follow_up_at ?? "");
 
   async function save(data: Parameters<typeof updateJobAction>[1]) {
     setBusy("save");
@@ -157,6 +158,35 @@ export default function JobDetailClient({ initialJob }: { initialJob: ApiJob }) 
           {info}
         </div>
       )}
+
+      <section className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">
+            Follow-up date
+          </label>
+          <input
+            type="date"
+            value={followUpAt}
+            onChange={(e) => setFollowUpAt(e.target.value)}
+            onBlur={() => {
+              const val = followUpAt || null;
+              if (val !== (job.follow_up_at ?? null)) save({ follow_up_at: val });
+            }}
+            className="w-full px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+          />
+          <p className="text-xs text-[var(--text-secondary)] mt-1">
+            Leave blank for no reminder. Shown as overdue in the kanban if past today.
+          </p>
+        </div>
+        {job.applied_at && (
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">Applied</p>
+            <p className="text-sm text-[var(--text-primary)]">
+              {new Date(job.applied_at).toLocaleDateString()}
+            </p>
+          </div>
+        )}
+      </section>
 
       <section>
         <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-2">

--- a/app/admin/(dashboard)/jobs/[id]/page.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getAdminJob } from "@/lib/adminApi";
-import { ApiJob } from "@/lib/api";
+import { getAdminJob, getAdminJobCvVersions } from "@/lib/adminApi";
+import { ApiCvVersion, ApiJob } from "@/lib/api";
 import JobDetailClient from "./JobDetailClient";
 
 export const revalidate = 0;
@@ -12,7 +12,10 @@ export default async function AdminJobDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const job = (await getAdminJob(id)) as ApiJob | null;
+  const [job, cvVersions] = await Promise.all([
+    getAdminJob(id) as Promise<ApiJob | null>,
+    getAdminJobCvVersions(id) as Promise<ApiCvVersion[]>,
+  ]);
   if (!job) notFound();
 
   return (
@@ -23,7 +26,7 @@ export default async function AdminJobDetailPage({
       >
         ← Back to pipeline
       </Link>
-      <JobDetailClient initialJob={job} />
+      <JobDetailClient initialJob={job} initialCvVersions={cvVersions} />
     </div>
   );
 }

--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -26,7 +26,7 @@ const PLATFORM_HELP: Record<string, { desc: string; verifyUrl: string; example: 
     example: "linear",
   },
   remoteok: {
-    desc: "Tag-based aggregator. Identifier is a technology keyword, not a company name.",
+    desc: "Tag-based aggregator. Comma-separate multiple tags in one source: react.js,next.js",
     verifyUrl: "https://remoteok.com/remote-{slug}-jobs",
     example: "python",
   },
@@ -48,6 +48,12 @@ const RECOMMENDED: { platform: string; identifier: string; note: string }[] = [
   { platform: "remoteok",   identifier: "typescript",   note: "All remote TypeScript jobs" },
 ];
 
+interface EditState {
+  id: string;
+  platform: string;
+  identifier: string;
+}
+
 export default function SourcesClient({
   initialSources,
   platforms,
@@ -62,6 +68,7 @@ export default function SourcesClient({
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showHelp, setShowHelp] = useState(sources.length === 0);
+  const [editing, setEditing] = useState<EditState | null>(null);
 
   const platformInfo = PLATFORM_HELP[platform];
   const existingKeys = new Set(sources.map((s) => `${s.platform}/${s.identifier}`));
@@ -104,9 +111,36 @@ export default function SourcesClient({
     setBusy(null);
     if (res.error) { setError(res.error); return; }
     if (res.data) {
-      setSources((prev) =>
-        prev.map((s) => (s.id === src.id ? (res.data as ApiJobSource) : s))
-      );
+      setSources((prev) => prev.map((s) => (s.id === src.id ? (res.data as ApiJobSource) : s)));
+      router.refresh();
+    }
+  }
+
+  function startEdit(src: ApiJobSource) {
+    setEditing({ id: src.id, platform: src.platform, identifier: src.identifier });
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditing(null);
+    setError(null);
+  }
+
+  async function saveEdit() {
+    if (!editing) return;
+    const trimmed = editing.identifier.trim();
+    if (!editing.platform || !trimmed) return;
+    setBusy(`edit-${editing.id}`);
+    setError(null);
+    const res = await updateJobSourceAction(editing.id, {
+      platform: editing.platform,
+      identifier: trimmed,
+    });
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      setSources((prev) => prev.map((s) => (s.id === editing.id ? (res.data as ApiJobSource) : s)));
+      setEditing(null);
       router.refresh();
     }
   }
@@ -120,6 +154,7 @@ export default function SourcesClient({
     setBusy(null);
     if (res.error) { setError(res.error); return; }
     setSources((prev) => prev.filter((s) => s.id !== src.id));
+    if (editing?.id === src.id) setEditing(null);
     router.refresh();
   }
 
@@ -262,34 +297,102 @@ export default function SourcesClient({
                 </td>
               </tr>
             ) : (
-              sources.map((s) => (
-                <tr key={s.id} className="border-t border-[var(--border-subtle)]">
-                  <td className="px-4 py-2 text-[var(--text-primary)]">{s.platform}</td>
-                  <td className="px-4 py-2 text-[var(--text-primary)] font-mono">{s.identifier}</td>
-                  <td className="px-4 py-2">
-                    <button
-                      onClick={() => toggleEnabled(s)}
-                      disabled={busy === s.id}
-                      className={`text-xs px-2 py-0.5 rounded-full ${
-                        s.enabled
-                          ? "bg-emerald-500/15 text-emerald-300"
-                          : "bg-red-500/15 text-red-300"
-                      } disabled:opacity-50`}
-                    >
-                      {s.enabled ? "enabled" : "disabled"}
-                    </button>
-                  </td>
-                  <td className="px-4 py-2 text-right">
-                    <button
-                      onClick={() => onDelete(s)}
-                      disabled={busy === s.id}
-                      className="text-xs text-red-300 hover:text-red-200 disabled:opacity-50"
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))
+              sources.map((s) => {
+                const isEditing = editing?.id === s.id;
+                const isBusy = busy === s.id || busy === `edit-${s.id}`;
+
+                if (isEditing) {
+                  return (
+                    <tr key={s.id} className="border-t border-[var(--border-subtle)] bg-[var(--bg-elevated)]">
+                      <td className="px-3 py-2">
+                        <select
+                          value={editing.platform}
+                          onChange={(e) => setEditing({ ...editing, platform: e.target.value })}
+                          className="w-full px-2 py-1.5 rounded-md bg-[var(--bg-base)] border border-[var(--accent-violet)]/60 text-[var(--text-primary)] text-sm"
+                        >
+                          {platforms.map((p) => (
+                            <option key={p.code} value={p.code} disabled={!p.enabled}>
+                              {p.display_name}
+                            </option>
+                          ))}
+                        </select>
+                      </td>
+                      <td className="px-3 py-2">
+                        <input
+                          type="text"
+                          value={editing.identifier}
+                          onChange={(e) => setEditing({ ...editing, identifier: e.target.value })}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") saveEdit();
+                            if (e.key === "Escape") cancelEdit();
+                          }}
+                          autoFocus
+                          className="w-full px-2 py-1.5 rounded-md bg-[var(--bg-base)] border border-[var(--accent-violet)]/60 text-[var(--text-primary)] text-sm font-mono"
+                        />
+                      </td>
+                      <td className="px-3 py-2 text-xs text-[var(--text-secondary)]">
+                        (saved)
+                      </td>
+                      <td className="px-3 py-2 text-right">
+                        <span className="inline-flex gap-2">
+                          <button
+                            onClick={saveEdit}
+                            disabled={isBusy || !editing.identifier.trim()}
+                            className="text-xs px-3 py-1 rounded-md bg-[var(--accent-violet)] text-white hover:bg-[var(--accent-violet)]/90 disabled:opacity-50 transition-colors"
+                          >
+                            {isBusy ? "Saving…" : "Save"}
+                          </button>
+                          <button
+                            onClick={cancelEdit}
+                            disabled={isBusy}
+                            className="text-xs px-3 py-1 rounded-md border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] disabled:opacity-50 transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </span>
+                      </td>
+                    </tr>
+                  );
+                }
+
+                return (
+                  <tr key={s.id} className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50">
+                    <td className="px-4 py-2 text-[var(--text-primary)]">{s.platform}</td>
+                    <td className="px-4 py-2 text-[var(--text-primary)] font-mono">{s.identifier}</td>
+                    <td className="px-4 py-2">
+                      <button
+                        onClick={() => toggleEnabled(s)}
+                        disabled={isBusy}
+                        className={`text-xs px-2 py-0.5 rounded-full ${
+                          s.enabled
+                            ? "bg-emerald-500/15 text-emerald-300"
+                            : "bg-red-500/15 text-red-300"
+                        } disabled:opacity-50`}
+                      >
+                        {s.enabled ? "enabled" : "disabled"}
+                      </button>
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <span className="inline-flex gap-3">
+                        <button
+                          onClick={() => startEdit(s)}
+                          disabled={isBusy || !!editing}
+                          className="text-xs text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] disabled:opacity-40 transition-colors"
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => onDelete(s)}
+                          disabled={isBusy || !!editing}
+                          className="text-xs text-red-300 hover:text-red-200 disabled:opacity-40 transition-colors"
+                        >
+                          Delete
+                        </button>
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -9,6 +9,45 @@ import {
   updateJobSourceAction,
 } from "@/app/actions/jobs";
 
+const PLATFORM_HELP: Record<string, { desc: string; verifyUrl: string; example: string }> = {
+  greenhouse: {
+    desc: "Used by Stripe, Shopify, Notion, Discord, Cloudflare, Anthropic, OpenAI, Figma, Brex…",
+    verifyUrl: "https://boards.greenhouse.io/{slug}",
+    example: "stripe",
+  },
+  lever: {
+    desc: "Used by Netflix, Reddit, Plaid, Linear, Coda…",
+    verifyUrl: "https://jobs.lever.co/{slug}",
+    example: "netflix",
+  },
+  ashby: {
+    desc: "Used by Linear, Vercel, Notion (new boards), Loom, Retool, Raycast…",
+    verifyUrl: "https://jobs.ashbyhq.com/{slug}",
+    example: "linear",
+  },
+  remoteok: {
+    desc: "Tag-based aggregator. Identifier is a technology keyword, not a company name.",
+    verifyUrl: "https://remoteok.com/remote-{slug}-jobs",
+    example: "python",
+  },
+};
+
+const RECOMMENDED: { platform: string; identifier: string; note: string }[] = [
+  { platform: "greenhouse", identifier: "stripe",       note: "Stripe" },
+  { platform: "greenhouse", identifier: "shopify",      note: "Shopify" },
+  { platform: "greenhouse", identifier: "anthropic",    note: "Anthropic" },
+  { platform: "greenhouse", identifier: "openai",       note: "OpenAI" },
+  { platform: "greenhouse", identifier: "cloudflare",   note: "Cloudflare" },
+  { platform: "greenhouse", identifier: "notion",       note: "Notion" },
+  { platform: "ashby",      identifier: "linear",       note: "Linear" },
+  { platform: "ashby",      identifier: "vercel",       note: "Vercel" },
+  { platform: "lever",      identifier: "plaid",        note: "Plaid" },
+  { platform: "lever",      identifier: "reddit",       note: "Reddit" },
+  { platform: "remoteok",   identifier: "python",       note: "All remote Python jobs" },
+  { platform: "remoteok",   identifier: "ai",           note: "All remote AI/ML jobs" },
+  { platform: "remoteok",   identifier: "typescript",   note: "All remote TypeScript jobs" },
+];
+
 export default function SourcesClient({
   initialSources,
   platforms,
@@ -22,6 +61,10 @@ export default function SourcesClient({
   const [identifier, setIdentifier] = useState("");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showHelp, setShowHelp] = useState(sources.length === 0);
+
+  const platformInfo = PLATFORM_HELP[platform];
+  const existingKeys = new Set(sources.map((s) => `${s.platform}/${s.identifier}`));
 
   async function onCreate(e: FormEvent) {
     e.preventDefault();
@@ -34,13 +77,22 @@ export default function SourcesClient({
       enabled: true,
     });
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     if (res.data) {
       setSources((prev) => [...prev, res.data as ApiJobSource]);
       setIdentifier("");
+      router.refresh();
+    }
+  }
+
+  async function addRecommended(p: string, id: string) {
+    setBusy(`rec-${p}-${id}`);
+    setError(null);
+    const res = await createJobSourceAction({ platform: p, identifier: id, enabled: true });
+    setBusy(null);
+    if (res.error) { setError(res.error); return; }
+    if (res.data) {
+      setSources((prev) => [...prev, res.data as ApiJobSource]);
       router.refresh();
     }
   }
@@ -50,10 +102,7 @@ export default function SourcesClient({
     setError(null);
     const res = await updateJobSourceAction(src.id, { enabled: !src.enabled });
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     if (res.data) {
       setSources((prev) =>
         prev.map((s) => (s.id === src.id ? (res.data as ApiJobSource) : s))
@@ -69,41 +118,115 @@ export default function SourcesClient({
     setError(null);
     const res = await deleteJobSourceAction(src.id);
     setBusy(null);
-    if (res.error) {
-      setError(res.error);
-      return;
-    }
+    if (res.error) { setError(res.error); return; }
     setSources((prev) => prev.filter((s) => s.id !== src.id));
     router.refresh();
   }
 
   return (
     <>
+      {/* Help section */}
+      <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+        <button
+          onClick={() => setShowHelp((v) => !v)}
+          className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--bg-elevated)] transition-colors"
+        >
+          <span>How sources work</span>
+          <span className="text-[var(--text-secondary)]">{showHelp ? "▲" : "▼"}</span>
+        </button>
+
+        {showHelp && (
+          <div className="px-4 pb-5 pt-1 space-y-4 border-t border-[var(--border-subtle)]">
+            <p className="text-sm text-[var(--text-secondary)]">
+              Each source is a <strong className="text-[var(--text-primary)]">(platform, identifier)</strong> pair.
+              The daily poller fetches open job listings from that board and scores them against your profile.
+            </p>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {Object.entries(PLATFORM_HELP).map(([code, info]) => {
+                const p = platforms.find((pl) => pl.code === code);
+                if (!p) return null;
+                return (
+                  <div key={code} className="rounded-md bg-[var(--bg-elevated)] p-3 text-sm">
+                    <p className="font-semibold text-[var(--text-primary)]">{p.display_name}</p>
+                    <p className="text-[var(--text-secondary)] text-xs mt-0.5">{info.desc}</p>
+                    <p className="text-[var(--text-secondary)] text-xs mt-1">
+                      Find the slug in the URL: <code className="text-[var(--accent-cyan)]">{info.verifyUrl}</code>
+                    </p>
+                    <p className="text-[var(--text-secondary)] text-xs mt-0.5">
+                      Example identifier: <code className="text-[var(--accent-violet)]">{info.example}</code>
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-[var(--text-primary)] mb-2">Recommended sources — click to add</p>
+              <div className="flex flex-wrap gap-2">
+                {RECOMMENDED.map(({ platform: p, identifier: id, note }) => {
+                  const key = `${p}/${id}`;
+                  const already = existingKeys.has(key);
+                  const platformEnabled = platforms.find((pl) => pl.code === p)?.enabled;
+                  if (!platformEnabled) return null;
+                  return (
+                    <button
+                      key={key}
+                      onClick={() => !already && addRecommended(p, id)}
+                      disabled={already || busy === `rec-${p}-${id}`}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition-colors ${
+                        already
+                          ? "border-emerald-500/40 text-emerald-300 cursor-default"
+                          : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)]"
+                      }`}
+                      title={`${p}/${id}`}
+                    >
+                      {already ? "✓ " : ""}{note}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Add form */}
       <form
         onSubmit={onCreate}
         className="mb-6 flex flex-col md:flex-row gap-3 p-4 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)]"
       >
-        <select
-          value={platform}
-          onChange={(e) => setPlatform(e.target.value)}
-          className="px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
-        >
-          {platforms.length === 0 ? (
-            <option value="">(no platforms — seed job_platforms first)</option>
-          ) : (
-            platforms.map((p) => (
-              <option key={p.code} value={p.code} disabled={!p.enabled}>
-                {p.display_name}
-                {p.enabled ? "" : " (disabled)"}
-              </option>
-            ))
+        <div className="flex flex-col gap-1 flex-shrink-0">
+          <select
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+            className="px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
+          >
+            {platforms.length === 0 ? (
+              <option value="">(no platforms — seed job_platforms first)</option>
+            ) : (
+              platforms.map((p) => (
+                <option key={p.code} value={p.code} disabled={!p.enabled}>
+                  {p.display_name}{p.enabled ? "" : " (disabled)"}
+                </option>
+              ))
+            )}
+          </select>
+          {platformInfo && (
+            <p className="text-xs text-[var(--text-secondary)] px-1">
+              e.g. <code className="text-[var(--accent-violet)]">{platformInfo.example}</code>
+            </p>
           )}
-        </select>
+        </div>
         <input
           type="text"
           value={identifier}
           onChange={(e) => setIdentifier(e.target.value)}
-          placeholder="board slug or tag (e.g. stripe / python)"
+          placeholder={
+            platformInfo
+              ? `Board slug or tag (e.g. ${platformInfo.example})`
+              : "Board slug or tag"
+          }
           className="flex-1 px-3 py-2 rounded-md bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[var(--text-primary)] text-sm"
         />
         <button
@@ -135,7 +258,7 @@ export default function SourcesClient({
             {sources.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-4 py-6 text-center text-[var(--text-secondary)] italic">
-                  No sources configured yet. Add one above to start polling.
+                  No sources configured yet. Add one above or use the recommended list.
                 </td>
               </tr>
             ) : (

--- a/app/admin/(dashboard)/jobs/stats/page.tsx
+++ b/app/admin/(dashboard)/jobs/stats/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+import { getJobStats } from "@/lib/adminApi";
+import { ApiJobStats, JOB_STATUSES, JobStatus } from "@/lib/api";
+
+export const revalidate = 0;
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  prospected: "Prospected",
+  tailored: "Tailored",
+  applied: "Applied",
+  interviewing: "Interviewing",
+  offer: "Offer",
+  rejected: "Rejected",
+};
+
+const STATUS_COLOR: Record<JobStatus, string> = {
+  prospected: "bg-[var(--border-strong)]",
+  tailored: "bg-[var(--accent-violet)]",
+  applied: "bg-[var(--accent-cyan)]",
+  interviewing: "bg-yellow-500",
+  offer: "bg-emerald-500",
+  rejected: "bg-red-500",
+};
+
+export default async function JobStatsPage() {
+  const stats = (await getJobStats()) as ApiJobStats | null;
+
+  if (!stats) {
+    return (
+      <div className="max-w-4xl mx-auto">
+        <Link href="/admin/jobs" className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors">
+          ← Back to pipeline
+        </Link>
+        <p className="mt-8 text-[var(--text-secondary)]">Could not load stats. Make sure the backend is running.</p>
+      </div>
+    );
+  }
+
+  const maxStatusCount = Math.max(...JOB_STATUSES.map((s) => stats.by_status[s] ?? 0), 1);
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-8">
+      <div>
+        <Link href="/admin/jobs" className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors">
+          ← Back to pipeline
+        </Link>
+        <h1 className="text-3xl font-bold text-[var(--text-primary)] mt-4">Pipeline analytics</h1>
+      </div>
+
+      {/* KPI row */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {[
+          { label: "Total jobs", value: stats.total },
+          { label: "Avg match score", value: `${(stats.avg_match_score * 100).toFixed(0)}%` },
+          { label: "Interview rate", value: stats.applied_to_interview_rate > 0 ? `${(stats.applied_to_interview_rate * 100).toFixed(0)}%` : "—" },
+          { label: "Overdue follow-ups", value: stats.overdue_followups, warn: stats.overdue_followups > 0 },
+        ].map(({ label, value, warn }) => (
+          <div key={label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
+            <p className="text-xs uppercase tracking-wide text-[var(--text-secondary)]">{label}</p>
+            <p className={`text-3xl font-bold mt-1 ${warn ? "text-orange-300" : "text-[var(--text-primary)]"}`}>
+              {value}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Status bar chart */}
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-4">By status</h2>
+        <div className="space-y-3">
+          {JOB_STATUSES.map((status) => {
+            const count = stats.by_status[status] ?? 0;
+            const pct = maxStatusCount > 0 ? (count / maxStatusCount) * 100 : 0;
+            return (
+              <div key={status} className="flex items-center gap-3">
+                <span className="w-24 text-xs text-[var(--text-secondary)] text-right shrink-0">
+                  {STATUS_LABELS[status]}
+                </span>
+                <div className="flex-1 h-5 rounded-full bg-[var(--bg-elevated)] overflow-hidden">
+                  <div
+                    className={`h-full rounded-full ${STATUS_COLOR[status]} opacity-70 transition-all`}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="w-6 text-xs text-[var(--text-primary)] font-medium">{count}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Top sources */}
+      {stats.top_sources.length > 0 && (
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-6">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-[var(--text-secondary)] mb-4">Top sources</h2>
+          <div className="space-y-2">
+            {stats.top_sources.map(({ source, count }) => (
+              <div key={source} className="flex items-center justify-between text-sm">
+                <span className="font-mono text-[var(--text-primary)]">{source}</span>
+                <span className="text-[var(--text-secondary)]">{count} job{count !== 1 ? "s" : ""}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -393,6 +393,15 @@ export async function getAdminJobPlatforms() {
   return res.json();
 }
 
+export async function getJobStats() {
+  const res = await fetch(`${API_BASE_URL}/jobs/stats`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
 export async function renderCvPdf(cvVersionId: string): Promise<{ pdf_url: string }> {
   const res = await fetch(`${API_BASE_URL}/cv/${cvVersionId}/render-pdf`, {
     method: "POST",

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -366,6 +366,15 @@ export async function getAdminJobs(params?: {
   return res.json();
 }
 
+export async function getAdminJobCvVersions(id: string) {
+  const res = await fetch(`${API_BASE_URL}/jobs/${id}/cv-versions`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
 export async function getAdminJob(id: string) {
   const res = await fetch(`${API_BASE_URL}/jobs/${id}`, {
     headers: await getAuthHeader(),

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -239,6 +239,14 @@ export interface ApiJobPlatform {
   enabled: boolean;
 }
 
+export interface ApiCvVersion {
+  id: string;
+  kind: "cv" | "cv_one_page" | "cover_letter";
+  locale: string;
+  pdf_url: string | null;
+  created_at: string;
+}
+
 // --- Helpers ---
 
 function formatDateRange(

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -211,8 +211,18 @@ export interface ApiJob {
   cover_letter_text: string | null;
   notes: string | null;
   applied_at: string | null;
+  follow_up_at: string | null;
   created_at: string;
   updated_at: string;
+}
+
+export interface ApiJobStats {
+  total: number;
+  by_status: Record<string, number>;
+  avg_match_score: number;
+  applied_to_interview_rate: number;
+  top_sources: { source: string; count: number }[];
+  overdue_followups: number;
 }
 
 export interface ApiJobSource {


### PR DESCRIPTION
## Summary

- **Sources help section** — collapsible guide explaining what platforms are, how to find identifiers, per-platform URL patterns with examples, and one-click recommended sources (Stripe, Anthropic, Linear, Vercel, remoteok tags, etc.)
- **Follow-up cadence** — date picker on job detail page, autosaves on blur; kanban shows orange overdue badge and border when past today
- **Analytics page** — `/admin/jobs/stats` with KPI cards (total, avg score, interview rate, overdue) + status bar chart + top sources
- **Poll now button** — in the kanban toolbar; calls the same endpoint as the GitHub Actions cron. Token stays server-side via server action, result shown inline
- **Richer match explanation** — new 1-2 sentence format: first sentence = specific overlap, second = gap (when score < 0.7)

## Prerequisites

- Backend PR #26 must be merged first (adds `follow_up_at` to the API response)
- Add `JOBS_POLL_TOKEN` to Vercel environment variables (same value as the backend secret) to enable the "Poll now" button

## Test plan

- [ ] `/admin/jobs/sources` — help section expands, recommended sources appear, one-click add works
- [ ] Add a follow-up date on a job detail page, blur, refresh — value persists
- [ ] Job card shows orange overdue border + badge when follow_up_at < today
- [ ] `/admin/jobs/stats` loads with correct counts
- [ ] "Poll now" button in kanban toolbar triggers poll and shows result inline