### PR TITLE
feat(jobs): discover and history admin pages + sources page upgrades

### DIFF
--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -14,10 +14,20 @@ async function authHeaders() {
   };
 }
 
+export interface PollSourceStat {
+  source: string;
+  fetched: number;
+  new: number;
+  error: boolean;
+  skipped?: boolean;
+}
+
 export interface PollStatusResult {
   new_jobs: number;
   sources_polled: number;
+  sources_skipped_today?: number;
   failures: string[];
+  source_stats?: PollSourceStat[];
 }
 
 export interface PollState {
@@ -257,6 +267,50 @@ export async function deleteJobSourceAction(id: string) {
     }
     revalidatePath("/admin/jobs/sources");
     return { success: true };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export interface SourceTestResult {
+  ok: boolean;
+  count: number;
+  sample: { title: string; company: string; url: string }[];
+  error: string;
+}
+
+export async function testJobSourceAction(id: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/sources/${id}/test`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Test failed" };
+    return { success: true, data: json as SourceTestResult };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export interface DiscoveryHit {
+  name: string;
+  platform: string;
+  slug: string;
+  jobs_count: number;
+  url: string;
+}
+
+export async function discoverSourcesAction(names: string[]) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover`, {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ names }),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Discovery failed" };
+    return { success: true, data: json as DiscoveryHit[] };
   } catch (err) {
     return { error: String(err) };
   }

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
-import { getPollStatusAction, pollJobsAction, stopPollAction, updateJobAction } from "@/app/actions/jobs";
+import { getPollStatusAction, pollJobsAction, stopPollAction, updateJobAction, PollSourceStat } from "@/app/actions/jobs";
 
 // How long (ms) the "Poll now" button stays disabled after a successful poll.
 const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
@@ -53,6 +53,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [pollInfo, setPollInfo] = useState<string | null>(null);
+  const [pollStats, setPollStats] = useState<PollSourceStat[] | null>(null);
   const [isPollPending, startPollTransition] = useTransition();
   const [pollCooldownMs, setPollCooldownMs] = useState(0);
   const [pollRunning, setPollRunning] = useState(false);
@@ -112,6 +113,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     if (pollCooldownMs > 0 || isPollPending) return;
     setError(null);
     setPollInfo(null);
+    setPollStats(null);
     spendPromptShownRef.current = false;
     setSpendPromptVisible(false);
     startPollTransition(async () => {
@@ -148,7 +150,12 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
           } else if ("failures" in result && Array.isArray(result.failures) && result.failures.length > 0 && result.new_jobs === 0) {
             setError(`Poll finished with errors: ${result.failures[0]}`);
           } else {
-            setPollInfo(`Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s).`);
+            const skipped = result.sources_skipped_today ?? 0;
+            const skipNote = skipped > 0 ? ` (${skipped} already polled today, skipped)` : "";
+            setPollInfo(`Poll complete — ${result.new_jobs} new job(s) from ${result.sources_polled} source(s)${skipNote}.`);
+            if (result.source_stats && result.source_stats.length > 0) {
+              setPollStats(result.source_stats);
+            }
           }
           router.refresh();
         }
@@ -225,7 +232,27 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
       )}
       {pollInfo && !error && (
         <div className="mb-4 px-4 py-3 rounded-lg bg-emerald-500/10 border border-emerald-500/40 text-sm text-emerald-300">
-          {pollInfo}
+          <p className="font-medium">{pollInfo}</p>
+          {pollStats && pollStats.length > 0 && (
+            <div className="mt-2 space-y-0.5">
+              {pollStats.map((s) => (
+                <p key={s.source} className="text-xs font-mono">
+                  <span className={s.error ? "text-red-400" : s.new > 0 ? "text-emerald-300" : "text-emerald-300/50"}>
+                    {s.error ? "✗" : s.skipped ? "–" : "✓"}
+                  </span>
+                  {" "}<span className="text-emerald-200/70">{s.source}</span>
+                  {" — "}
+                  {s.error
+                    ? "error"
+                    : s.skipped && (s as { skip_reason?: string }).skip_reason === "polled_today"
+                    ? "skipped — already polled today"
+                    : s.skipped
+                    ? `${s.fetched} fetched (budget exhausted)`
+                    : `${s.fetched} fetched, ${s.new} new`}
+                </p>
+              ))}
+            </div>
+          )}
         </div>
       )}
 

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -69,6 +69,13 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
     }
   }, []);
 
+  // Sync local jobs state when the server re-fetches (e.g. after router.refresh()
+  // following a poll). useState only reads its initial value on mount, so
+  // without this the kanban shows stale counts even after a successful refresh.
+  useEffect(() => {
+    setJobs(initialJobs);
+  }, [initialJobs]);
+
   // Tick down the cooldown every 30 s.
   useEffect(() => {
     if (pollCooldownMs <= 0) return;

--- a/app/admin/(dashboard)/jobs/discover/DiscoverClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/DiscoverClient.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiJobSource } from "@/lib/api";
+import {
+  DiscoveryHit,
+  discoverSourcesAction,
+  createJobSourceAction,
+} from "@/app/actions/jobs";
+
+const PLATFORM_COLOR: Record<string, string> = {
+  greenhouse:      "bg-emerald-500/15 text-emerald-300",
+  lever:           "bg-violet-500/15 text-violet-300",
+  ashby:           "bg-cyan-500/15 text-cyan-300",
+  recruitee:       "bg-yellow-500/15 text-yellow-300",
+  smartrecruiters: "bg-pink-500/15 text-pink-300",
+};
+
+type AddState = "idle" | "adding" | "added" | "error";
+
+export default function DiscoverClient({
+  existingSources,
+}: {
+  existingSources: ApiJobSource[];
+}) {
+  const router = useRouter();
+  const [input, setInput] = useState("Anthropic\nStripe\nLinear\nFrisbii\nContinental");
+  const [hits, setHits] = useState<DiscoveryHit[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [addState, setAddState] = useState<Record<string, AddState>>({});
+  const [addError, setAddError] = useState<Record<string, string>>({});
+
+  const existingKeys = useMemo(
+    () => new Set(existingSources.map((s) => `${s.platform}:${s.identifier.toLowerCase()}`)),
+    [existingSources],
+  );
+
+  const isAlreadyTracked = (hit: DiscoveryHit) =>
+    existingKeys.has(`${hit.platform}:${hit.slug.toLowerCase()}`);
+
+  async function handleDiscover() {
+    const names = input
+      .split("\n")
+      .map((n) => n.trim())
+      .filter(Boolean);
+    if (names.length === 0) {
+      setError("Paste at least one company name.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    setHits(null);
+    setAddState({});
+    setAddError({});
+    const res = await discoverSourcesAction(names);
+    setLoading(false);
+    if ("error" in res) {
+      setError(res.error);
+      return;
+    }
+    setHits(res.data);
+  }
+
+  async function handleAdd(hit: DiscoveryHit) {
+    const key = `${hit.platform}:${hit.slug}`;
+    setAddState((s) => ({ ...s, [key]: "adding" }));
+    setAddError((e) => ({ ...e, [key]: "" }));
+    const res = await createJobSourceAction({
+      platform: hit.platform,
+      identifier: hit.slug,
+      enabled: true,
+    });
+    if ("error" in res) {
+      setAddState((s) => ({ ...s, [key]: "error" }));
+      setAddError((e) => ({ ...e, [key]: res.error }));
+      return;
+    }
+    setAddState((s) => ({ ...s, [key]: "added" }));
+    router.refresh();
+  }
+
+  return (
+    <>
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-5">
+        <label className="block text-sm font-medium text-[var(--text-primary)] mb-2">
+          Company names (one per line)
+        </label>
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          rows={6}
+          spellCheck={false}
+          className="w-full bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-md px-3 py-2 text-sm font-mono text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-cyan)]"
+          placeholder="Anthropic&#10;Stripe&#10;Linear"
+        />
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            onClick={handleDiscover}
+            disabled={loading}
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--accent-cyan)] text-black font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {loading ? "Probing…" : "Discover"}
+          </button>
+          {error && <span className="text-sm text-red-300">{error}</span>}
+        </div>
+      </div>
+
+      {hits && (
+        <div className="mt-6">
+          <div className="mb-3 flex items-baseline justify-between">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">
+              Results
+            </h2>
+            <span className="text-sm text-[var(--text-secondary)]">
+              {hits.length} match{hits.length === 1 ? "" : "es"}
+            </span>
+          </div>
+
+          {hits.length === 0 ? (
+            <p className="text-sm text-[var(--text-secondary)] italic">
+              No matches on any known platform. Try alternate spellings or check
+              the company&apos;s careers page URL manually.
+            </p>
+          ) : (
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+              <table className="w-full text-sm">
+                <thead className="bg-[var(--bg-elevated)] text-[var(--text-secondary)] text-xs uppercase tracking-wide">
+                  <tr>
+                    <th className="px-4 py-2.5 text-left">Company</th>
+                    <th className="px-4 py-2.5 text-left">Platform</th>
+                    <th className="px-4 py-2.5 text-left">Slug</th>
+                    <th className="px-4 py-2.5 text-right">Open jobs</th>
+                    <th className="px-4 py-2.5 text-left">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {hits.map((hit) => {
+                    const key = `${hit.platform}:${hit.slug}`;
+                    const state = addState[key] ?? "idle";
+                    const tracked = isAlreadyTracked(hit);
+                    return (
+                      <tr
+                        key={key + ":" + hit.name}
+                        className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50"
+                      >
+                        <td className="px-4 py-3 font-medium text-[var(--text-primary)]">
+                          {hit.name}
+                        </td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`text-xs px-2 py-0.5 rounded-full font-semibold ${PLATFORM_COLOR[hit.platform] ?? "bg-[var(--border-strong)]/20 text-[var(--text-secondary)]"}`}
+                          >
+                            {hit.platform}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 font-mono text-xs text-[var(--text-secondary)]">
+                          <a
+                            href={hit.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-[var(--accent-cyan)]"
+                          >
+                            {hit.slug}
+                          </a>
+                        </td>
+                        <td className="px-4 py-3 text-right tabular-nums text-[var(--text-secondary)]">
+                          {hit.jobs_count}
+                        </td>
+                        <td className="px-4 py-3">
+                          {tracked ? (
+                            <span className="text-xs text-[var(--text-secondary)] italic">
+                              Already tracked
+                            </span>
+                          ) : state === "added" ? (
+                            <span className="text-xs text-emerald-300">✓ Added</span>
+                          ) : (
+                            <button
+                              onClick={() => handleAdd(hit)}
+                              disabled={state === "adding"}
+                              className="text-xs px-3 py-1 rounded border border-[var(--border-strong)] text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors disabled:opacity-50"
+                            >
+                              {state === "adding" ? "Adding…" : "Add as source"}
+                            </button>
+                          )}
+                          {state === "error" && addError[key] && (
+                            <div className="text-xs text-red-300 mt-1">
+                              {addError[key]}
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/admin/(dashboard)/jobs/discover/page.tsx
+++ b/app/admin/(dashboard)/jobs/discover/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { getAdminJobSources } from "@/lib/adminApi";
+import { ApiJobSource } from "@/lib/api";
+import DiscoverClient from "./DiscoverClient";
+
+export const revalidate = 0;
+
+export default async function DiscoverPage() {
+  const existing = (await getAdminJobSources()) as ApiJobSource[];
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <Link
+        href="/admin/jobs/sources"
+        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors"
+      >
+        ← Back to sources
+      </Link>
+      <div className="mb-8 mt-4">
+        <h1 className="text-3xl font-bold text-[var(--text-primary)]">Discover companies</h1>
+        <p className="text-[var(--text-secondary)] mt-2">
+          Paste company names — one per line — and we probe every known ATS
+          (Greenhouse, Lever, Ashby, Recruitee, SmartRecruiters) in parallel.
+          Each match is one click away from becoming a tracked source.
+        </p>
+      </div>
+
+      <DiscoverClient existingSources={existing} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/history/HistoryClient.tsx
+++ b/app/admin/(dashboard)/jobs/history/HistoryClient.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
+import { updateJobAction } from "@/app/actions/jobs";
+
+const STATUS_LABELS: Record<JobStatus, string> = {
+  prospected: "Prospected",
+  tailored: "Tailored",
+  applied: "Applied",
+  interviewing: "Interviewing",
+  offer: "Offer",
+  rejected: "Rejected",
+};
+
+const STATUS_COLOR: Record<JobStatus, string> = {
+  prospected: "bg-[var(--border-strong)]/20 text-[var(--text-secondary)]",
+  tailored:   "bg-violet-500/15 text-violet-300",
+  applied:    "bg-cyan-500/15 text-cyan-300",
+  interviewing: "bg-yellow-500/15 text-yellow-300",
+  offer:      "bg-emerald-500/15 text-emerald-300",
+  rejected:   "bg-red-500/15 text-red-300",
+};
+
+const HISTORY_STATUSES: JobStatus[] = ["tailored", "applied", "interviewing", "offer", "rejected"];
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short", day: "numeric", year: "numeric",
+  });
+}
+
+function scoreColor(score: number): string {
+  if (score >= 0.7) return "text-emerald-300";
+  if (score >= 0.4) return "text-yellow-300";
+  return "text-red-300";
+}
+
+export default function HistoryClient({ initialJobs }: { initialJobs: ApiJob[] }) {
+  const router = useRouter();
+  const [jobs, setJobs] = useState<ApiJob[]>(initialJobs);
+  const [statusFilter, setStatusFilter] = useState<JobStatus | "all">("all");
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const filtered = useMemo(
+    () => statusFilter === "all" ? jobs : jobs.filter((j) => j.status === statusFilter),
+    [jobs, statusFilter],
+  );
+
+  const counts = useMemo(() => {
+    const out: Partial<Record<JobStatus | "all", number>> = { all: jobs.length };
+    for (const s of HISTORY_STATUSES) {
+      out[s] = jobs.filter((j) => j.status === s).length;
+    }
+    return out;
+  }, [jobs]);
+
+  async function handleStatusChange(job: ApiJob, next: JobStatus) {
+    if (next === job.status) return;
+    setBusyId(job.id);
+    setError(null);
+    const res = await updateJobAction(job.id, { status: next });
+    setBusyId(null);
+    if (res.error) { setError(res.error); return; }
+    setJobs((prev) => prev.map((j) => j.id === job.id ? { ...j, status: next } : j));
+    router.refresh();
+  }
+
+  return (
+    <>
+      {/* Status filter tabs */}
+      <div className="mb-4 flex flex-wrap gap-2">
+        {(["all", ...HISTORY_STATUSES] as const).map((s) => (
+          <button
+            key={s}
+            onClick={() => setStatusFilter(s)}
+            className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
+              statusFilter === s
+                ? "border-[var(--accent-cyan)] text-[var(--accent-cyan)] bg-[var(--accent-cyan)]/10"
+                : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)]/50"
+            }`}
+          >
+            {s === "all" ? "All" : STATUS_LABELS[s]}
+            <span className="ml-1.5 opacity-60">{counts[s] ?? 0}</span>
+          </button>
+        ))}
+      </div>
+
+      {error && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-red-500/10 border border-red-500/40 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-[var(--bg-elevated)] text-[var(--text-secondary)] text-xs uppercase tracking-wide">
+            <tr>
+              <th className="px-4 py-2.5 text-left">Job</th>
+              <th className="px-4 py-2.5 text-left">Source</th>
+              <th className="px-4 py-2.5 text-left">Score</th>
+              <th className="px-4 py-2.5 text-left">Status</th>
+              <th className="px-4 py-2.5 text-left">Applied</th>
+              <th className="px-4 py-2.5 text-left">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="px-4 py-8 text-center text-[var(--text-secondary)] italic">
+                  No jobs here yet. Generate a CV or answer a question for any pipeline job to start tracking.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((job) => (
+                <tr
+                  key={job.id}
+                  className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50"
+                >
+                  {/* Title + company */}
+                  <td className="px-4 py-3 max-w-xs">
+                    <a
+                      href={job.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="font-medium text-[var(--text-primary)] hover:text-[var(--accent-cyan)] transition-colors leading-snug block"
+                    >
+                      {job.title}
+                    </a>
+                    <span className="text-xs text-[var(--text-secondary)]">{job.company}</span>
+                    {job.location && (
+                      <span className="text-xs text-[var(--text-secondary)]"> · {job.location}</span>
+                    )}
+                  </td>
+
+                  {/* Source */}
+                  <td className="px-4 py-3 text-xs text-[var(--text-secondary)] font-mono whitespace-nowrap">
+                    {job.source}
+                  </td>
+
+                  {/* Match score */}
+                  <td className="px-4 py-3">
+                    <span className={`text-xs font-semibold ${scoreColor(job.match_score)}`}>
+                      {(job.match_score * 100).toFixed(0)}%
+                    </span>
+                  </td>
+
+                  {/* Status selector */}
+                  <td className="px-4 py-3">
+                    <select
+                      value={job.status}
+                      disabled={busyId === job.id}
+                      onChange={(e) => handleStatusChange(job, e.target.value as JobStatus)}
+                      className={`text-xs px-2 py-1 rounded-full border-0 font-semibold cursor-pointer disabled:opacity-50 ${STATUS_COLOR[job.status]}`}
+                    >
+                      {JOB_STATUSES.map((s) => (
+                        <option key={s} value={s}>{STATUS_LABELS[s]}</option>
+                      ))}
+                    </select>
+                  </td>
+
+                  {/* Applied at */}
+                  <td className="px-4 py-3 text-xs text-[var(--text-secondary)] whitespace-nowrap">
+                    {formatDate(job.applied_at)}
+                  </td>
+
+                  {/* Updated at */}
+                  <td className="px-4 py-3 text-xs text-[var(--text-secondary)] whitespace-nowrap">
+                    {formatDate(job.updated_at)}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/app/admin/(dashboard)/jobs/history/HistoryClient.tsx
+++ b/app/admin/(dashboard)/jobs/history/HistoryClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
 import { updateJobAction } from "@/app/actions/jobs";
@@ -44,6 +44,11 @@ export default function HistoryClient({ initialJobs }: { initialJobs: ApiJob[] }
   const [statusFilter, setStatusFilter] = useState<JobStatus | "all">("all");
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Resync when the server re-fetches (e.g. after a status change triggers refresh).
+  useEffect(() => {
+    setJobs(initialJobs);
+  }, [initialJobs]);
 
   const filtered = useMemo(
     () => statusFilter === "all" ? jobs : jobs.filter((j) => j.status === statusFilter),

--- a/app/admin/(dashboard)/jobs/history/page.tsx
+++ b/app/admin/(dashboard)/jobs/history/page.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { getAdminJobHistory } from "@/lib/adminApi";
+import { ApiJob } from "@/lib/api";
+import HistoryClient from "./HistoryClient";
+
+export const revalidate = 0;
+
+export default async function JobHistoryPage() {
+  const jobs = (await getAdminJobHistory()) as ApiJob[];
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-[var(--text-primary)]">
+            Application History
+          </h1>
+          <p className="text-[var(--text-secondary)] mt-2">
+            Every job you have tailored or applied to, most recent activity first.
+          </p>
+        </div>
+        <Link
+          href="/admin/jobs"
+          className="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+        >
+          ← Pipeline
+        </Link>
+      </div>
+
+      <HistoryClient initialJobs={jobs} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/page.tsx
+++ b/app/admin/(dashboard)/jobs/page.tsx
@@ -20,12 +20,26 @@ export default async function AdminJobsPage() {
             through the pipeline and generate tailored applications.
           </p>
         </div>
-        <Link
-          href="/admin/jobs/sources"
-          className="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
-        >
-          Manage sources
-        </Link>
+        <div className="flex gap-2 shrink-0">
+          <Link
+            href="/admin/jobs/history"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+          >
+            History
+          </Link>
+          <Link
+            href="/admin/jobs/discover"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+          >
+            Discover
+          </Link>
+          <Link
+            href="/admin/jobs/sources"
+            className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+          >
+            Manage sources
+          </Link>
+        </div>
       </div>
 
       <JobsClient initialJobs={jobs} />

--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { Fragment, FormEvent, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ApiJobPlatform, ApiJobSource } from "@/lib/api";
 import {
   createJobSourceAction,
   deleteJobSourceAction,
+  SourceTestResult,
+  testJobSourceAction,
   updateJobSourceAction,
 } from "@/app/actions/jobs";
 
@@ -25,10 +27,35 @@ const PLATFORM_HELP: Record<string, { desc: string; verifyUrl: string; example: 
     verifyUrl: "https://jobs.ashbyhq.com/{slug}",
     example: "linear",
   },
+  workable: {
+    desc: "Global job board feed (jobs.workable.com). Identifier is a search query (e.g. \"python remote\", \"frontend\").",
+    verifyUrl: "https://jobs.workable.com/search?query={slug}",
+    example: "python remote",
+  },
   remoteok: {
     desc: "Tag-based aggregator. Comma-separate multiple tags in one source: react.js,next.js",
     verifyUrl: "https://remoteok.com/remote-{slug}-jobs",
     example: "python",
+  },
+  remotive: {
+    desc: "Remote-only aggregator. Identifier is a category slug.",
+    verifyUrl: "https://remotive.com/remote-jobs/{slug}",
+    example: "software-dev",
+  },
+  jobicy: {
+    desc: "Remote-only aggregator. Identifier is a job tag (single tag per source).",
+    verifyUrl: "https://jobicy.com/?s={slug}",
+    example: "python",
+  },
+  recruitee: {
+    desc: "Per-company subdomain board. Only works if the company has the public board enabled (most do).",
+    verifyUrl: "https://{slug}.recruitee.com/",
+    example: "frisbii",
+  },
+  smartrecruiters: {
+    desc: "Used by Continental, IKEA, Bosch, and thousands of enterprises. Identifier is the company name (case-sensitive).",
+    verifyUrl: "https://careers.smartrecruiters.com/{slug}",
+    example: "Continental",
   },
 };
 
@@ -43,15 +70,29 @@ const RECOMMENDED: { platform: string; identifier: string; note: string }[] = [
   { platform: "ashby",      identifier: "vercel",       note: "Vercel" },
   { platform: "lever",      identifier: "plaid",        note: "Plaid" },
   { platform: "lever",      identifier: "reddit",       note: "Reddit" },
-  { platform: "remoteok",   identifier: "python",       note: "All remote Python jobs" },
-  { platform: "remoteok",   identifier: "ai",           note: "All remote AI/ML jobs" },
-  { platform: "remoteok",   identifier: "typescript",   note: "All remote TypeScript jobs" },
+  { platform: "workable",   identifier: "python remote",   note: "Workable: Python remote" },
+  { platform: "workable",   identifier: "frontend",        note: "Workable: Frontend" },
+  { platform: "remoteok",   identifier: "python",       note: "Remote Python jobs" },
+  { platform: "remoteok",   identifier: "ai",           note: "Remote AI/ML jobs" },
+  { platform: "remoteok",   identifier: "typescript",   note: "Remote TypeScript jobs" },
+  { platform: "remotive",   identifier: "software-dev", note: "Remotive Software Dev" },
+  { platform: "remotive",   identifier: "devops-sysadmin", note: "Remotive DevOps" },
+  { platform: "jobicy",          identifier: "python",    note: "Jobicy Python" },
+  { platform: "jobicy",          identifier: "react",     note: "Jobicy React" },
+  { platform: "smartrecruiters", identifier: "Continental", note: "Continental (SR)" },
+  { platform: "smartrecruiters", identifier: "IKEA",        note: "IKEA (SR)" },
 ];
 
 interface EditState {
   id: string;
   platform: string;
   identifier: string;
+}
+
+interface TestState {
+  id: string;
+  result: SourceTestResult | null;
+  error: string;
 }
 
 export default function SourcesClient({
@@ -69,6 +110,7 @@ export default function SourcesClient({
   const [error, setError] = useState<string | null>(null);
   const [showHelp, setShowHelp] = useState(sources.length === 0);
   const [editing, setEditing] = useState<EditState | null>(null);
+  const [testState, setTestState] = useState<TestState | null>(null);
 
   const platformInfo = PLATFORM_HELP[platform];
   const existingKeys = new Set(sources.map((s) => `${s.platform}/${s.identifier}`));
@@ -119,6 +161,7 @@ export default function SourcesClient({
   function startEdit(src: ApiJobSource) {
     setEditing({ id: src.id, platform: src.platform, identifier: src.identifier });
     setError(null);
+    setTestState(null);
   }
 
   function cancelEdit() {
@@ -155,7 +198,21 @@ export default function SourcesClient({
     if (res.error) { setError(res.error); return; }
     setSources((prev) => prev.filter((s) => s.id !== src.id));
     if (editing?.id === src.id) setEditing(null);
+    if (testState?.id === src.id) setTestState(null);
     router.refresh();
+  }
+
+  async function onTest(src: ApiJobSource) {
+    setBusy(`test-${src.id}`);
+    setTestState({ id: src.id, result: null, error: "" });
+    setError(null);
+    const res = await testJobSourceAction(src.id);
+    setBusy(null);
+    if (res.error) {
+      setTestState({ id: src.id, result: null, error: res.error });
+      return;
+    }
+    setTestState({ id: src.id, result: res.data as SourceTestResult, error: "" });
   }
 
   return (
@@ -299,7 +356,9 @@ export default function SourcesClient({
             ) : (
               sources.map((s) => {
                 const isEditing = editing?.id === s.id;
-                const isBusy = busy === s.id || busy === `edit-${s.id}`;
+                const isBusy = busy === s.id || busy === `edit-${s.id}` || busy === `test-${s.id}`;
+                const isTesting = busy === `test-${s.id}`;
+                const testResult = testState?.id === s.id ? testState : null;
 
                 if (isEditing) {
                   return (
@@ -356,41 +415,78 @@ export default function SourcesClient({
                 }
 
                 return (
-                  <tr key={s.id} className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50">
-                    <td className="px-4 py-2 text-[var(--text-primary)]">{s.platform}</td>
-                    <td className="px-4 py-2 text-[var(--text-primary)] font-mono">{s.identifier}</td>
-                    <td className="px-4 py-2">
-                      <button
-                        onClick={() => toggleEnabled(s)}
-                        disabled={isBusy}
-                        className={`text-xs px-2 py-0.5 rounded-full ${
-                          s.enabled
-                            ? "bg-emerald-500/15 text-emerald-300"
-                            : "bg-red-500/15 text-red-300"
-                        } disabled:opacity-50`}
-                      >
-                        {s.enabled ? "enabled" : "disabled"}
-                      </button>
-                    </td>
-                    <td className="px-4 py-2 text-right">
-                      <span className="inline-flex gap-3">
+                  <Fragment key={s.id}>
+                    <tr className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50">
+                      <td className="px-4 py-2 text-[var(--text-primary)]">{s.platform}</td>
+                      <td className="px-4 py-2 text-[var(--text-primary)] font-mono">{s.identifier}</td>
+                      <td className="px-4 py-2">
                         <button
-                          onClick={() => startEdit(s)}
-                          disabled={isBusy || !!editing}
-                          className="text-xs text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] disabled:opacity-40 transition-colors"
+                          onClick={() => toggleEnabled(s)}
+                          disabled={isBusy}
+                          className={`text-xs px-2 py-0.5 rounded-full ${
+                            s.enabled
+                              ? "bg-emerald-500/15 text-emerald-300"
+                              : "bg-red-500/15 text-red-300"
+                          } disabled:opacity-50`}
                         >
-                          Edit
+                          {s.enabled ? "enabled" : "disabled"}
                         </button>
-                        <button
-                          onClick={() => onDelete(s)}
-                          disabled={isBusy || !!editing}
-                          className="text-xs text-red-300 hover:text-red-200 disabled:opacity-40 transition-colors"
-                        >
-                          Delete
-                        </button>
-                      </span>
-                    </td>
-                  </tr>
+                      </td>
+                      <td className="px-4 py-2 text-right">
+                        <span className="inline-flex gap-3">
+                          <button
+                            onClick={() => onTest(s)}
+                            disabled={isBusy || !!editing}
+                            className="text-xs text-[var(--accent-cyan)] hover:text-[var(--accent-cyan)]/80 disabled:opacity-40 transition-colors"
+                          >
+                            {isTesting ? "Testing…" : "Test"}
+                          </button>
+                          <button
+                            onClick={() => startEdit(s)}
+                            disabled={isBusy || !!editing}
+                            className="text-xs text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] disabled:opacity-40 transition-colors"
+                          >
+                            Edit
+                          </button>
+                          <button
+                            onClick={() => onDelete(s)}
+                            disabled={isBusy || !!editing}
+                            className="text-xs text-red-300 hover:text-red-200 disabled:opacity-40 transition-colors"
+                          >
+                            Delete
+                          </button>
+                        </span>
+                      </td>
+                    </tr>
+                    {testResult && (
+                      <tr className="border-t border-[var(--border-subtle)] bg-[var(--bg-elevated)]/40">
+                        <td colSpan={4} className="px-4 py-3">
+                          {testResult.error ? (
+                            <p className="text-xs text-red-300">Test error: {testResult.error}</p>
+                          ) : testResult.result ? (
+                            <div className="space-y-1.5">
+                              <p className="text-xs text-[var(--text-secondary)]">
+                                <span className={testResult.result.ok ? "text-emerald-300" : "text-red-300"}>
+                                  {testResult.result.ok ? "✓" : "✗"}
+                                </span>
+                                {" "}{testResult.result.count} job{testResult.result.count !== 1 ? "s" : ""} found
+                                {testResult.result.sample.length > 0 && " · sample:"}
+                              </p>
+                              {testResult.result.sample.map((j, i) => (
+                                <p key={i} className="text-xs text-[var(--text-secondary)] pl-3">
+                                  <a href={j.url} target="_blank" rel="noopener noreferrer"
+                                     className="text-[var(--accent-cyan)] hover:underline">
+                                    {j.title}
+                                  </a>
+                                  {" @ "}{j.company}
+                                </p>
+                              ))}
+                            </div>
+                          ) : null}
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
                 );
               })
             )}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -366,6 +366,15 @@ export async function getAdminJobs(params?: {
   return res.json();
 }
 
+export async function getAdminJobHistory() {
+  const res = await fetch(`${API_BASE_URL}/jobs/history`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return [];
+  return res.json();
+}
+
 export async function getAdminJobCvVersions(id: string) {
   const res = await fetch(`${API_BASE_URL}/jobs/${id}/cv-versions`, {
     headers: await getAuthHeader(),


### PR DESCRIPTION
## Summary

Frontend half of chunk 16 (`docs/plan/16-jobs-discovery-and-tracking.md`). Three new/upgraded admin surfaces backed by the companion backend PR:

- **`/admin/jobs/discover`** — paste company names → one-click "Add as source". Hits `POST /jobs/discover` and dedupes against already-tracked sources inline.
- **`/admin/jobs/history`** — every job tailored/applied/etc., status filter tabs, inline status dropdown. Sourced from new `GET /jobs/history` and includes pasted-JD entries thanks to backend intent tracking.
- **`/admin/jobs/sources`** — per-row Test button (dry-run fetch w/ sample); Fragment key fix; PLATFORM_HELP and RECOMMENDED rows updated for the 5 new adapters (workable identifier changed: now a search query, not a company shortcode).
- **`/admin/jobs`** — header gains History · Discover · Manage sources buttons; per-source poll breakdown rendered after a poll completes.

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] Navigate `/admin/jobs` → Discover → paste `Anthropic, Stripe, Linear, Frisbii, Continental` → results table shows ~5 hits, Add-as-source works on each.
- [ ] Navigate `/admin/jobs` → History → empty until you tailor a job; after CV-from-paste, the pasted JD appears with status "Tailored".
- [ ] On `/admin/jobs/sources`, click Test on a real row; sample jobs render inline.
- [ ] Click Poll now twice; the second click shows the skip count and per-source breakdown.

## Companion PRs

- Backend: zergcore/portfolio_backend#29
- Extension: zergcore/portfolio-browser-extension (separate PR in this push)