### PR TITLE
fix(projects): admin form bug fixes + MCP setup guide

### DIFF
--- a/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
+++ b/app/admin/(dashboard)/jobs/sources/SourcesClient.tsx
@@ -11,6 +11,8 @@ import {
   updateJobSourceAction,
 } from "@/app/actions/jobs";
 
+const MCP_HTTP_URL = (process.env.NEXT_PUBLIC_API_URL ?? "").replace(/\/api\/v1\/?$/, "/api/mcp/");
+
 const PLATFORM_HELP: Record<string, { desc: string; verifyUrl: string; example: string }> = {
   greenhouse: {
     desc: "Used by Stripe, Shopify, Notion, Discord, Cloudflare, Anthropic, OpenAI, Figma, Brex…",
@@ -116,9 +118,18 @@ export default function SourcesClient({
   const [showHelp, setShowHelp] = useState(sources.length === 0);
   const [editing, setEditing] = useState<EditState | null>(null);
   const [testState, setTestState] = useState<TestState | null>(null);
+  const [showMcp, setShowMcp] = useState(false);
+  const [copied, setCopied] = useState<string | null>(null);
 
   const platformInfo = PLATFORM_HELP[platform];
   const existingKeys = new Set(sources.map((s) => `${s.platform}/${s.identifier}`));
+
+  function copyText(text: string, key: string) {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(key);
+      setTimeout(() => setCopied(null), 1800);
+    });
+  }
 
   async function onCreate(e: FormEvent) {
     e.preventDefault();
@@ -220,6 +231,23 @@ export default function SourcesClient({
     setTestState({ id: src.id, result: res.data as SourceTestResult, error: "" });
   }
 
+  const claudeCodeCmd = `claude mcp add zergcore-jobs --transport http \\\n  -H "Authorization: Bearer <MCP_ADMIN_TOKEN>" \\\n  ${MCP_HTTP_URL}`;
+  const localStdioCmd = `cd backend\nsource .venv/bin/activate\nMCP_ADMIN_TOKEN=<your-token> python -m app.jobs.mcp`;
+  const desktopJson = JSON.stringify({
+    mcpServers: {
+      "zergcore-jobs": {
+        command: "/path/to/backend/.venv/bin/python",
+        args: ["-m", "app.jobs.mcp"],
+        cwd: "/path/to/portfolio/backend",
+        env: {
+          DATABASE_URL: "postgresql+asyncpg://...",
+          GEMINI_API_KEY: "your-key",
+          MCP_ADMIN_TOKEN: "your-token",
+        },
+      },
+    },
+  }, null, 2);
+
   return (
     <>
       {/* Help section */}
@@ -284,6 +312,85 @@ export default function SourcesClient({
                 })}
               </div>
             </div>
+          </div>
+        )}
+      </div>
+
+      {/* MCP setup */}
+      <div className="mb-6 rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-surface)] overflow-hidden">
+        <button
+          type="button"
+          onClick={() => setShowMcp((v) => !v)}
+          className="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-[var(--text-primary)] hover:bg-[var(--bg-elevated)] transition-colors"
+        >
+          <span>Claude / AI client setup (MCP)</span>
+          <span className="text-[var(--text-secondary)]">{showMcp ? "▲" : "▼"}</span>
+        </button>
+
+        {showMcp && (
+          <div className="px-4 pb-5 pt-1 space-y-5 border-t border-[var(--border-subtle)] text-sm">
+            <p className="text-[var(--text-secondary)]">
+              The backend exposes all 9 job-pipeline tools over the{" "}
+              <strong className="text-[var(--text-primary)]">Model Context Protocol (MCP)</strong>.
+              Connect Claude Code or Claude Desktop to drive job search from chat — no admin UI needed.
+              Write tools require <code className="text-[var(--accent-cyan)]">MCP_ADMIN_TOKEN</code> (set it in Render env vars).
+            </p>
+
+            {/* HTTP transport — Claude Code */}
+            <div className="space-y-2">
+              <p className="font-medium text-[var(--text-primary)]">
+                Option A — HTTP (deployed backend, Claude Code)
+              </p>
+              <p className="text-xs text-[var(--text-secondary)]">
+                Endpoint: <code className="text-[var(--accent-cyan)]">{MCP_HTTP_URL}</code>
+              </p>
+              <div className="relative">
+                <pre className="rounded-lg bg-[var(--bg-elevated)] px-4 py-3 text-xs text-[var(--text-primary)] overflow-x-auto whitespace-pre">{claudeCodeCmd}</pre>
+                <button
+                  type="button"
+                  onClick={() => copyText(claudeCodeCmd, "http")}
+                  className="absolute top-2 right-2 text-xs px-2 py-1 rounded bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  {copied === "http" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            {/* Stdio — local */}
+            <div className="space-y-2">
+              <p className="font-medium text-[var(--text-primary)]">
+                Option B — stdio (local backend, any MCP client)
+              </p>
+              <div className="relative">
+                <pre className="rounded-lg bg-[var(--bg-elevated)] px-4 py-3 text-xs text-[var(--text-primary)] overflow-x-auto whitespace-pre">{localStdioCmd}</pre>
+                <button
+                  type="button"
+                  onClick={() => copyText(localStdioCmd, "stdio")}
+                  className="absolute top-2 right-2 text-xs px-2 py-1 rounded bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  {copied === "stdio" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+              <p className="text-xs text-[var(--text-secondary)]">
+                Then add to <code className="text-[var(--accent-cyan)]">~/.config/Claude/claude_desktop_config.json</code> (Linux) or{" "}
+                <code className="text-[var(--accent-cyan)]">~/Library/Application Support/Claude/claude_desktop_config.json</code> (macOS):
+              </p>
+              <div className="relative">
+                <pre className="rounded-lg bg-[var(--bg-elevated)] px-4 py-3 text-xs text-[var(--text-primary)] overflow-x-auto whitespace-pre">{desktopJson}</pre>
+                <button
+                  type="button"
+                  onClick={() => copyText(desktopJson, "desktop")}
+                  className="absolute top-2 right-2 text-xs px-2 py-1 rounded bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors"
+                >
+                  {copied === "desktop" ? "Copied!" : "Copy"}
+                </button>
+              </div>
+            </div>
+
+            <p className="text-xs text-[var(--text-secondary)]">
+              Generate a secure token: <code className="text-[var(--accent-cyan)]">openssl rand -hex 32</code>
+              {" "}— set the same value as <code className="text-[var(--accent-cyan)]">MCP_ADMIN_TOKEN</code> in the backend env and in your MCP client config.
+            </p>
           </div>
         )}
       </div>

--- a/app/admin/(dashboard)/projects/ProjectFormModal.tsx
+++ b/app/admin/(dashboard)/projects/ProjectFormModal.tsx
@@ -75,7 +75,7 @@ export default function ProjectFormModal({
       live_url: data.live_url || null,
       tags: tags.split(",").map((s) => s.trim()).filter(Boolean),
       images,
-      image_url: images.find((img) => img.is_primary)?.url || null,
+      image_url: images.find((img) => img.is_primary)?.url || "",
       skill_ids: skillIds,
       role: null,
       timeline: null,

--- a/components/admin/forms/LocalizedTextField.tsx
+++ b/components/admin/forms/LocalizedTextField.tsx
@@ -91,6 +91,7 @@ export default function LocalizedTextField({
 
       {multiline ? (
         <textarea
+          key={activeLocale}
           {...register(fieldName)}
           rows={rows}
           placeholder={placeholder[activeLocale]}
@@ -98,6 +99,7 @@ export default function LocalizedTextField({
         />
       ) : (
         <input
+          key={activeLocale}
           {...register(fieldName)}
           placeholder={placeholder[activeLocale]}
           className={inputClass}

--- a/components/admin/forms/SkillMultiSelect.tsx
+++ b/components/admin/forms/SkillMultiSelect.tsx
@@ -42,8 +42,6 @@ export default function SkillMultiSelect({ allSkills, selectedIds, onChange }: P
 
   return (
     <div className="space-y-2" ref={containerRef}>
-      <label className="text-sm font-medium text-[var(--text-secondary)]">Skills</label>
-
       {selectedSkills.length > 0 && (
         <div className="flex flex-wrap gap-1.5">
           {selectedSkills.map(s => (


### PR DESCRIPTION
## Summary

- **Bug fix — `image_url` null**: `ProjectFormModal` was sending `null` when no primary image is set; backend schema expects `str` with default `""`. Changed `|| null` → `|| ""`.
- **Bug fix — title EN/ES tabs show same value**: `LocalizedTextField` reused the same DOM input element when switching locale tabs, so React-Hook-Form showed the wrong field's value. Added `key={activeLocale}` to force remount on tab switch.
- **Bug fix — Skills label appears twice**: `SkillMultiSelect` rendered its own internal `<label>Skills</label>` in addition to the outer form's label. Removed the internal one.
- **feat — MCP/Claude client setup card** on the Job Sources page: collapsible section with the HTTP endpoint URL, a ready-to-paste `claude mcp add` command (for the deployed backend), and the stdio + Claude Desktop JSON config for local use. Each snippet has a copy-to-clipboard button.

## Test plan

- [ ] Create a project with no images — no validation error
- [ ] Create a project with a primary image — `image_url` is populated
- [ ] Edit a project title: type EN value, switch to ES tab, type ES value — both values are preserved independently
- [ ] Open the Skills field — only one "Skills" label appears
- [ ] Jobs → Sources → expand "Claude / AI client setup" — endpoint URL, commands, and copy buttons render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)