### PR TITLE
feat(jobs): career-ops improvements + fix localized field rendering crash

### DIFF
--- a/app/admin/(dashboard)/cv/generate/page.tsx
+++ b/app/admin/(dashboard)/cv/generate/page.tsx
@@ -819,8 +819,6 @@ function QaPairCard(props: {
 
   // If the parent updates the pair (after a successful regenerate), sync the hint
   // so the input reflects what the model just used.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  // (deliberately re-running on pair.hint change only)
   useStateSync(pair.hint ?? "", setHint);
 
   async function handleRegenerate() {
@@ -896,7 +894,6 @@ function QaPairCard(props: {
 
 /** Reflect prop changes into local state when the parent replaces the pair after a regenerate. */
 function useStateSync(value: string, setter: (v: string) => void) {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const ref = useRef(value);
   if (ref.current !== value) {
     ref.current = value;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -268,7 +268,8 @@ function formatDateRange(
 function getEnText(field: LocalizedText | string | undefined | null): string {
   if (!field) return "";
   if (typeof field === "string") return field;
-  return field.en || "";
+  const val = field.en || field.es;
+  return typeof val === "string" ? val : "";
 }
 
 export async function getProfile(): Promise<Profile | null> {


### PR DESCRIPTION
## Summary

- **Career-ops admin UX**: sources management, analytics tab, follow-up tracking, poll-now button with 1-hour cooldown, cron every 6h, cap raised to 60 new jobs/run
- **Inline source editing**: platform and identifier fields editable in-place from the sources list
- **Job detail page**: document history panel, QA section, one-page CV generation, cover letter copy button
- **Critical bug fix**: `getEnText` now guards against non-string `field.en` values — prevents the `Objects are not valid as a React child (found: object with keys {en, es})` production crash that caused intermittent 500s on fresh ISR renders

## Test plan

- [ ] `/en` homepage loads without 500 on a cold (non-cached) render — check Vercel function logs
- [ ] Admin `/admin/jobs` — kanban renders, sources tab shows all configured sources
- [ ] Poll Now button triggers a run; cooldown badge appears and blocks a second click for 1 hour
- [ ] Inline source edit: click platform/identifier field, change value, save — reflects immediately
- [ ] Job detail page: document history tab shows timeline; QA section loads; cover letter copy button copies text
- [ ] One-page CV generation completes without error (backend must be running)
- [ ] Localized field smoke test: visit `/en` and `/es` — no blank titles, no console errors about React children

🤖 Generated with [Claude Code](https://claude.com/claude-code)