### PR TITLE
feat(jobs): category picker, load-more pagination, discovery inbox

### DIFF
--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -358,11 +358,27 @@ export interface CataloguePlatform {
   notes: string;
 }
 
+export interface ProviderStatus {
+  name: string;
+  display_name: string;
+  page_size: number;
+  pages_per_platform: number;
+  free_tier_per_day: number;
+  requires_billing: boolean;
+  query_budget_per_run: number;
+  configured: boolean;
+  env_vars: string[];
+  setup_steps: string[];
+  setup_links: { label: string; url: string }[];
+}
+
 export interface DiscoveryCatalogue {
   platforms: CataloguePlatform[];
   harvest_query_budget?: number;
   harvest_cooldown_seconds?: number;
-  google_cse_free_tier_per_day?: number;
+  providers?: ProviderStatus[];
+  active_provider?: string | null;
+  active_free_tier_per_day?: number | null;
 }
 
 export async function getDiscoveryCatalogueAction() {

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -92,6 +92,25 @@ export async function pollJobsAction() {
   }
 }
 
+export async function loadMoreJobsAction(offset: number, limit: number = 500) {
+  try {
+    const url = new URL(`${API_BASE_URL}/jobs`);
+    url.searchParams.set("limit", String(limit));
+    url.searchParams.set("offset", String(offset));
+    const res = await fetch(url.toString(), {
+      headers: await authHeaders(),
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { error: json.detail || "Failed to load more jobs" };
+    }
+    return { success: true, data: await res.json() };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function updateJobAction(
   id: string,
   data: { status?: string; cover_letter_text?: string | null; notes?: string | null; follow_up_at?: string | null },
@@ -311,6 +330,81 @@ export async function discoverSourcesAction(names: string[]) {
     const json = await res.json();
     if (!res.ok) return { error: json.detail || "Discovery failed" };
     return { success: true, data: json as DiscoveryHit[] };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export interface DiscoveredSourceRow {
+  id: string;
+  platform: string;
+  slug: string;
+  hint: string | null;
+  discovered_at: string;
+  last_seen_at: string;
+  times_seen: number;
+  dismissed_at: string | null;
+  promoted_source_id: string | null;
+}
+
+export async function harvestInboxAction() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover/harvest`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Harvest failed" };
+    return { success: true, data: json as Record<string, unknown> };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function listDiscoveryInboxAction() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover/inbox`, {
+      headers: await authHeaders(),
+      cache: "no-store",
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { error: json.detail || "Failed to load inbox" };
+    }
+    return { success: true, data: (await res.json()) as DiscoveredSourceRow[] };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function promoteDiscoveredAction(id: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover/inbox/${id}/promote`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    const json = await res.json();
+    if (!res.ok) return { error: json.detail || "Promote failed" };
+    revalidatePath("/admin/jobs/sources");
+    revalidatePath("/admin/jobs/discover/inbox");
+    return { success: true, data: json };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
+export async function dismissDiscoveredAction(id: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover/inbox/${id}/dismiss`, {
+      method: "POST",
+      headers: await authHeaders(),
+    });
+    if (!res.ok && res.status !== 204) {
+      const json = await res.json().catch(() => ({}));
+      return { error: json.detail || "Dismiss failed" };
+    }
+    revalidatePath("/admin/jobs/discover/inbox");
+    return { success: true };
   } catch (err) {
     return { error: String(err) };
   }

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -360,6 +360,9 @@ export interface CataloguePlatform {
 
 export interface DiscoveryCatalogue {
   platforms: CataloguePlatform[];
+  harvest_query_budget?: number;
+  harvest_cooldown_seconds?: number;
+  google_cse_free_tier_per_day?: number;
 }
 
 export async function getDiscoveryCatalogueAction() {
@@ -378,13 +381,24 @@ export async function getDiscoveryCatalogueAction() {
   }
 }
 
-export async function harvestInboxAction() {
+export async function harvestInboxAction(force = false) {
   try {
-    const res = await fetch(`${API_BASE_URL}/jobs/discover/harvest`, {
+    const url = new URL(`${API_BASE_URL}/jobs/discover/harvest`);
+    if (force) url.searchParams.set("force", "true");
+    const res = await fetch(url.toString(), {
       method: "POST",
       headers: await authHeaders(),
     });
     const json = await res.json();
+    if (res.status === 429) {
+      // Backend cooldown — surface the structured detail so the UI can offer override.
+      const detail = json.detail ?? {};
+      return {
+        error: detail.message || "Harvest cooldown active",
+        cooldown: true,
+        cooldownSecondsRemaining: detail.cooldown_seconds_remaining ?? 0,
+      };
+    }
     if (!res.ok) return { error: json.detail || "Harvest failed" };
     return { success: true, data: json as Record<string, unknown> };
   } catch (err) {

--- a/app/actions/jobs.ts
+++ b/app/actions/jobs.ts
@@ -347,6 +347,37 @@ export interface DiscoveredSourceRow {
   promoted_source_id: string | null;
 }
 
+export interface CataloguePlatform {
+  code: string;
+  display_name: string;
+  kind: "company_slug" | "search_query" | "tag" | "category";
+  has_adapter: boolean;
+  host_pattern: string | null;
+  slug_regex: string | null;
+  docs_url: string;
+  notes: string;
+}
+
+export interface DiscoveryCatalogue {
+  platforms: CataloguePlatform[];
+}
+
+export async function getDiscoveryCatalogueAction() {
+  try {
+    const res = await fetch(`${API_BASE_URL}/jobs/discover/catalogue`, {
+      headers: await authHeaders(),
+      cache: "force-cache",
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { error: json.detail || "Failed to load catalogue" };
+    }
+    return { success: true, data: (await res.json()) as DiscoveryCatalogue };
+  } catch (err) {
+    return { error: String(err) };
+  }
+}
+
 export async function harvestInboxAction() {
   try {
     const res = await fetch(`${API_BASE_URL}/jobs/discover/harvest`, {

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -4,13 +4,15 @@ import { useEffect, useMemo, useRef, useState, useTransition } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ApiJob, JOB_STATUSES, JobStatus } from "@/lib/api";
-import { getPollStatusAction, pollJobsAction, stopPollAction, updateJobAction, PollSourceStat } from "@/app/actions/jobs";
+import { getPollStatusAction, loadMoreJobsAction, pollJobsAction, stopPollAction, updateJobAction, PollSourceStat } from "@/app/actions/jobs";
 
 // How long (ms) the "Poll now" button stays disabled after a successful poll.
 const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 const POLL_LS_KEY = "jobs_last_poll_ts";
 // Show "stop spending?" banner after this many jobs enriched in one poll.
 const SPEND_PROMPT_THRESHOLD = 10;
+// Each "Load more" call fetches this many additional rows from the server.
+const LOAD_MORE_BATCH = 500;
 
 function msToHuman(ms: number): string {
   const m = Math.ceil(ms / 60_000);
@@ -59,6 +61,9 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const [pollRunning, setPollRunning] = useState(false);
   const [spendPromptVisible, setSpendPromptVisible] = useState(false);
   const spendPromptShownRef = useRef(false);
+  // Pagination — initialJobs is the first page (500 max from server).
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [exhausted, setExhausted] = useState(initialJobs.length < LOAD_MORE_BATCH);
 
   // Hydrate cooldown from localStorage on mount.
   useEffect(() => {
@@ -74,7 +79,30 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   // without this the kanban shows stale counts even after a successful refresh.
   useEffect(() => {
     setJobs(initialJobs);
+    setExhausted(initialJobs.length < LOAD_MORE_BATCH);
   }, [initialJobs]);
+
+  async function handleLoadMore() {
+    setLoadingMore(true);
+    setError(null);
+    const res = await loadMoreJobsAction(jobs.length, LOAD_MORE_BATCH);
+    setLoadingMore(false);
+    if ("error" in res) {
+      setError(res.error);
+      return;
+    }
+    const next = res.data as ApiJob[];
+    if (next.length === 0) {
+      setExhausted(true);
+      return;
+    }
+    // Server orders by match_score desc then created_at desc, but the user may
+    // have updated jobs locally. Merge on id to avoid duplicate cards.
+    const ids = new Set(jobs.map((j) => j.id));
+    const merged = [...jobs, ...next.filter((j) => !ids.has(j.id))];
+    setJobs(merged);
+    if (next.length < LOAD_MORE_BATCH) setExhausted(true);
+  }
 
   // Tick down the cooldown every 30 s.
   useEffect(() => {
@@ -361,6 +389,26 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
             </div>
           </section>
         ))}
+      </div>
+
+      <div className="mt-6 flex items-center justify-center gap-3 text-sm">
+        <span className="text-[var(--text-secondary)]">
+          Showing {jobs.length.toLocaleString()} job{jobs.length === 1 ? "" : "s"}
+        </span>
+        {!exhausted && (
+          <button
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="px-4 py-1.5 rounded-md border border-[var(--border-strong)] text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors disabled:opacity-50"
+          >
+            {loadingMore ? "Loading…" : `Load ${LOAD_MORE_BATCH} more`}
+          </button>
+        )}
+        {exhausted && jobs.length >= LOAD_MORE_BATCH && (
+          <span className="text-xs text-[var(--text-secondary)] italic">
+            (all loaded)
+          </span>
+        )}
       </div>
     </>
   );

--- a/app/admin/(dashboard)/jobs/discover/DiscoverClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/DiscoverClient.tsx
@@ -8,6 +8,7 @@ import {
   discoverSourcesAction,
   createJobSourceAction,
 } from "@/app/actions/jobs";
+import categories from "@/data/discover_categories.json";
 
 const PLATFORM_COLOR: Record<string, string> = {
   greenhouse:      "bg-emerald-500/15 text-emerald-300",
@@ -19,6 +20,14 @@ const PLATFORM_COLOR: Record<string, string> = {
 
 type AddState = "idle" | "adding" | "added" | "error";
 
+interface Category {
+  label: string;
+  description: string;
+  companies: string[];
+}
+type CategoryMap = Record<string, Category>;
+const CATEGORIES = categories as CategoryMap;
+
 export default function DiscoverClient({
   existingSources,
 }: {
@@ -26,6 +35,7 @@ export default function DiscoverClient({
 }) {
   const router = useRouter();
   const [input, setInput] = useState("Anthropic\nStripe\nLinear\nFrisbii\nContinental");
+  const [categoryKey, setCategoryKey] = useState<string>("");
   const [hits, setHits] = useState<DiscoveryHit[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -84,13 +94,42 @@ export default function DiscoverClient({
   return (
     <>
       <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-5">
-        <label className="block text-sm font-medium text-[var(--text-primary)] mb-2">
-          Company names (one per line)
-        </label>
+        <div className="flex items-baseline justify-between mb-2 gap-3">
+          <label className="block text-sm font-medium text-[var(--text-primary)]">
+            Company names (one per line)
+          </label>
+          <div className="flex items-center gap-2">
+            <label className="text-xs text-[var(--text-secondary)]" htmlFor="discover-category">
+              Quick-fill
+            </label>
+            <select
+              id="discover-category"
+              value={categoryKey}
+              onChange={(e) => {
+                const k = e.target.value;
+                setCategoryKey(k);
+                if (k && CATEGORIES[k]) setInput(CATEGORIES[k].companies.join("\n"));
+              }}
+              className="text-xs bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-cyan)]"
+            >
+              <option value="">— pick a category —</option>
+              {Object.entries(CATEGORIES).map(([k, c]) => (
+                <option key={k} value={k} title={c.description}>
+                  {c.label} ({c.companies.length})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        {categoryKey && CATEGORIES[categoryKey] && (
+          <p className="mb-2 text-xs text-[var(--text-secondary)] italic">
+            {CATEGORIES[categoryKey].description}
+          </p>
+        )}
         <textarea
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          rows={6}
+          rows={8}
           spellCheck={false}
           className="w-full bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-md px-3 py-2 text-sm font-mono text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-cyan)]"
           placeholder="Anthropic&#10;Stripe&#10;Linear"

--- a/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  DiscoveredSourceRow,
+  dismissDiscoveredAction,
+  harvestInboxAction,
+  listDiscoveryInboxAction,
+  promoteDiscoveredAction,
+} from "@/app/actions/jobs";
+
+const PLATFORM_COLOR: Record<string, string> = {
+  greenhouse:      "bg-emerald-500/15 text-emerald-300",
+  lever:           "bg-violet-500/15 text-violet-300",
+  ashby:           "bg-cyan-500/15 text-cyan-300",
+  recruitee:       "bg-yellow-500/15 text-yellow-300",
+  smartrecruiters: "bg-pink-500/15 text-pink-300",
+};
+
+type RowState = "idle" | "promoting" | "dismissing" | "done";
+
+export default function InboxClient() {
+  const [rows, setRows] = useState<DiscoveredSourceRow[] | null>(null);
+  const [error, setError] = useState("");
+  const [harvestSummary, setHarvestSummary] = useState<string | null>(null);
+  const [harvesting, setHarvesting] = useState(false);
+  const [rowState, setRowState] = useState<Record<string, RowState>>({});
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  async function refresh() {
+    const res = await listDiscoveryInboxAction();
+    if ("error" in res) {
+      setError(res.error);
+      setRows([]);
+      return;
+    }
+    setRows(res.data);
+  }
+
+  async function handleHarvest() {
+    setHarvesting(true);
+    setError("");
+    setHarvestSummary(null);
+    const res = await harvestInboxAction();
+    setHarvesting(false);
+    if ("error" in res) {
+      setError(res.error);
+      return;
+    }
+    const data = res.data;
+    if (data.skipped === "google_cse_creds_missing") {
+      setHarvestSummary(
+        "Skipped: set GOOGLE_CSE_KEY and GOOGLE_CSE_CX on the backend to enable bulk harvest.",
+      );
+      return;
+    }
+    const parts: string[] = [];
+    for (const [platform, stats] of Object.entries(data)) {
+      const s = stats as { seen: number; new: number };
+      parts.push(`${platform}: ${s.new} new (${s.seen} seen)`);
+    }
+    setHarvestSummary(parts.join(" · "));
+    await refresh();
+  }
+
+  async function handlePromote(id: string) {
+    setRowState((m) => ({ ...m, [id]: "promoting" }));
+    const res = await promoteDiscoveredAction(id);
+    if ("error" in res) {
+      setError(res.error);
+      setRowState((m) => ({ ...m, [id]: "idle" }));
+      return;
+    }
+    setRowState((m) => ({ ...m, [id]: "done" }));
+    setRows((prev) => (prev ? prev.filter((r) => r.id !== id) : prev));
+  }
+
+  async function handleDismiss(id: string) {
+    setRowState((m) => ({ ...m, [id]: "dismissing" }));
+    const res = await dismissDiscoveredAction(id);
+    if ("error" in res) {
+      setError(res.error);
+      setRowState((m) => ({ ...m, [id]: "idle" }));
+      return;
+    }
+    setRows((prev) => (prev ? prev.filter((r) => r.id !== id) : prev));
+  }
+
+  return (
+    <>
+      <div className="mb-4 flex items-center gap-3">
+        <button
+          onClick={handleHarvest}
+          disabled={harvesting}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--accent-cyan)] text-black font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          {harvesting ? "Harvesting…" : "Run Google CSE harvest"}
+        </button>
+        {harvestSummary && (
+          <span className="text-xs text-[var(--text-secondary)]">{harvestSummary}</span>
+        )}
+        {error && <span className="text-xs text-red-300">{error}</span>}
+      </div>
+
+      {rows === null ? (
+        <p className="text-sm text-[var(--text-secondary)] italic">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-sm text-[var(--text-secondary)] italic">
+          Inbox empty — click <strong>Run Google CSE harvest</strong> to populate (requires
+          GOOGLE_CSE_KEY + GOOGLE_CSE_CX on the backend).
+        </p>
+      ) : (
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-[var(--bg-elevated)] text-[var(--text-secondary)] text-xs uppercase tracking-wide">
+              <tr>
+                <th className="px-4 py-2.5 text-left">Platform</th>
+                <th className="px-4 py-2.5 text-left">Slug</th>
+                <th className="px-4 py-2.5 text-right">Seen</th>
+                <th className="px-4 py-2.5 text-left">First seen</th>
+                <th className="px-4 py-2.5 text-left">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const state = rowState[r.id] ?? "idle";
+                const busy = state === "promoting" || state === "dismissing";
+                return (
+                  <tr
+                    key={r.id}
+                    className="border-t border-[var(--border-subtle)] hover:bg-[var(--bg-elevated)]/50"
+                  >
+                    <td className="px-4 py-3">
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full font-semibold ${PLATFORM_COLOR[r.platform] ?? "bg-[var(--border-strong)]/20 text-[var(--text-secondary)]"}`}
+                      >
+                        {r.platform}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs">{r.slug}</td>
+                    <td className="px-4 py-3 text-right tabular-nums text-[var(--text-secondary)]">
+                      {r.times_seen}
+                    </td>
+                    <td className="px-4 py-3 text-xs text-[var(--text-secondary)] whitespace-nowrap">
+                      {new Date(r.discovered_at).toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                        year: "numeric",
+                      })}
+                    </td>
+                    <td className="px-4 py-3 flex gap-2">
+                      <button
+                        onClick={() => handlePromote(r.id)}
+                        disabled={busy}
+                        className="text-xs px-3 py-1 rounded border border-[var(--accent-cyan)] text-[var(--accent-cyan)] hover:bg-[var(--accent-cyan)]/10 transition-colors disabled:opacity-50"
+                      >
+                        {state === "promoting" ? "Promoting…" : "Promote"}
+                      </button>
+                      <button
+                        onClick={() => handleDismiss(r.id)}
+                        disabled={busy}
+                        className="text-xs px-3 py-1 rounded border border-[var(--border-strong)] text-[var(--text-secondary)] hover:border-red-400/60 hover:text-red-300 transition-colors disabled:opacity-50"
+                      >
+                        {state === "dismissing" ? "…" : "Dismiss"}
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
@@ -22,6 +22,9 @@ const PLATFORM_COLOR: Record<string, string> = {
 
 type RowState = "idle" | "promoting" | "dismissing" | "done";
 
+const LAST_HARVEST_LS_KEY = "discovery_last_harvest_ts";
+const LOCAL_COOLDOWN_HOURS = 22;
+
 export default function InboxClient() {
   const [rows, setRows] = useState<DiscoveredSourceRow[] | null>(null);
   const [catalogue, setCatalogue] = useState<DiscoveryCatalogue | null>(null);
@@ -46,10 +49,22 @@ export default function InboxClient() {
     [catalogue],
   );
 
+  const [lastHarvestTs, setLastHarvestTs] = useState<number | null>(null);
+
   useEffect(() => {
     void refresh();
     void loadCatalogue();
+    const raw = localStorage.getItem(LAST_HARVEST_LS_KEY);
+    if (raw) setLastHarvestTs(Number(raw));
   }, []);
+
+  const hoursSinceLastHarvest = useMemo(() => {
+    if (!lastHarvestTs) return null;
+    return (Date.now() - lastHarvestTs) / 3_600_000;
+  }, [lastHarvestTs]);
+
+  const inLocalCooldown =
+    hoursSinceLastHarvest !== null && hoursSinceLastHarvest < LOCAL_COOLDOWN_HOURS;
 
   async function loadCatalogue() {
     const res = await getDiscoveryCatalogueAction();
@@ -67,16 +82,33 @@ export default function InboxClient() {
     setRows(res.data);
   }
 
-  async function handleHarvest() {
+  async function handleHarvest(force = false) {
+    if (inLocalCooldown && !force) {
+      // Surface a confirmation step; the user can hit "Run anyway" which
+      // sets force=true and sends force=true to the backend.
+      setError(
+        `Last harvest ran ${Math.floor(hoursSinceLastHarvest!)}h ago. ` +
+          "Running again may exceed the 100 q/day free tier.",
+      );
+      return;
+    }
     setHarvesting(true);
     setError("");
     setHarvestSummary(null);
-    const res = await harvestInboxAction();
+    const res = await harvestInboxAction(force);
     setHarvesting(false);
+    if ("cooldown" in res && res.cooldown) {
+      setError(res.error);
+      return;
+    }
     if ("error" in res) {
       setError(res.error);
       return;
     }
+    // Successful harvest — record locally so the next run hits the guard.
+    const now = Date.now();
+    localStorage.setItem(LAST_HARVEST_LS_KEY, String(now));
+    setLastHarvestTs(now);
     const data = res.data;
     if (data.skipped === "google_cse_creds_missing") {
       setHarvestSummary(
@@ -118,14 +150,24 @@ export default function InboxClient() {
 
   return (
     <>
-      <div className="mb-4 flex items-center gap-3 flex-wrap">
+      <div className="mb-2 flex items-center gap-3 flex-wrap">
         <button
-          onClick={handleHarvest}
+          onClick={() => handleHarvest(false)}
           disabled={harvesting}
           className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[var(--accent-cyan)] text-black font-medium text-sm hover:opacity-90 transition-opacity disabled:opacity-50"
         >
           {harvesting ? "Harvesting…" : "Run Google CSE harvest"}
         </button>
+        {inLocalCooldown && (
+          <button
+            onClick={() => handleHarvest(true)}
+            disabled={harvesting}
+            className="text-xs px-3 py-1.5 rounded border border-amber-500/60 text-amber-300 hover:bg-amber-500/10 transition-colors disabled:opacity-50"
+            title="Override the 22 h cooldown — may exceed the free 100 q/day tier"
+          >
+            Run anyway
+          </button>
+        )}
         <button
           onClick={() => setShowCsePanel((v) => !v)}
           className="text-xs px-3 py-1.5 rounded border border-[var(--border-strong)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
@@ -137,6 +179,17 @@ export default function InboxClient() {
         )}
         {error && <span className="text-xs text-red-300">{error}</span>}
       </div>
+
+      {catalogue?.harvest_query_budget != null && (
+        <p className="mb-4 text-xs text-[var(--text-secondary)]">
+          One harvest = <strong>{catalogue.harvest_query_budget}</strong> of your{" "}
+          <strong>{catalogue.google_cse_free_tier_per_day ?? 100}</strong> daily free
+          Google CSE queries.{" "}
+          {hoursSinceLastHarvest !== null
+            ? `Last run ${Math.floor(hoursSinceLastHarvest)}h ago.`
+            : "No harvest yet today."}
+        </p>
+      )}
 
       {showCsePanel && cseHostPatterns.length > 0 && (
         <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">

--- a/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
@@ -110,18 +110,23 @@ export default function InboxClient() {
     localStorage.setItem(LAST_HARVEST_LS_KEY, String(now));
     setLastHarvestTs(now);
     const data = res.data;
-    if (data.skipped === "google_cse_creds_missing") {
+    if (data.skipped === "no_search_provider_configured" || data.skipped === "google_cse_creds_missing") {
       setHarvestSummary(
-        "Skipped: set GOOGLE_CSE_KEY and GOOGLE_CSE_CX on the backend to enable bulk harvest.",
+        "Skipped: no search provider configured. Expand the setup panel below for instructions.",
       );
+      setShowCsePanel(true);
       return;
     }
     const parts: string[] = [];
-    for (const [platform, stats] of Object.entries(data)) {
-      const s = stats as { seen: number; new: number };
-      parts.push(`${platform}: ${s.new} new (${s.seen} seen)`);
+    const provider = data.provider as string | undefined;
+    for (const [k, v] of Object.entries(data)) {
+      if (k === "provider") continue;
+      const s = v as { seen: number; new: number };
+      parts.push(`${k}: ${s.new} new (${s.seen} seen)`);
     }
-    setHarvestSummary(parts.join(" · "));
+    setHarvestSummary(
+      (provider ? `[${provider}] ` : "") + parts.join(" · "),
+    );
     await refresh();
   }
 
@@ -180,54 +185,119 @@ export default function InboxClient() {
         {error && <span className="text-xs text-red-300">{error}</span>}
       </div>
 
-      {catalogue?.harvest_query_budget != null && (
+      {catalogue?.active_provider ? (
         <p className="mb-4 text-xs text-[var(--text-secondary)]">
-          One harvest = <strong>{catalogue.harvest_query_budget}</strong> of your{" "}
-          <strong>{catalogue.google_cse_free_tier_per_day ?? 100}</strong> daily free
-          Google CSE queries.{" "}
+          Active provider: <strong>{catalogue.active_provider}</strong> · one
+          harvest spends <strong>{catalogue.harvest_query_budget}</strong> of your{" "}
+          <strong>{catalogue.active_free_tier_per_day}</strong> daily free
+          queries.{" "}
           {hoursSinceLastHarvest !== null
             ? `Last run ${Math.floor(hoursSinceLastHarvest)}h ago.`
             : "No harvest yet today."}
         </p>
+      ) : (
+        <p className="mb-4 text-xs text-amber-300">
+          No search provider configured. Click <strong>Show CSE setup</strong> for
+          step-by-step setup instructions for Brave Search (no card) or Google
+          CSE.
+        </p>
       )}
 
-      {showCsePanel && cseHostPatterns.length > 0 && (
-        <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
-          <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-1">
-            Google CSE setup
-          </h3>
-          <p className="text-xs text-[var(--text-secondary)] mb-3">
-            Paste these into your Programmable Search Engine&apos;s <strong>Sites to
-            search</strong> list at{" "}
-            <a
-              href="https://programmablesearchengine.google.com/"
-              target="_blank"
-              rel="noreferrer"
-              className="text-[var(--accent-cyan)] hover:underline"
-            >
-              programmablesearchengine.google.com
-            </a>
-            . API key from{" "}
-            <a
-              href="https://console.cloud.google.com/apis/credentials"
-              target="_blank"
-              rel="noreferrer"
-              className="text-[var(--accent-cyan)] hover:underline"
-            >
-              Google Cloud → Credentials
-            </a>
-            {" "}with the <em>Custom Search API</em> enabled. Free tier:
-            100 queries / day.
-          </p>
-          <pre className="text-xs font-mono bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded p-3 whitespace-pre overflow-x-auto text-[var(--text-primary)]">
+      {showCsePanel && (
+        <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4 space-y-5">
+          {cseHostPatterns.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+                Step 1 — Host patterns (only needed for Google CSE)
+              </h3>
+              <p className="text-xs text-[var(--text-secondary)] mb-2">
+                If you use Google CSE, paste these into your Programmable Search
+                Engine&apos;s <strong>Sites to search</strong> list. Brave Search
+                doesn&apos;t need them — it indexes the whole web.
+              </p>
+              <pre className="text-xs font-mono bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded p-3 whitespace-pre overflow-x-auto text-[var(--text-primary)]">
 {cseHostPatterns.map((p) => p.pattern).join("\n")}
-          </pre>
-          <p className="text-xs text-[var(--text-secondary)] mt-2">
-            <strong>{cseHostPatterns.filter((p) => p.hasAdapter).length}</strong> active +{" "}
-            <strong>{cseHostPatterns.filter((p) => !p.hasAdapter).length}</strong> wishlist.
-            Then set <code>GOOGLE_CSE_KEY</code> and <code>GOOGLE_CSE_CX</code> on
-            the backend.
-          </p>
+              </pre>
+              <p className="text-xs text-[var(--text-secondary)] mt-2">
+                <strong>{cseHostPatterns.filter((p) => p.hasAdapter).length}</strong>{" "}
+                active + <strong>{cseHostPatterns.filter((p) => !p.hasAdapter).length}</strong>{" "}
+                wishlist.
+              </p>
+            </div>
+          )}
+
+          <div>
+            <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-2">
+              Step 2 — Configure a search provider
+            </h3>
+            <p className="text-xs text-[var(--text-secondary)] mb-3">
+              Pick whichever fits your privacy / quota preference. The harvester
+              auto-uses the first one configured (Brave wins if both are set).
+            </p>
+            <div className="grid gap-3 md:grid-cols-2">
+              {catalogue?.providers?.map((p) => (
+                <div
+                  key={p.name}
+                  className={`rounded-md border p-3 ${
+                    p.configured
+                      ? "border-emerald-500/40 bg-emerald-500/5"
+                      : "border-[var(--border-subtle)] bg-[var(--bg-elevated)]/50"
+                  }`}
+                >
+                  <div className="flex items-baseline justify-between mb-1.5 gap-2">
+                    <strong className="text-sm text-[var(--text-primary)]">
+                      {p.display_name}
+                    </strong>
+                    {p.configured ? (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/20 text-emerald-300 font-semibold uppercase tracking-wide">
+                        Configured
+                      </span>
+                    ) : p.requires_billing ? (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-300 font-semibold uppercase tracking-wide">
+                        Card required
+                      </span>
+                    ) : (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-cyan-500/15 text-cyan-300 font-semibold uppercase tracking-wide">
+                        No card
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-[var(--text-secondary)] mb-2">
+                    Free tier: <strong>{p.free_tier_per_day}/day</strong> · this
+                    harvester spends <strong>{p.query_budget_per_run}</strong> per
+                    run.
+                  </p>
+                  <ol className="text-xs text-[var(--text-secondary)] list-decimal pl-4 space-y-1 mb-2">
+                    {p.setup_steps.map((s, i) => (
+                      <li key={i}>{s}</li>
+                    ))}
+                  </ol>
+                  <div className="flex flex-wrap gap-2 mb-2">
+                    {p.setup_links.map((l) => (
+                      <a
+                        key={l.url}
+                        href={l.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-[11px] px-2 py-0.5 rounded border border-[var(--border-subtle)] text-[var(--accent-cyan)] hover:border-[var(--accent-cyan)]"
+                      >
+                        {l.label} ↗
+                      </a>
+                    ))}
+                  </div>
+                  <p className="text-[11px] text-[var(--text-secondary)]">
+                    Env vars:{" "}
+                    {p.env_vars.map((v, i) => (
+                      <span key={v}>
+                        <code className="font-mono">{v}</code>
+                        {i < p.env_vars.length - 1 ? ", " : ""}
+                      </span>
+                    ))}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       )}
 

--- a/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
+++ b/app/admin/(dashboard)/jobs/discover/inbox/InboxClient.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
+  CataloguePlatform,
   DiscoveredSourceRow,
+  DiscoveryCatalogue,
   dismissDiscoveredAction,
+  getDiscoveryCatalogueAction,
   harvestInboxAction,
   listDiscoveryInboxAction,
   promoteDiscoveredAction,
@@ -21,14 +24,38 @@ type RowState = "idle" | "promoting" | "dismissing" | "done";
 
 export default function InboxClient() {
   const [rows, setRows] = useState<DiscoveredSourceRow[] | null>(null);
+  const [catalogue, setCatalogue] = useState<DiscoveryCatalogue | null>(null);
   const [error, setError] = useState("");
   const [harvestSummary, setHarvestSummary] = useState<string | null>(null);
   const [harvesting, setHarvesting] = useState(false);
   const [rowState, setRowState] = useState<Record<string, RowState>>({});
+  const [showCsePanel, setShowCsePanel] = useState(false);
+
+  // Lookup tables built from the catalogue.
+  const platformsByCode = useMemo(() => {
+    const m = new Map<string, CataloguePlatform>();
+    catalogue?.platforms.forEach((p) => m.set(p.code, p));
+    return m;
+  }, [catalogue]);
+
+  const cseHostPatterns = useMemo(
+    () =>
+      catalogue?.platforms
+        .filter((p) => p.kind === "company_slug" && p.host_pattern)
+        .map((p) => ({ code: p.code, pattern: p.host_pattern as string, hasAdapter: p.has_adapter })) ?? [],
+    [catalogue],
+  );
 
   useEffect(() => {
     void refresh();
+    void loadCatalogue();
   }, []);
+
+  async function loadCatalogue() {
+    const res = await getDiscoveryCatalogueAction();
+    if ("error" in res) return;
+    setCatalogue(res.data);
+  }
 
   async function refresh() {
     const res = await listDiscoveryInboxAction();
@@ -91,7 +118,7 @@ export default function InboxClient() {
 
   return (
     <>
-      <div className="mb-4 flex items-center gap-3">
+      <div className="mb-4 flex items-center gap-3 flex-wrap">
         <button
           onClick={handleHarvest}
           disabled={harvesting}
@@ -99,11 +126,57 @@ export default function InboxClient() {
         >
           {harvesting ? "Harvesting…" : "Run Google CSE harvest"}
         </button>
+        <button
+          onClick={() => setShowCsePanel((v) => !v)}
+          className="text-xs px-3 py-1.5 rounded border border-[var(--border-strong)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+        >
+          {showCsePanel ? "Hide" : "Show"} CSE setup
+        </button>
         {harvestSummary && (
           <span className="text-xs text-[var(--text-secondary)]">{harvestSummary}</span>
         )}
         {error && <span className="text-xs text-red-300">{error}</span>}
       </div>
+
+      {showCsePanel && cseHostPatterns.length > 0 && (
+        <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] p-4">
+          <h3 className="text-sm font-semibold text-[var(--text-primary)] mb-1">
+            Google CSE setup
+          </h3>
+          <p className="text-xs text-[var(--text-secondary)] mb-3">
+            Paste these into your Programmable Search Engine&apos;s <strong>Sites to
+            search</strong> list at{" "}
+            <a
+              href="https://programmablesearchengine.google.com/"
+              target="_blank"
+              rel="noreferrer"
+              className="text-[var(--accent-cyan)] hover:underline"
+            >
+              programmablesearchengine.google.com
+            </a>
+            . API key from{" "}
+            <a
+              href="https://console.cloud.google.com/apis/credentials"
+              target="_blank"
+              rel="noreferrer"
+              className="text-[var(--accent-cyan)] hover:underline"
+            >
+              Google Cloud → Credentials
+            </a>
+            {" "}with the <em>Custom Search API</em> enabled. Free tier:
+            100 queries / day.
+          </p>
+          <pre className="text-xs font-mono bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded p-3 whitespace-pre overflow-x-auto text-[var(--text-primary)]">
+{cseHostPatterns.map((p) => p.pattern).join("\n")}
+          </pre>
+          <p className="text-xs text-[var(--text-secondary)] mt-2">
+            <strong>{cseHostPatterns.filter((p) => p.hasAdapter).length}</strong> active +{" "}
+            <strong>{cseHostPatterns.filter((p) => !p.hasAdapter).length}</strong> wishlist.
+            Then set <code>GOOGLE_CSE_KEY</code> and <code>GOOGLE_CSE_CX</code> on
+            the backend.
+          </p>
+        </div>
+      )}
 
       {rows === null ? (
         <p className="text-sm text-[var(--text-secondary)] italic">Loading…</p>
@@ -128,6 +201,8 @@ export default function InboxClient() {
               {rows.map((r) => {
                 const state = rowState[r.id] ?? "idle";
                 const busy = state === "promoting" || state === "dismissing";
+                const platformMeta = platformsByCode.get(r.platform);
+                const isWishlist = platformMeta ? !platformMeta.has_adapter : false;
                 return (
                   <tr
                     key={r.id}
@@ -139,6 +214,14 @@ export default function InboxClient() {
                       >
                         {r.platform}
                       </span>
+                      {isWishlist && (
+                        <span
+                          className="ml-2 text-[10px] px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-300 font-semibold uppercase tracking-wide"
+                          title="No adapter yet — promotion disabled until support is added."
+                        >
+                          Wishlist
+                        </span>
+                      )}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs">{r.slug}</td>
                     <td className="px-4 py-3 text-right tabular-nums text-[var(--text-secondary)]">
@@ -154,8 +237,9 @@ export default function InboxClient() {
                     <td className="px-4 py-3 flex gap-2">
                       <button
                         onClick={() => handlePromote(r.id)}
-                        disabled={busy}
-                        className="text-xs px-3 py-1 rounded border border-[var(--accent-cyan)] text-[var(--accent-cyan)] hover:bg-[var(--accent-cyan)]/10 transition-colors disabled:opacity-50"
+                        disabled={busy || isWishlist}
+                        title={isWishlist ? "No adapter for this platform yet" : undefined}
+                        className="text-xs px-3 py-1 rounded border border-[var(--accent-cyan)] text-[var(--accent-cyan)] hover:bg-[var(--accent-cyan)]/10 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                       >
                         {state === "promoting" ? "Promoting…" : "Promote"}
                       </button>

--- a/app/admin/(dashboard)/jobs/discover/inbox/page.tsx
+++ b/app/admin/(dashboard)/jobs/discover/inbox/page.tsx
@@ -1,0 +1,26 @@
+import Link from "next/link";
+import InboxClient from "./InboxClient";
+
+export const revalidate = 0;
+
+export default function DiscoveryInboxPage() {
+  return (
+    <div className="max-w-5xl mx-auto">
+      <Link
+        href="/admin/jobs/discover"
+        className="text-sm text-[var(--text-secondary)] hover:text-[var(--accent-cyan)] transition-colors"
+      >
+        ← Back to Discover
+      </Link>
+      <div className="mb-8 mt-4">
+        <h1 className="text-3xl font-bold text-[var(--text-primary)]">Discovery inbox</h1>
+        <p className="text-[var(--text-secondary)] mt-2">
+          Company slugs harvested from Google Custom Search across the supported ATS
+          hosts. Promote ones you want to track, dismiss the rest.
+        </p>
+      </div>
+
+      <InboxClient />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/jobs/discover/page.tsx
+++ b/app/admin/(dashboard)/jobs/discover/page.tsx
@@ -16,13 +16,21 @@ export default async function DiscoverPage() {
       >
         ← Back to sources
       </Link>
-      <div className="mb-8 mt-4">
-        <h1 className="text-3xl font-bold text-[var(--text-primary)]">Discover companies</h1>
-        <p className="text-[var(--text-secondary)] mt-2">
-          Paste company names — one per line — and we probe every known ATS
-          (Greenhouse, Lever, Ashby, Recruitee, SmartRecruiters) in parallel.
-          Each match is one click away from becoming a tracked source.
-        </p>
+      <div className="mb-8 mt-4 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-[var(--text-primary)]">Discover companies</h1>
+          <p className="text-[var(--text-secondary)] mt-2">
+            Paste company names — one per line — and we probe every known ATS
+            (Greenhouse, Lever, Ashby, Recruitee, SmartRecruiters) in parallel.
+            Each match is one click away from becoming a tracked source.
+          </p>
+        </div>
+        <Link
+          href="/admin/jobs/discover/inbox"
+          className="shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[var(--border-strong)] text-sm font-medium text-[var(--text-primary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] transition-colors"
+        >
+          Inbox →
+        </Link>
       </div>
 
       <DiscoverClient existingSources={existing} />

--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -57,6 +57,11 @@ const PLATFORM_HELP: Record<string, { desc: string; verifyUrl: string; example: 
     verifyUrl: "https://careers.smartrecruiters.com/{slug}",
     example: "Continental",
   },
+  arbeitnow: {
+    desc: "Free EU-leaning aggregator across many ATSes. Identifier is a search query (e.g. \"python remote\").",
+    verifyUrl: "https://www.arbeitnow.com/?search={slug}",
+    example: "python remote",
+  },
 };
 
 const RECOMMENDED: { platform: string; identifier: string; note: string }[] = [

--- a/data/discover_categories.json
+++ b/data/discover_categories.json
@@ -1,0 +1,84 @@
+{
+  "ai_ml": {
+    "label": "AI / ML",
+    "description": "Frontier labs, applied AI, MLOps, AI safety",
+    "companies": [
+      "Anthropic", "OpenAI", "Hugging Face", "Cohere", "Mistral AI",
+      "Perplexity", "Scale AI", "Replicate", "Pinecone", "LangChain",
+      "Together AI", "Runway", "Stability AI", "Modal Labs", "Weights & Biases",
+      "Glean", "Adept", "Inflection AI", "Character AI", "ElevenLabs"
+    ]
+  },
+  "dev_tools": {
+    "label": "Dev tools / Infra",
+    "description": "Developer-platform companies and infrastructure",
+    "companies": [
+      "Vercel", "Netlify", "Linear", "Notion", "Figma", "Loom",
+      "GitHub", "GitLab", "Cloudflare", "Stripe", "Datadog", "New Relic",
+      "Sentry", "Retool", "Render", "Fly.io", "Supabase", "PlanetScale",
+      "Neon", "Railway", "Resend", "Sanity"
+    ]
+  },
+  "fintech": {
+    "label": "Fintech",
+    "description": "Payments, banking, crypto, embedded finance",
+    "companies": [
+      "Stripe", "Plaid", "Wise", "Revolut", "Klarna", "Affirm",
+      "Mercury", "Brex", "Ramp", "Chime", "Robinhood", "Coinbase",
+      "Block", "Marqeta", "Adyen", "Monzo", "N26", "Modern Treasury"
+    ]
+  },
+  "climate": {
+    "label": "Climate / Energy",
+    "description": "Decarbonisation, energy software, climate analytics",
+    "companies": [
+      "Watershed", "Persefoni", "Pachama", "Climate AI", "Sylvera",
+      "Octopus Energy", "Patch", "Carbon Direct", "Climeworks", "Twelve",
+      "Form Energy", "Commonwealth Fusion Systems"
+    ]
+  },
+  "data": {
+    "label": "Data / Analytics",
+    "description": "Data platforms, warehousing, BI, observability",
+    "companies": [
+      "Snowflake", "Databricks", "Confluent", "dbt Labs", "Fivetran",
+      "Hex", "Mode", "Metabase", "Airbyte", "Estuary", "Materialize",
+      "Datafold", "MotherDuck", "Tinybird"
+    ]
+  },
+  "big_tech": {
+    "label": "Big tech",
+    "description": "Large established tech companies",
+    "companies": [
+      "Google", "Meta", "Microsoft", "Amazon", "Apple", "Netflix",
+      "Uber", "Lyft", "Airbnb", "Spotify", "Pinterest", "Reddit",
+      "Twitter", "LinkedIn", "Salesforce"
+    ]
+  },
+  "saas_horizontal": {
+    "label": "Horizontal SaaS",
+    "description": "Productivity, collaboration, CRM, HR",
+    "companies": [
+      "Asana", "Monday", "ClickUp", "Slack", "Zoom", "Calendly",
+      "Intercom", "Front", "HubSpot", "Pipedrive", "Gusto", "Rippling",
+      "Deel", "Remote", "Lattice", "Notion", "Coda", "Airtable"
+    ]
+  },
+  "latam_startups": {
+    "label": "LATAM startups",
+    "description": "Companies founded or with strong presence in Latin America",
+    "companies": [
+      "Rappi", "Nubank", "Kavak", "Bitso", "Mercado Libre", "dLocal",
+      "Clip", "Konfio", "Clara", "Lana", "Truora", "Habi", "Belvo"
+    ]
+  },
+  "eu_startups": {
+    "label": "EU startups",
+    "description": "European tech companies with active hiring",
+    "companies": [
+      "Klarna", "Spotify", "Wise", "Revolut", "N26", "Adyen",
+      "Personio", "GetYourGuide", "Tier", "Pleo", "Pennylane",
+      "Aircall", "Qonto", "Sumup", "Mollie", "Bunq", "Mistral AI"
+    ]
+  }
+}

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -351,6 +351,7 @@ export async function getAdminJobs(params?: {
   status?: string;
   minScore?: number;
   limit?: number;
+  offset?: number;
 }) {
   const url = new URL(`${API_BASE_URL}/jobs`);
   if (params?.status) url.searchParams.set("status", params.status);
@@ -358,6 +359,8 @@ export async function getAdminJobs(params?: {
     url.searchParams.set("min_score", String(params.minScore));
   if (params?.limit !== undefined)
     url.searchParams.set("limit", String(params.limit));
+  if (params?.offset !== undefined)
+    url.searchParams.set("offset", String(params.offset));
   const res = await fetch(url.toString(), {
     headers: await getAuthHeader(),
     next: { revalidate: 0 },


### PR DESCRIPTION
## Summary

Stacks on top of PR #30 (frontend feat/16). Three UI additions matching the backend feat/17 PR.

- **Category picker** on \`/admin/jobs/discover\` — quick-fill dropdown backed by \`data/discover_categories.json\` with 9 curated categories (AI/ML, dev tools, fintech, climate, data, big tech, horizontal SaaS, LATAM startups, EU startups). Pick a category → textarea pre-fills with its company list → edit if needed → Discover.
- **Load-more pagination** on \`/admin/jobs\` — new \"Load 500 more\" button below the kanban. Server returns \`?offset=N\` (no upper bound), client dedupes by id. Stops the kanban from silently capping at 500.
- **Discovery inbox** at \`/admin/jobs/discover/inbox\` — lists harvested (platform, slug) candidates with Promote / Dismiss per row, plus a \"Run Google CSE harvest\" button. Helpful instruction message when GOOGLE_CSE_KEY/CX env vars are missing.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Navigate \`/admin/jobs/discover\`, pick a category, confirm textarea pre-fills and Discover works as before
- [ ] On \`/admin/jobs\`, scroll to bottom — \"Load 500 more\" should appear if pipeline has >= 500 rows; clicking it appends
- [ ] Navigate \`/admin/jobs/discover/inbox\` — without CSE env vars, shows the skipped message; with them, harvests populate the table

## Companion PRs

- Backend: zergcore/portfolio_backend#30 — Arbeitnow adapter, CSE harvester, offset pagination