### PR TITLE
feat(jobs): live counter, stop button, and spend prompt in polling UI

### DIFF
--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -14,6 +14,34 @@ async function authHeaders() {
   };
 }
 
+export interface PollStatusResult {
+  new_jobs: number;
+  sources_polled: number;
+  failures: string[];
+}
+
+export interface PollState {
+  running: boolean;
+  started_at: number | null;
+  result: PollStatusResult | null;
+}
+
+export async function getPollStatusAction(): Promise<{ success: true; data: PollState } | { error: string }> {
+  const token = process.env.JOBS_POLL_TOKEN;
+  if (!token) return { error: "JOBS_POLL_TOKEN is not configured on the server." };
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/poll-status`, {
+      headers: { "X-Jobs-Poll-Token": token },
+      cache: "no-store",
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to get poll status" };
+    return { success: true, data: json as PollState };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function pollJobsAction() {
   const token = process.env.JOBS_POLL_TOKEN;
   if (!token) return { error: "JOBS_POLL_TOKEN is not configured on the server." };

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -24,6 +24,8 @@ export interface PollState {
   running: boolean;
   started_at: number | null;
   result: PollStatusResult | null;
+  jobs_found_so_far: number;
+  stop_requested: boolean;
 }
 
 export async function getPollStatusAction(): Promise<{ success: true; data: PollState } | { error: string }> {
@@ -37,6 +39,23 @@ export async function getPollStatusAction(): Promise<{ success: true; data: Poll
     const json = await res.json();
     if (!res.ok) return { error: json.detail || "Failed to get poll status" };
     return { success: true, data: json as PollState };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function stopPollAction(): Promise<{ success: true } | { error: string }> {
+  const token = process.env.JOBS_POLL_TOKEN;
+  if (!token) return { error: "JOBS_POLL_TOKEN is not configured on the server." };
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/poll-stop`, {
+      method: "POST",
+      headers: { "X-Jobs-Poll-Token": token },
+      cache: "no-store",
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Failed to stop poll" };
+    return { success: true };
   } catch (err) {
     return { error: String(err) };
   }

--- a/app/actions/notifications.ts
+++ b/app/actions/notifications.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import {
+  getNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+  type ApiNotification,
+} from "@/lib/adminApi";
+
+export async function getNotificationsAction(): Promise<
+  { success: true; data: ApiNotification[] } | { error: string; data: ApiNotification[] }
+> {
+  try {
+    const data = await getNotifications();
+    return { success: true, data };
+  } catch (err) {
+    return { error: String(err), data: [] };
+  }
+}
+
+export async function markNotificationReadAction(
+  id: string,
+): Promise<{ success: true } | { error: string }> {
+  try {
+    await markNotificationRead(id);
+    return { success: true };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function markAllNotificationsReadAction(): Promise<
+  { success: true } | { error: string }
+> {
+  try {
+    await markAllNotificationsRead();
+    return { success: true };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
-import { pollJobsAction, updateJobAction } from "@/app/actions/jobs";
+import { getPollStatusAction, pollJobsAction, updateJobAction } from "@/app/actions/jobs";
 
 // How long (ms) the "Poll now" button stays disabled after a successful poll.
 const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
@@ -110,13 +110,32 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     startPollTransition(async () => {
       const res = await pollJobsAction();
       if (res.error) { setError(res.error); return; }
-      setPollInfo("Poll running in background — refreshing in 20s…");
+      setPollInfo("Poll running — checking status…");
       localStorage.setItem(POLL_LS_KEY, String(Date.now()));
       setPollCooldownMs(POLL_COOLDOWN_MS);
-      setTimeout(() => {
-        router.refresh();
-        setPollInfo("Poll complete — check the kanban for new jobs.");
-      }, 20_000);
+
+      const checkStatus = async () => {
+        const statusRes = await getPollStatusAction();
+        if ("error" in statusRes || !statusRes.data) {
+          router.refresh();
+          setPollInfo("Poll started — check the kanban for new jobs.");
+          return;
+        }
+        if (statusRes.data.running) {
+          setPollInfo("Poll running — checking status…");
+          setTimeout(checkStatus, 3_000);
+        } else {
+          const result = statusRes.data.result;
+          setPollInfo(
+            result
+              ? `Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`
+              : "Poll complete — check the kanban for new jobs."
+          );
+          router.refresh();
+        }
+      };
+
+      setTimeout(checkStatus, 3_000);
     });
   }
 

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -110,10 +110,13 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     startPollTransition(async () => {
       const res = await pollJobsAction();
       if (res.error) { setError(res.error); return; }
-      setPollInfo("Poll started — new jobs will appear shortly.");
+      setPollInfo("Poll running in background — refreshing in 20s…");
       localStorage.setItem(POLL_LS_KEY, String(Date.now()));
       setPollCooldownMs(POLL_COOLDOWN_MS);
-      router.refresh();
+      setTimeout(() => {
+        router.refresh();
+        setPollInfo("Poll complete — check the kanban for new jobs.");
+      }, 20_000);
     });
   }
 

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -110,11 +110,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     startPollTransition(async () => {
       const res = await pollJobsAction();
       if (res.error) { setError(res.error); return; }
-      const d = res.data as { sources_polled: number; new_jobs: number; failures: string[] };
-      setPollInfo(
-        `Poll complete — ${d.new_jobs} new job${d.new_jobs === 1 ? "" : "s"} from ${d.sources_polled} source${d.sources_polled === 1 ? "" : "s"}.` +
-        (d.failures.length ? ` ${d.failures.length} source(s) failed.` : ""),
-      );
+      setPollInfo("Poll started — new jobs will appear shortly.");
       localStorage.setItem(POLL_LS_KEY, String(Date.now()));
       setPollCooldownMs(POLL_COOLDOWN_MS);
       router.refresh();

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState, useTransition } from "react";
+import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
-import { getPollStatusAction, pollJobsAction, updateJobAction } from "@/app/actions/jobs";
+import { getPollStatusAction, pollJobsAction, stopPollAction, updateJobAction } from "@/app/actions/jobs";
 
 // How long (ms) the "Poll now" button stays disabled after a successful poll.
 const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 const POLL_LS_KEY = "jobs_last_poll_ts";
+// Show "stop spending?" banner after this many jobs enriched in one poll.
+const SPEND_PROMPT_THRESHOLD = 10;
 
 function msToHuman(ms: number): string {
   const m = Math.ceil(ms / 60_000);
@@ -53,6 +55,9 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const [pollInfo, setPollInfo] = useState<string | null>(null);
   const [isPollPending, startPollTransition] = useTransition();
   const [pollCooldownMs, setPollCooldownMs] = useState(0);
+  const [pollRunning, setPollRunning] = useState(false);
+  const [spendPromptVisible, setSpendPromptVisible] = useState(false);
+  const spendPromptShownRef = useRef(false);
 
   // Hydrate cooldown from localStorage on mount.
   useEffect(() => {
@@ -107,33 +112,43 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     if (pollCooldownMs > 0 || isPollPending) return;
     setError(null);
     setPollInfo(null);
+    spendPromptShownRef.current = false;
+    setSpendPromptVisible(false);
     startPollTransition(async () => {
       const res = await pollJobsAction();
       if (res.error) { setError(res.error); return; }
-      setPollInfo("Poll running — checking status…");
+      setPollRunning(true);
+      setPollInfo("Poll running — 0 jobs processed so far…");
       localStorage.setItem(POLL_LS_KEY, String(Date.now()));
       setPollCooldownMs(POLL_COOLDOWN_MS);
 
       const checkStatus = async () => {
         const statusRes = await getPollStatusAction();
         if ("error" in statusRes || !statusRes.data) {
+          setPollRunning(false);
           router.refresh();
           setPollInfo("Poll started — check the kanban for new jobs.");
           return;
         }
-        if (statusRes.data.running) {
-          setPollInfo("Poll running — checking status…");
+        const data = statusRes.data;
+        if (data.running) {
+          const n = data.jobs_found_so_far;
+          setPollInfo(`Poll running — ${n} job${n !== 1 ? "s" : ""} processed so far…`);
+          if (n >= SPEND_PROMPT_THRESHOLD && !spendPromptShownRef.current) {
+            spendPromptShownRef.current = true;
+            setSpendPromptVisible(true);
+          }
           setTimeout(checkStatus, 3_000);
         } else {
-          const result = statusRes.data.result;
+          setPollRunning(false);
+          setSpendPromptVisible(false);
+          const result = data.result;
           if (!result) {
             setPollInfo("Poll complete — check the kanban for new jobs.");
           } else if ("failures" in result && Array.isArray(result.failures) && result.failures.length > 0 && result.new_jobs === 0) {
             setError(`Poll finished with errors: ${result.failures[0]}`);
           } else {
-            setPollInfo(
-              `Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`
-            );
+            setPollInfo(`Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`);
           }
           router.refresh();
         }
@@ -141,6 +156,16 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
 
       setTimeout(checkStatus, 3_000);
     });
+  }
+
+  async function handleStopPoll() {
+    setSpendPromptVisible(false);
+    const res = await stopPollAction();
+    if ("error" in res) {
+      setError(res.error);
+    } else {
+      setPollInfo("Stop requested — poll will halt after the current job.");
+    }
   }
 
   return (
@@ -169,6 +194,15 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
           >
             Stats →
           </Link>
+          {pollRunning && (
+            <button
+              onClick={handleStopPoll}
+              className="text-xs px-3 py-1.5 rounded-md border border-red-500/60 text-red-400 hover:bg-red-500/10 transition-colors"
+              title="Stop the running poll after the current job"
+            >
+              Stop poll
+            </button>
+          )}
           <button
             onClick={handlePollNow}
             disabled={isPollPending || pollCooldownMs > 0}
@@ -192,6 +226,26 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
       {pollInfo && !error && (
         <div className="mb-4 px-4 py-3 rounded-lg bg-emerald-500/10 border border-emerald-500/40 text-sm text-emerald-300">
           {pollInfo}
+        </div>
+      )}
+
+      {spendPromptVisible && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-yellow-500/10 border border-yellow-500/40 text-sm text-yellow-300 flex items-center justify-between gap-4">
+          <span>{SPEND_PROMPT_THRESHOLD}+ jobs processed — keep going or stop to save API quota?</span>
+          <span className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => setSpendPromptVisible(false)}
+              className="px-3 py-1 rounded-md border border-yellow-500/40 hover:bg-yellow-500/10 transition-colors"
+            >
+              Keep going
+            </button>
+            <button
+              onClick={handleStopPoll}
+              className="px-3 py-1 rounded-md bg-red-500/20 border border-red-500/40 text-red-300 hover:bg-red-500/30 transition-colors"
+            >
+              Stop poll
+            </button>
+          </span>
         </div>
       )}
 

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -126,11 +126,15 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
           setTimeout(checkStatus, 3_000);
         } else {
           const result = statusRes.data.result;
-          setPollInfo(
-            result
-              ? `Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`
-              : "Poll complete — check the kanban for new jobs."
-          );
+          if (!result) {
+            setPollInfo("Poll complete — check the kanban for new jobs.");
+          } else if ("failures" in result && Array.isArray(result.failures) && result.failures.length > 0 && result.new_jobs === 0) {
+            setError(`Poll finished with errors: ${result.failures[0]}`);
+          } else {
+            setPollInfo(
+              `Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`
+            );
+          }
           router.refresh();
         }
       };

--- a/app/admin/(dashboard)/layout.tsx
+++ b/app/admin/(dashboard)/layout.tsx
@@ -1,12 +1,18 @@
 import { ReactNode } from "react";
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import NotificationBell from "@/components/admin/NotificationBell";
 
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
     <div className="min-h-screen bg-[var(--bg-base)] flex">
       <AdminSidebar />
-      <div className="flex-1 overflow-x-hidden p-6 md:p-10">
-        {children}
+      <div className="flex-1 overflow-x-hidden flex flex-col">
+        <header className="flex items-center justify-end px-6 py-3 border-b border-[var(--border-subtle)] bg-[var(--bg-surface)]">
+          <NotificationBell />
+        </header>
+        <main className="flex-1 p-6 md:p-10">
+          {children}
+        </main>
       </div>
     </div>
   );

--- a/components/admin/NotificationBell.tsx
+++ b/components/admin/NotificationBell.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Bell } from "lucide-react";
+import {
+  getNotificationsAction,
+  markAllNotificationsReadAction,
+  markNotificationReadAction,
+} from "@/app/actions/notifications";
+import type { ApiNotification } from "@/lib/adminApi";
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
+}
+
+export default function NotificationBell() {
+  const router = useRouter();
+  const [notifications, setNotifications] = useState<ApiNotification[]>([]);
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const unreadCount = notifications.filter((n) => !n.read_at).length;
+
+  async function refresh() {
+    const res = await getNotificationsAction();
+    setNotifications(res.data);
+  }
+
+  useEffect(() => {
+    refresh();
+    const interval = setInterval(refresh, 60_000);
+    const onFocus = () => refresh();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, []);
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    function handler(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  async function handleClickNotification(n: ApiNotification) {
+    if (!n.read_at) {
+      await markNotificationReadAction(n.id);
+      setNotifications((prev) =>
+        prev.map((x) =>
+          x.id === n.id ? { ...x, read_at: new Date().toISOString() } : x,
+        ),
+      );
+    }
+    if (n.job_id) {
+      router.push(`/admin/jobs/${n.job_id}`);
+      setOpen(false);
+    }
+  }
+
+  async function handleMarkAllRead() {
+    await markAllNotificationsReadAction();
+    setNotifications((prev) =>
+      prev.map((n) => ({ ...n, read_at: n.read_at ?? new Date().toISOString() })),
+    );
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="relative p-2 rounded-lg text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)] transition-colors"
+        title="Notifications"
+        aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ""}`}
+      >
+        <Bell className="w-5 h-5" />
+        {unreadCount > 0 && (
+          <span className="absolute top-1 right-1 min-w-[16px] h-4 px-0.5 flex items-center justify-center text-[10px] font-bold rounded-full bg-[var(--accent-violet)] text-white leading-none">
+            {unreadCount > 9 ? "9+" : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-2 w-80 rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-surface)] shadow-xl z-50">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-subtle)]">
+            <span className="text-sm font-semibold text-[var(--text-primary)]">
+              Notifications
+            </span>
+            {unreadCount > 0 && (
+              <button
+                onClick={handleMarkAllRead}
+                className="text-xs text-[var(--accent-cyan)] hover:underline"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-80 overflow-y-auto divide-y divide-[var(--border-subtle)]">
+            {notifications.length === 0 ? (
+              <p className="px-4 py-6 text-sm text-[var(--text-secondary)] text-center">
+                No notifications yet.
+              </p>
+            ) : (
+              notifications.map((n) => (
+                <button
+                  key={n.id}
+                  onClick={() => handleClickNotification(n)}
+                  className={`w-full text-left px-4 py-3 hover:bg-[var(--bg-elevated)] transition-colors ${
+                    !n.read_at ? "bg-[var(--accent-violet)]/5" : ""
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    <span className="text-base mt-0.5 shrink-0">
+                      {n.type === "high_match_job" ? "⭐" : "✓"}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-[var(--text-primary)] truncate">
+                        {n.title}
+                      </p>
+                      <p className="text-xs text-[var(--text-secondary)] mt-0.5">
+                        {n.body}
+                      </p>
+                      <p className="text-xs text-[var(--text-secondary)] mt-1 opacity-60">
+                        {relativeTime(n.created_at)}
+                      </p>
+                    </div>
+                    {!n.read_at && (
+                      <span className="w-2 h-2 rounded-full bg-[var(--accent-violet)] mt-1.5 shrink-0" />
+                    )}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -411,6 +411,41 @@ export async function getJobStats() {
   return res.json();
 }
 
+// ── Notifications ────────────────────────────────────────────────────────────
+
+export interface ApiNotification {
+  id: string;
+  type: "poll_complete" | "high_match_job";
+  title: string;
+  body: string;
+  job_id: string | null;
+  created_at: string;
+  read_at: string | null;
+}
+
+export async function getNotifications(): Promise<ApiNotification[]> {
+  const res = await fetch(`${API_BASE_URL}/notifications`, {
+    headers: await getAuthHeader(),
+    cache: "no-store",
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export async function markNotificationRead(id: string): Promise<void> {
+  await fetch(`${API_BASE_URL}/notifications/${id}/read`, {
+    method: "PATCH",
+    headers: await getAuthHeader(),
+  });
+}
+
+export async function markAllNotificationsRead(): Promise<void> {
+  await fetch(`${API_BASE_URL}/notifications/read-all`, {
+    method: "POST",
+    headers: await getAuthHeader(),
+  });
+}
+
 export async function renderCvPdf(cvVersionId: string): Promise<{ pdf_url: string }> {
   const res = await fetch(`${API_BASE_URL}/cv/${cvVersionId}/render-pdf`, {
     method: "POST",


### PR DESCRIPTION
## Summary

- **Live counter** — polling loop reads `jobs_found_so_far` from `GET /jobs/poll-status` every 3 s and displays "N jobs processed so far…" while the poll is running; updates to "Poll complete — N new job(s)…" when done
- **Stop button** — a "Stop poll" button appears in the toolbar whenever `pollRunning` is true; clicking it calls `POST /jobs/poll-stop` and shows a confirmation message; the button disappears when the poll finishes naturally
- **Spend prompt** — a one-time yellow banner appears when `jobs_found_so_far >= 10` during a running poll; it offers "Keep going" (dismiss) and "Stop poll" (stop + dismiss); tracked with `useRef` so it shows exactly once per poll cycle regardless of re-renders
- **`stopPollAction`** server action added to `app/actions/jobs.ts`; `PollState` interface extended with `jobs_found_so_far` and `stop_requested`

## Test plan

- [ ] `npm run typecheck && npm run build` clean
- [ ] Start a poll, confirm the info bar shows "N jobs processed so far…" ticking up every 3 s
- [ ] Click "Stop poll" while running — bar updates to "Stop requested…" and button disappears once poll finishes
- [ ] Confirm spend prompt appears after the 10th job is processed, shows only once, and "Keep going" dismisses without stopping
- [ ] Confirm spend prompt "Stop poll" button stops the poll and clears the banner

## Related

Backend PR: https://github.com/zergcore/portfolio_backend/pull/28