### PR TITLE
feat(ai): AI model management admin page with catalog, chain editor, and bulk controls

### DIFF
--- a/app/actions/ai.ts
+++ b/app/actions/ai.ts
@@ -1,11 +1,38 @@
 "use server";
 
 import { cookies } from "next/headers";
-import type { AiUsageData } from "@/lib/types/ai";
+import type { AiTestResult, AiUsageData } from "@/lib/types/ai";
 
-export type { AiUsageData } from "@/lib/types/ai";
+export type { AiChainEntry, AiKnownModel, AiTestResult, AiUsageData } from "@/lib/types/ai";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://127.0.0.1:8000/api/v1";
+
+export interface ProviderCreditInfo {
+  openrouter?: {
+    usage_usd?: number;
+    limit_usd?: number | null;
+    is_free_tier?: boolean;
+    label?: string;
+    error?: string;
+  };
+  groq?: { note: string; docs_url: string };
+  google?: { note: string; docs_url: string };
+}
+
+export async function getProviderCredits(): Promise<ProviderCreditInfo | null> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/provider-credits`, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+      next: { revalidate: 60 },
+    });
+    if (!res.ok) return null;
+    return res.json() as Promise<ProviderCreditInfo>;
+  } catch {
+    return null;
+  }
+}
 
 export async function getAiUsage(): Promise<AiUsageData | null> {
   const cookieStore = await cookies();
@@ -20,5 +47,218 @@ export async function getAiUsage(): Promise<AiUsageData | null> {
     return res.json() as Promise<AiUsageData>;
   } catch {
     return null;
+  }
+}
+
+export async function testAiFeature(feature: string): Promise<AiTestResult> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+
+  try {
+    const res = await fetch(`${API_BASE}/ai/config/${encodeURIComponent(feature)}/test`, {
+      method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => `HTTP ${res.status}`);
+      return { ok: false, error: text, provider: null, model: null };
+    }
+    return res.json() as Promise<AiTestResult>;
+  } catch (e) {
+    return { ok: false, error: String(e), provider: null, model: null };
+  }
+}
+
+export async function setFeatureChain(
+  feature: string,
+  chain: { provider: string; model: string }[],
+): Promise<{ ok: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+
+  try {
+    const res = await fetch(`${API_BASE}/ai/config/${encodeURIComponent(feature)}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ chain }),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => `HTTP ${res.status}`);
+      return { ok: false, error: text };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function resetFeatureChain(
+  feature: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+
+  try {
+    const res = await fetch(`${API_BASE}/ai/config/${encodeURIComponent(feature)}`, {
+      method: "DELETE",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => `HTTP ${res.status}`);
+      return { ok: false, error: text };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function createAiModel(data: {
+  provider: string;
+  model: string;
+  display_name?: string;
+  notes?: string;
+}): Promise<{ ok: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function updateAiModel(
+  id: number,
+  data: { display_name?: string | null; notes?: string | null; enabled?: boolean },
+): Promise<{ ok: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models/${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(data),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function syncAiModels(): Promise<{
+  ok: boolean;
+  total_added?: number;
+  added?: Record<string, number>;
+  errors?: string[];
+  error?: string;
+}> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models/sync`, {
+      method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, ...(await res.json()) };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function fetchAiModelRankings(): Promise<{
+  ok: boolean;
+  sources?: string[];
+  updated_elo?: number;
+  updated_benchmark?: number;
+  reordered_features?: string[];
+  fetched_rows?: Record<string, number>;
+  errors?: string[];
+  error?: string;
+}> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models/fetch-rankings`, {
+      method: "POST",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, ...(await res.json()) };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function bulkToggleModels(params: {
+  enabled: boolean;
+  tier: "free" | "paid" | "all";
+  provider?: string;
+}): Promise<{ ok: boolean; updated?: number; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models/bulk-toggle`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ enabled: params.enabled, tier: params.tier, provider: params.provider }),
+    });
+    if (!res.ok) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true, ...(await res.json()) };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export async function deleteAiModel(id: number): Promise<{ ok: boolean; error?: string }> {
+  const cookieStore = await cookies();
+  const token = cookieStore.get("admin_token")?.value;
+  try {
+    const res = await fetch(`${API_BASE}/ai/models/${id}`, {
+      method: "DELETE",
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!res.ok && res.status !== 204) {
+      const json = await res.json().catch(() => ({}));
+      return { ok: false, error: json.detail ?? `HTTP ${res.status}` };
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
   }
 }

--- a/app/admin/(dashboard)/ai/AiConfigClient.tsx
+++ b/app/admin/(dashboard)/ai/AiConfigClient.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import { Fragment, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { FiPlus, FiTrash2, FiX } from "react-icons/fi";
+import { testAiFeature, setFeatureChain, resetFeatureChain } from "@/app/actions/ai";
+import type { AiChainEntry, AiConfigData, AiKnownModel, AiModelEntry, AiTestResult } from "@/lib/types/ai";
+import AiModelsManager from "./AiModelsManager";
+
+interface Props {
+  config: AiConfigData;
+  knownModels: AiKnownModel[];
+}
+
+function ModelBadge({ entry }: { entry: AiModelEntry }) {
+  const shortModel = entry.model.split("/").pop() ?? entry.model;
+
+  if (!entry.skipped) {
+    return (
+      <div className="rounded border border-green-500/40 bg-green-500/10 px-2 py-1 text-xs min-w-0">
+        <div className="font-medium text-green-400 truncate">{entry.provider}</div>
+        <div className="text-green-600 truncate" title={entry.model}>{shortModel}</div>
+      </div>
+    );
+  }
+
+  if (entry.reason === "rate_limited") {
+    const remaining = entry.until
+      ? Math.max(0, entry.until - Math.floor(Date.now() / 1000))
+      : 0;
+    const mins = Math.ceil(remaining / 60);
+    return (
+      <div className="rounded border border-orange-500/40 bg-orange-500/10 px-2 py-1 text-xs min-w-0">
+        <div className="font-medium text-orange-400 truncate">{entry.provider}</div>
+        <div className="text-orange-600 truncate" title={entry.model}>{shortModel}</div>
+        <div className="text-orange-500 text-[10px]">rate-limited {mins}m</div>
+      </div>
+    );
+  }
+
+  const label = entry.reason === "missing_key" ? "no key" : "bad model";
+  return (
+    <div className="rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-xs min-w-0">
+      <div className="font-medium text-red-400 truncate">{entry.provider}</div>
+      <div className="text-red-600 truncate" title={entry.model}>{shortModel}</div>
+      <div className="text-red-500 text-[10px]">{label}</div>
+    </div>
+  );
+}
+
+interface EditPanelProps {
+  feature: string;
+  initial: AiChainEntry[];
+  knownModels: AiKnownModel[];
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const CUSTOM_SENTINEL = "__custom__";
+
+const FEATURE_META: Record<string, { type: "generation" | "embed"; description: string }> = {
+  rewrite:         { type: "generation", description: "AI-enhance CMS text fields" },
+  translate:       { type: "generation", description: "Translate content EN ↔ ES" },
+  suggest:         { type: "generation", description: "Suggest content for CMS fields" },
+  suggest_tags:    { type: "generation", description: "Suggest tags for blog posts" },
+  suggest_skills:  { type: "generation", description: "Suggest skills from job descriptions" },
+  jd_parse:        { type: "generation", description: "Parse job descriptions into structured data" },
+  cv_select:       { type: "generation", description: "Select relevant CV sections for a job" },
+  cover_letter:    { type: "generation", description: "Generate cover letters from CV + JD" },
+  qa_responder:    { type: "generation", description: "Answer application form questions" },
+  job_explain:     { type: "generation", description: "Explain job match scores in plain language" },
+  detect_language: { type: "generation", description: "Detect language of job descriptions" },
+  embed:           { type: "embed",      description: "Vector embeddings for job match scoring — embedding models only" },
+};
+
+function isEmbeddingModel(m: AiKnownModel): boolean {
+  return (
+    m.model.toLowerCase().includes("embed") ||
+    (m.notes ?? "").toLowerCase().includes("embeddings only")
+  );
+}
+
+function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPanelProps) {
+  const [chain, setChain] = useState<AiChainEntry[]>(initial.map((e) => ({ ...e })));
+  const [selected, setSelected] = useState("");
+  const [customProvider, setCustomProvider] = useState("");
+  const [customModel, setCustomModel] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const isEmbedFeature = FEATURE_META[feature]?.type === "embed";
+  const compatibleModels = knownModels.filter((m) =>
+    isEmbedFeature ? isEmbeddingModel(m) : !isEmbeddingModel(m)
+  );
+  const providerGroups = compatibleModels.reduce<Record<string, AiKnownModel[]>>((acc, m) => {
+    (acc[m.provider] ??= []).push(m);
+    return acc;
+  }, {});
+  const isCustom = selected === CUSTOM_SENTINEL;
+
+  const addEntry = () => {
+    if (compatibleModels.length > 0 && !isCustom) {
+      if (!selected) return;
+      const [p, ...rest] = selected.split("|");
+      const m = rest.join("|");
+      setChain((prev) => [...prev, { provider: p, model: m }]);
+      setSelected("");
+    } else {
+      const p = customProvider.trim();
+      const m = customModel.trim();
+      if (!p || !m) return;
+      setChain((prev) => [...prev, { provider: p, model: m }]);
+      setCustomProvider("");
+      setCustomModel("");
+      setSelected("");
+    }
+  };
+
+  const removeEntry = (i: number) => setChain((prev) => prev.filter((_, idx) => idx !== i));
+
+  const updateEntry = (i: number, field: "provider" | "model", value: string) => {
+    setChain((prev) => prev.map((e, idx) => (idx === i ? { ...e, [field]: value } : e)));
+  };
+
+  const handleSave = () => {
+    if (chain.length === 0) { setError("Chain must have at least one entry."); return; }
+    setError(null);
+    startTransition(async () => {
+      const result = await setFeatureChain(feature, chain);
+      if (result.ok) { onSaved(); onClose(); }
+      else setError(result.error ?? "Save failed");
+    });
+  };
+
+  const handleReset = () => {
+    startTransition(async () => {
+      const result = await resetFeatureChain(feature);
+      if (result.ok) { onSaved(); onClose(); }
+      else setError(result.error ?? "Reset failed");
+    });
+  };
+
+  return (
+    <tr>
+      <td
+        colSpan={999}
+        className="px-4 py-4 bg-[var(--bg-base)] border-b border-[var(--border-default)]"
+      >
+        <div className="max-w-2xl space-y-3">
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-semibold text-[var(--text-primary)]">
+              Edit chain — <code className="text-[var(--accent-cyan)]">{feature}</code>
+            </span>
+            <button onClick={onClose} className="text-[var(--text-muted)] hover:text-[var(--text-primary)]">
+              <FiX className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Current entries */}
+          <div className="space-y-1.5">
+            {chain.map((entry, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <span className="text-xs text-[var(--text-muted)] w-4 text-right shrink-0">{i + 1}</span>
+                <input
+                  value={entry.provider}
+                  onChange={(e) => updateEntry(i, "provider", e.target.value)}
+                  placeholder="provider"
+                  className="w-28 px-2 py-1 text-xs rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                />
+                <input
+                  value={entry.model}
+                  onChange={(e) => updateEntry(i, "model", e.target.value)}
+                  placeholder="model"
+                  className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                />
+                <button
+                  onClick={() => removeEntry(i)}
+                  className="text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors shrink-0"
+                >
+                  <FiTrash2 className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+
+          {/* Add row */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-[var(--text-muted)] w-4 text-right shrink-0">+</span>
+            {compatibleModels.length > 0 ? (
+              <>
+                <select
+                  value={selected}
+                  onChange={(e) => setSelected(e.target.value)}
+                  className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                >
+                  <option value="">— select a model —</option>
+                  {Object.entries(providerGroups).map(([prov, ms]) => (
+                    <optgroup key={prov} label={prov}>
+                      {ms.map((m) => (
+                        <option
+                          key={m.id}
+                          value={`${m.provider}|${m.model}`}
+                        >
+                          {m.display_name ?? m.model}{m.notes ? ` (${m.notes})` : ""}{!m.enabled ? " — disabled" : ""}
+                        </option>
+                      ))}
+                    </optgroup>
+                  ))}
+                  <option value={CUSTOM_SENTINEL}>Custom…</option>
+                </select>
+                {isCustom && (
+                  <>
+                    <input
+                      value={customProvider}
+                      onChange={(e) => setCustomProvider(e.target.value)}
+                      placeholder="provider"
+                      className="w-24 px-2 py-1 text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                    />
+                    <input
+                      value={customModel}
+                      onChange={(e) => setCustomModel(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && addEntry()}
+                      placeholder="model string"
+                      className="w-40 px-2 py-1 text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                    />
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                <input
+                  value={customProvider}
+                  onChange={(e) => setCustomProvider(e.target.value)}
+                  placeholder="provider"
+                  className="w-28 px-2 py-1 text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                />
+                <input
+                  value={customModel}
+                  onChange={(e) => setCustomModel(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && addEntry()}
+                  placeholder="model"
+                  className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border-subtle)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+                />
+              </>
+            )}
+            <button
+              onClick={addEntry}
+              className="text-[var(--accent-violet)] hover:text-[var(--accent-violet)]/80 transition-colors shrink-0"
+            >
+              <FiPlus className="w-4 h-4" />
+            </button>
+          </div>
+
+          {error && <p className="text-xs text-[var(--color-error)]">{error}</p>}
+
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              onClick={handleSave}
+              className="px-3 py-1.5 text-xs rounded-md bg-[var(--accent-violet)] text-white hover:bg-[var(--accent-violet)]/80 transition-colors"
+            >
+              Save
+            </button>
+            <button
+              onClick={handleReset}
+              className="px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--color-error)] hover:text-[var(--color-error)] transition-colors"
+            >
+              Reset to defaults
+            </button>
+          </div>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default function AiConfigClient({ config, knownModels }: Props) {
+  const router = useRouter();
+  const features = Object.keys(config);
+  const maxChain = features.length > 0
+    ? Math.max(...features.map((f) => config[f].length))
+    : 0;
+
+  const [testResults, setTestResults] = useState<Record<string, AiTestResult | "loading">>({});
+  const [editingFeature, setEditingFeature] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  const handleTest = (feature: string) => {
+    setTestResults((prev) => ({ ...prev, [feature]: "loading" }));
+    startTransition(async () => {
+      const result = await testAiFeature(feature);
+      setTestResults((prev) => ({ ...prev, [feature]: result }));
+    });
+  };
+
+  if (features.length === 0) {
+    return (
+      <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)] p-8 text-center text-sm text-[var(--text-muted)]">
+        No AI config data available.
+      </div>
+    );
+  }
+
+  const bgCell = "bg-[var(--bg-elevated)] group-hover:bg-[var(--bg-base)]";
+
+  return (
+    <div className="space-y-10">
+    <div className="overflow-x-auto rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)]">
+      <table className="w-full text-sm">
+        <thead className="border-b border-[var(--border-default)]">
+          <tr>
+            <th className="px-4 py-3 text-left text-[var(--text-muted)] font-medium whitespace-nowrap sticky left-0 z-10 bg-[var(--bg-elevated)]">
+              Feature
+            </th>
+            {Array.from({ length: maxChain }, (_, i) => (
+              <th key={i} className="px-3 py-3 text-left text-[var(--text-muted)] font-medium whitespace-nowrap">
+                #{i + 1}
+              </th>
+            ))}
+            <th className="px-4 py-3 text-left text-[var(--text-muted)] font-medium whitespace-nowrap">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {features.map((feature) => {
+            const chain = config[feature];
+            const testResult = testResults[feature];
+            const isEditing = editingFeature === feature;
+
+            return (
+              <Fragment key={feature}>
+                <tr className="group border-b border-[var(--border-subtle)] last:border-0">
+                  <td className={`px-4 py-3 sticky left-0 z-10 ${bgCell}`}>
+                    <span className="font-medium text-[var(--text-primary)] whitespace-nowrap">{feature}</span>
+                    {FEATURE_META[feature] && (
+                      <p className="text-[10px] text-[var(--text-muted)] mt-0.5 max-w-[160px]">
+                        {FEATURE_META[feature].description}
+                      </p>
+                    )}
+                  </td>
+                  {Array.from({ length: maxChain }, (_, i) => (
+                    <td key={i} className="px-3 py-2 align-top">
+                      {chain[i] ? <ModelBadge entry={chain[i]} /> : null}
+                    </td>
+                  ))}
+                  <td className="px-4 py-3 align-middle">
+                    <div className="flex items-center gap-2 flex-wrap min-w-[220px]">
+                      <button
+                        onClick={() => handleTest(feature)}
+                        disabled={testResult === "loading"}
+                        className="px-2.5 py-1 text-xs rounded-md bg-[var(--accent-violet)]/10 text-[var(--accent-violet)] border border-[var(--accent-violet)]/30 hover:bg-[var(--accent-violet)]/20 disabled:opacity-50 transition-colors"
+                      >
+                        {testResult === "loading" ? "…" : "Test"}
+                      </button>
+                      <button
+                        onClick={() => setEditingFeature(isEditing ? null : feature)}
+                        className={`px-2.5 py-1 text-xs rounded-md border transition-colors ${
+                          isEditing
+                            ? "border-[var(--accent-cyan)] text-[var(--accent-cyan)] bg-[var(--accent-cyan)]/10"
+                            : "border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)]"
+                        }`}
+                      >
+                        Edit
+                      </button>
+                      {testResult && testResult !== "loading" && (
+                        testResult.ok ? (
+                          <span className="text-xs text-green-400 whitespace-nowrap">
+                            ✓ {testResult.latency_ms}ms
+                          </span>
+                        ) : (
+                          <span
+                            className="text-xs text-red-400 max-w-[160px] truncate"
+                            title={testResult.error}
+                          >
+                            ✗ {testResult.error}
+                          </span>
+                        )
+                      )}
+                    </div>
+                  </td>
+                </tr>
+
+                {isEditing && (
+                  <EditPanel
+                    feature={feature}
+                    initial={chain.map((e) => ({ provider: e.provider, model: e.model }))}
+                    knownModels={knownModels}
+                    onClose={() => setEditingFeature(null)}
+                    onSaved={() => router.refresh()}
+                  />
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+    <AiModelsManager models={knownModels} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/ai/AiConfigClient.tsx
+++ b/app/admin/(dashboard)/ai/AiConfigClient.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { Fragment, useState, useTransition } from "react";
+import { Fragment, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { FiPlus, FiTrash2, FiX } from "react-icons/fi";
+import { FiMenu, FiPlus, FiTrash2, FiX } from "react-icons/fi";
 import { testAiFeature, setFeatureChain, resetFeatureChain } from "@/app/actions/ai";
 import type { AiChainEntry, AiConfigData, AiKnownModel, AiModelEntry, AiTestResult } from "@/lib/types/ai";
 import AiModelsManager from "./AiModelsManager";
@@ -87,10 +87,12 @@ function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPane
   const [customModel, setCustomModel] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [, startTransition] = useTransition();
+  const dragIdx = useRef<number | null>(null);
+  const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
 
   const isEmbedFeature = FEATURE_META[feature]?.type === "embed";
-  const compatibleModels = knownModels.filter((m) =>
-    isEmbedFeature ? isEmbeddingModel(m) : !isEmbeddingModel(m)
+  const compatibleModels = knownModels.filter(
+    (m) => m.enabled && (isEmbedFeature ? isEmbeddingModel(m) : !isEmbeddingModel(m))
   );
   const providerGroups = compatibleModels.reduce<Record<string, AiKnownModel[]>>((acc, m) => {
     (acc[m.provider] ??= []).push(m);
@@ -156,10 +158,35 @@ function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPane
             </button>
           </div>
 
-          {/* Current entries */}
+          {/* Current entries — draggable to reorder */}
           <div className="space-y-1.5">
             {chain.map((entry, i) => (
-              <div key={i} className="flex items-center gap-2">
+              <div
+                key={i}
+                draggable
+                onDragStart={() => { dragIdx.current = i; }}
+                onDragOver={(e) => { e.preventDefault(); setDragOverIdx(i); }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  const from = dragIdx.current;
+                  if (from === null || from === i) return;
+                  setChain((prev) => {
+                    const next = [...prev];
+                    const [moved] = next.splice(from, 1);
+                    next.splice(i, 0, moved);
+                    return next;
+                  });
+                  dragIdx.current = null;
+                  setDragOverIdx(null);
+                }}
+                onDragEnd={() => { dragIdx.current = null; setDragOverIdx(null); }}
+                className={`flex items-center gap-2 rounded transition-colors ${
+                  dragOverIdx === i && dragIdx.current !== i
+                    ? "ring-1 ring-[var(--accent-violet)] bg-[var(--accent-violet)]/5"
+                    : ""
+                } ${dragIdx.current === i ? "opacity-40" : ""}`}
+              >
+                <FiMenu className="w-3 h-3 text-[var(--text-muted)] shrink-0 cursor-grab active:cursor-grabbing" />
                 <span className="text-xs text-[var(--text-muted)] w-4 text-right shrink-0">{i + 1}</span>
                 <input
                   value={entry.provider}

--- a/app/admin/(dashboard)/ai/AiModelsManager.tsx
+++ b/app/admin/(dashboard)/ai/AiModelsManager.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { Fragment, useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { FiAward, FiDownloadCloud, FiPlus, FiTrash2 } from "react-icons/fi";
+import {
+  bulkToggleModels,
+  createAiModel,
+  deleteAiModel,
+  fetchAiModelRankings,
+  syncAiModels,
+  updateAiModel,
+} from "@/app/actions/ai";
+import type { AiKnownModel } from "@/lib/types/ai";
+
+interface Props {
+  models: AiKnownModel[];
+}
+
+const isFreeModel = (m: AiKnownModel) =>
+  (m.notes?.toLowerCase() ?? "").includes("free tier");
+
+export default function AiModelsManager({ models }: Props) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [localModels, setLocalModels] = useState<AiKnownModel[]>(models);
+  const [error, setError] = useState<string | null>(null);
+  const [syncResult, setSyncResult] = useState<string | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  const [rankingResult, setRankingResult] = useState<string | null>(null);
+  const [fetchingRankings, setFetchingRankings] = useState(false);
+  const [bulkLoading, setBulkLoading] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalModels(models);
+  }, [models]);
+
+  // Add form state
+  const [provider, setProvider] = useState("");
+  const [model, setModel] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [notes, setNotes] = useState("");
+
+  const handleAdd = () => {
+    const p = provider.trim();
+    const m = model.trim();
+    if (!p || !m) { setError("Provider and model are required."); return; }
+    setError(null);
+    startTransition(async () => {
+      const res = await createAiModel({
+        provider: p,
+        model: m,
+        display_name: displayName.trim() || undefined,
+        notes: notes.trim() || undefined,
+      });
+      if (res.ok) {
+        setProvider(""); setModel(""); setDisplayName(""); setNotes("");
+        router.refresh();
+      } else {
+        setError(res.error ?? "Failed to add model");
+      }
+    });
+  };
+
+  const handleToggle = (m: AiKnownModel) => {
+    setLocalModels((prev) =>
+      prev.map((item) => (item.id === m.id ? { ...item, enabled: !item.enabled } : item))
+    );
+    startTransition(async () => {
+      const res = await updateAiModel(m.id, { enabled: !m.enabled });
+      if (!res.ok) {
+        setLocalModels((prev) =>
+          prev.map((item) => (item.id === m.id ? { ...item, enabled: m.enabled } : item))
+        );
+        setError(res.error ?? "Update failed");
+      }
+    });
+  };
+
+  const handleDelete = (id: number) => {
+    startTransition(async () => {
+      const res = await deleteAiModel(id);
+      if (!res.ok) setError(res.error ?? "Delete failed");
+      else setLocalModels((prev) => prev.filter((item) => item.id !== id));
+    });
+  };
+
+  const handleBulkToggle = async (
+    enabled: boolean,
+    tier: "free" | "paid" | "all",
+    prov?: string,
+  ) => {
+    const key = `${enabled ? "en" : "dis"}_${tier}${prov ? `_${prov}` : ""}`;
+    setBulkLoading(key);
+    setError(null);
+    // Optimistic
+    setLocalModels((prev) =>
+      prev.map((m) => {
+        if (prov && m.provider !== prov) return m;
+        const free = isFreeModel(m);
+        if (tier === "paid" && free) return m;
+        if (tier === "free" && !free) return m;
+        return { ...m, enabled };
+      })
+    );
+    const res = await bulkToggleModels({ enabled, tier, provider: prov });
+    setBulkLoading(null);
+    if (!res.ok) {
+      setLocalModels(models); // full revert on failure
+      setError(res.error ?? "Bulk toggle failed");
+    }
+  };
+
+  const handleFetchRankings = async () => {
+    setFetchingRankings(true);
+    setRankingResult(null);
+    setError(null);
+    const res = await fetchAiModelRankings();
+    setFetchingRankings(false);
+    if (!res.ok) {
+      setError(res.error ?? "Fetch rankings failed");
+      return;
+    }
+    const parts: string[] = [];
+    if ((res.updated_elo ?? 0) > 0) parts.push(`${res.updated_elo} ELO scores`);
+    if ((res.updated_benchmark ?? 0) > 0) parts.push(`${res.updated_benchmark} benchmark scores`);
+    const scored = parts.length ? `Updated ${parts.join(" + ")}.` : "No new scores matched.";
+    const reordered = (res.reordered_features?.length ?? 0) > 0
+      ? ` Auto-reordered ${res.reordered_features!.length} chain(s): ${res.reordered_features!.join(", ")}.`
+      : "";
+    const srcs = res.sources?.length ? ` Sources: ${res.sources.join("; ")}.` : "";
+    const fetched = res.fetched_rows && Object.keys(res.fetched_rows).length
+      ? ` Fetched: ${Object.entries(res.fetched_rows).map(([k, v]) => `${k.split("/").pop()}: ${v} rows`).join(", ")}.`
+      : "";
+    const errs = res.errors?.length ? ` Errors: ${res.errors.join("; ")}` : "";
+    setRankingResult(scored + reordered + srcs + fetched + errs);
+    if ((res.updated_elo ?? 0) + (res.updated_benchmark ?? 0) > 0) router.refresh();
+  };
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setSyncResult(null);
+    setError(null);
+    const res = await syncAiModels();
+    setSyncing(false);
+    if (!res.ok) {
+      setError(res.error ?? "Sync failed");
+      return;
+    }
+    const parts = Object.entries(res.added ?? {})
+      .filter(([, n]) => n > 0)
+      .map(([p, n]) => `${p}: +${n}`);
+    const summary = res.total_added === 0
+      ? "Already up to date — no new models found."
+      : `Added ${res.total_added} model${res.total_added === 1 ? "" : "s"}${parts.length ? ` (${parts.join(", ")})` : ""}.`;
+    const errNote = res.errors?.length ? ` Errors: ${res.errors.join("; ")}` : "";
+    setSyncResult(summary + errNote);
+    if ((res.total_added ?? 0) > 0) router.refresh();
+  };
+
+  const providers = [...new Set(localModels.map((m) => m.provider))].sort();
+  const globalPaidCount = localModels.filter((m) => !isFreeModel(m)).length;
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide">
+            Known Models Catalog
+          </h2>
+          <p className="text-xs text-[var(--text-muted)] mt-0.5">
+            Models available in the Edit chain dropdown. Disabled models are hidden from the dropdown but not deleted.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2 shrink-0">
+          {globalPaidCount > 0 && (
+            <>
+              <button
+                onClick={() => handleBulkToggle(false, "paid")}
+                disabled={bulkLoading !== null}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] text-[var(--text-muted)] hover:border-orange-500/50 hover:text-orange-400 disabled:opacity-40 transition-colors"
+                title={`Disable all ${globalPaidCount} paid models`}
+              >
+                Disable all paid
+              </button>
+              <button
+                onClick={() => handleBulkToggle(true, "paid")}
+                disabled={bulkLoading !== null}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] text-[var(--text-muted)] hover:border-emerald-500/50 hover:text-emerald-400 disabled:opacity-40 transition-colors"
+                title={`Enable all ${globalPaidCount} paid models`}
+              >
+                Enable all paid
+              </button>
+            </>
+          )}
+          <button
+            onClick={handleFetchRankings}
+            disabled={fetchingRankings}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-violet)] hover:text-[var(--accent-violet)] disabled:opacity-50 transition-colors"
+            title="Fetch ELO and benchmark scores from public leaderboards and auto-reorder chains"
+          >
+            <FiAward className="w-3.5 h-3.5" />
+            {fetchingRankings ? "Fetching…" : "Fetch rankings"}
+          </button>
+          <button
+            onClick={handleSync}
+            disabled={syncing}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] text-[var(--text-secondary)] hover:border-[var(--accent-cyan)] hover:text-[var(--accent-cyan)] disabled:opacity-50 transition-colors"
+            title="Fetch current model lists from Groq, OpenRouter, and Google and add any new ones"
+          >
+            <FiDownloadCloud className="w-3.5 h-3.5" />
+            {syncing ? "Syncing…" : "Sync from providers"}
+          </button>
+        </div>
+      </div>
+
+      {rankingResult && (
+        <div className="px-4 py-2 rounded-lg bg-violet-500/10 border border-violet-500/30 text-xs text-violet-300 space-y-1">
+          <p>{rankingResult}</p>
+          {rankingResult.includes("No new scores") && (
+            <p className="text-violet-400/70">
+              If no rows were fetched, the leaderboard dataset may require auth.
+              Add <code className="bg-violet-500/20 px-1 rounded">HUGGINGFACE_API_TOKEN</code> to{" "}
+              <code className="bg-violet-500/20 px-1 rounded">backend/.env</code>.{" "}
+              Get a free <strong>Read</strong> token at{" "}
+              <a
+                href="https://huggingface.co/settings/tokens"
+                target="_blank"
+                rel="noreferrer"
+                className="underline hover:text-violet-300"
+              >
+                huggingface.co/settings/tokens
+              </a>{" "}
+              (free account required, no credit card).
+            </p>
+          )}
+        </div>
+      )}
+      {syncResult && (
+        <div className="px-4 py-2 rounded-lg bg-emerald-500/10 border border-emerald-500/30 text-xs text-emerald-300">
+          {syncResult}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)]">
+        <table className="w-full text-sm">
+          <thead className="border-b border-[var(--border-default)]">
+            <tr>
+              {["Model", "Display name", "Notes", "ELO", "Bench %", "Enabled", ""].map((h) => (
+                <th key={h} className="px-4 py-3 text-left text-[var(--text-muted)] font-medium whitespace-nowrap">
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {providers.map((prov) => {
+              const provModels = localModels.filter((m) => m.provider === prov);
+              const paidCount = provModels.filter((m) => !isFreeModel(m)).length;
+              return (
+                <Fragment key={prov}>
+                  {/* Provider group header */}
+                  <tr className="border-b border-[var(--border-default)] bg-[var(--bg-base)]/60">
+                    <td colSpan={7} className="px-4 py-1.5">
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] font-semibold uppercase tracking-wider text-[var(--text-muted)]">
+                          {prov}
+                          <span className="ml-2 font-normal normal-case">
+                            {provModels.length} model{provModels.length !== 1 ? "s" : ""}
+                            {paidCount > 0 && ` · ${paidCount} paid`}
+                          </span>
+                        </span>
+                        {paidCount > 0 && (
+                          <div className="flex items-center gap-1.5">
+                            <button
+                              onClick={() => handleBulkToggle(false, "paid", prov)}
+                              disabled={bulkLoading !== null}
+                              className="text-[10px] px-2 py-0.5 rounded border border-[var(--border-default)] text-[var(--text-muted)] hover:border-orange-500/50 hover:text-orange-400 disabled:opacity-40 transition-colors"
+                            >
+                              Disable paid
+                            </button>
+                            <button
+                              onClick={() => handleBulkToggle(true, "paid", prov)}
+                              disabled={bulkLoading !== null}
+                              className="text-[10px] px-2 py-0.5 rounded border border-[var(--border-default)] text-[var(--text-muted)] hover:border-emerald-500/50 hover:text-emerald-400 disabled:opacity-40 transition-colors"
+                            >
+                              Enable paid
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                  {/* Model rows */}
+                  {provModels.map((m) => (
+                    <tr
+                      key={m.id}
+                      className={`border-b border-[var(--border-subtle)] last:border-0 hover:bg-[var(--bg-base)] ${
+                        !m.enabled ? "opacity-50" : ""
+                      }`}
+                    >
+                      <td className="px-4 py-2 font-mono text-xs text-[var(--text-primary)] max-w-xs truncate" title={m.model}>
+                        {m.model}
+                      </td>
+                      <td className="px-4 py-2 text-[var(--text-secondary)]">{m.display_name ?? "—"}</td>
+                      <td className="px-4 py-2 text-xs text-[var(--text-muted)]">{m.notes ?? "—"}</td>
+                      <td className="px-4 py-2 text-xs tabular-nums text-[var(--text-secondary)]">
+                        {m.elo_score ?? "—"}
+                      </td>
+                      <td className="px-4 py-2 text-xs tabular-nums text-[var(--text-secondary)]">
+                        {m.avg_benchmark != null ? `${m.avg_benchmark.toFixed(1)}%` : "—"}
+                      </td>
+                      <td className="px-4 py-2">
+                        <button
+                          onClick={() => handleToggle(m)}
+                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                            m.enabled ? "bg-[var(--accent-violet)]" : "bg-[var(--border-strong)]"
+                          }`}
+                          title={m.enabled ? "Disable" : "Enable"}
+                        >
+                          <span
+                            className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
+                              m.enabled ? "translate-x-4" : "translate-x-0.5"
+                            }`}
+                          />
+                        </button>
+                      </td>
+                      <td className="px-4 py-2">
+                        <button
+                          onClick={() => handleDelete(m.id)}
+                          className="text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors"
+                          title="Delete permanently"
+                        >
+                          <FiTrash2 className="w-4 h-4" />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </Fragment>
+              );
+            })}
+            {localModels.length === 0 && (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-[var(--text-muted)]">
+                  No models in catalog yet.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Add form */}
+      <div className="rounded-xl border border-[var(--border-default)] bg-[var(--bg-elevated)] p-4 space-y-3">
+        <p className="text-xs font-semibold text-[var(--text-secondary)] uppercase tracking-wide">Add model</p>
+        <div className="flex flex-wrap gap-2">
+          <input
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            placeholder="provider  (e.g. groq)"
+            className="w-36 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+          />
+          <input
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            placeholder="model string  (e.g. llama-3.3-70b-versatile)"
+            className="flex-1 min-w-48 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+          />
+          <input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="display name  (optional)"
+            className="w-44 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+          />
+          <input
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
+            placeholder="notes  (optional, e.g. free tier)"
+            className="w-44 px-3 py-1.5 text-xs rounded-md border border-[var(--border-default)] bg-[var(--bg-base)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
+          />
+          <button
+            onClick={handleAdd}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md bg-[var(--accent-violet)] text-white hover:bg-[var(--accent-violet)]/80 transition-colors"
+          >
+            <FiPlus className="w-3.5 h-3.5" />
+            Add
+          </button>
+        </div>
+        {error && <p className="text-xs text-[var(--color-error)]">{error}</p>}
+      </div>
+    </section>
+  );
+}

--- a/app/admin/(dashboard)/ai/AiModelsManager.tsx
+++ b/app/admin/(dashboard)/ai/AiModelsManager.tsx
@@ -219,19 +219,17 @@ export default function AiModelsManager({ models }: Props) {
           <p>{rankingResult}</p>
           {rankingResult.includes("No new scores") && (
             <p className="text-violet-400/70">
-              If no rows were fetched, the leaderboard dataset may require auth.
-              Add <code className="bg-violet-500/20 px-1 rounded">HUGGINGFACE_API_TOKEN</code> to{" "}
-              <code className="bg-violet-500/20 px-1 rounded">backend/.env</code>.{" "}
-              Get a free <strong>Read</strong> token at{" "}
-              <a
-                href="https://huggingface.co/settings/tokens"
-                target="_blank"
-                rel="noreferrer"
-                className="underline hover:text-violet-300"
-              >
-                huggingface.co/settings/tokens
-              </a>{" "}
-              (free account required, no credit card).
+              <strong>AlpacaEval</strong> is tried first and is fully public — no token needed.
+              The LMSYS and Open LLM leaderboards are <strong>gated</strong>: a token alone is not
+              enough. You must visit each dataset page on HuggingFace and click{" "}
+              <em>Agree and access repository</em>:
+              {" "}
+              <a href="https://huggingface.co/datasets/lmsys/chatbot-arena-leaderboard" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">chatbot-arena-leaderboard</a>
+              {" · "}
+              <a href="https://huggingface.co/datasets/HuggingFaceH4/open_llm_leaderboard" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">open_llm_leaderboard</a>.
+              Then add your <strong>Read</strong> token to{" "}
+              <code className="bg-violet-500/20 px-1 rounded">HUGGINGFACE_API_TOKEN</code> in{" "}
+              <code className="bg-violet-500/20 px-1 rounded">backend/.env</code>.
             </p>
           )}
         </div>

--- a/app/admin/(dashboard)/ai/page.tsx
+++ b/app/admin/(dashboard)/ai/page.tsx
@@ -1,0 +1,24 @@
+import { getAiConfig, getAiKnownModels } from "@/lib/adminApi";
+import type { AiConfigData, AiKnownModel } from "@/lib/types/ai";
+import AiConfigClient from "./AiConfigClient";
+
+export const revalidate = 0;
+
+export default async function AiConfigPage() {
+  const [config, knownModels] = await Promise.all([
+    getAiConfig() as Promise<AiConfigData | null>,
+    getAiKnownModels() as Promise<AiKnownModel[] | null>,
+  ]);
+
+  return (
+    <div className="p-6 max-w-full space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold text-[var(--text-primary)] mb-1">AI Model Config</h1>
+        <p className="text-sm text-[var(--text-muted)]">
+          Live routing chain per feature. Skip status reflects this worker&apos;s in-process state.
+        </p>
+      </div>
+      <AiConfigClient config={config ?? {}} knownModels={knownModels ?? []} />
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/ai/usage/page.tsx
+++ b/app/admin/(dashboard)/ai/usage/page.tsx
@@ -1,4 +1,4 @@
-import { getAiUsage } from "@/app/actions/ai";
+import { getAiUsage, getProviderCredits } from "@/app/actions/ai";
 
 function fmt(n: number | null, unit = ""): string {
   if (n == null) return "—";
@@ -6,7 +6,7 @@ function fmt(n: number | null, unit = ""): string {
 }
 
 export default async function AIUsagePage() {
-  const data = await getAiUsage();
+  const [data, credits] = await Promise.all([getAiUsage(), getProviderCredits()]);
   const stats = data?.stats ?? [];
   const calls = data?.calls ?? [];
 
@@ -18,6 +18,67 @@ export default async function AIUsagePage() {
           Token counts: tiktoken (OpenAI/Groq) · google-genai count_tokens (Gemini). Refreshes every 60 s.
         </p>
       </div>
+
+      {/* ── Provider balances ── */}
+      {credits && Object.keys(credits).length > 0 && (
+        <section>
+          <h2 className="text-sm font-semibold text-[var(--text-secondary)] uppercase tracking-wide mb-3">
+            Provider balances
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {credits.openrouter && (
+              <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-4 space-y-1">
+                <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wide">OpenRouter</p>
+                {credits.openrouter.error ? (
+                  <p className="text-xs text-[var(--color-error)]">{credits.openrouter.error}</p>
+                ) : (
+                  <>
+                    <p className="text-lg font-bold text-[var(--text-primary)]">
+                      ${(credits.openrouter.usage_usd ?? 0).toFixed(4)}
+                      <span className="text-xs font-normal text-[var(--text-muted)] ml-1">spent</span>
+                    </p>
+                    {credits.openrouter.limit_usd != null ? (
+                      <p className="text-xs text-[var(--text-secondary)]">
+                        Limit: ${credits.openrouter.limit_usd.toFixed(2)}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-[var(--text-secondary)]">No spend limit set</p>
+                    )}
+                    {credits.openrouter.is_free_tier && (
+                      <p className="text-xs text-emerald-400">Free tier</p>
+                    )}
+                    {credits.openrouter.label && (
+                      <p className="text-xs text-[var(--text-muted)] truncate">Key: {credits.openrouter.label}</p>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+            {credits.groq && (
+              <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-4 space-y-1">
+                <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wide">Groq</p>
+                <p className="text-lg font-bold text-emerald-400">Free</p>
+                <p className="text-xs text-[var(--text-secondary)]">{credits.groq.note}</p>
+                <a href={credits.groq.docs_url} target="_blank" rel="noopener noreferrer"
+                  className="text-xs text-[var(--accent-cyan)] hover:underline">
+                  View rate limits →
+                </a>
+              </div>
+            )}
+            {credits.google && (
+              <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-4 space-y-1">
+                <p className="text-xs font-semibold text-[var(--text-muted)] uppercase tracking-wide">Google / Gemini</p>
+                <p className="text-lg font-bold text-[var(--text-muted)]">—</p>
+                <p className="text-xs text-[var(--text-secondary)]">{credits.google.note}</p>
+                <a href={credits.google.docs_url} target="_blank" rel="noopener noreferrer"
+                  className="text-xs text-[var(--accent-cyan)] hover:underline">
+                  Open AI Studio →
+                </a>
+              </div>
+            )}
+          </div>
+        </section>
+      )}
 
       {!data ? (
         <div className="bg-[var(--bg-elevated)] rounded-xl border border-[var(--border-default)] p-6">

--- a/app/admin/(dashboard)/jobs/JobsClient.tsx
+++ b/app/admin/(dashboard)/jobs/JobsClient.tsx
@@ -11,6 +11,8 @@ const POLL_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour
 const POLL_LS_KEY = "jobs_last_poll_ts";
 // Show "stop spending?" banner after this many jobs enriched in one poll.
 const SPEND_PROMPT_THRESHOLD = 10;
+// Initial page size (matches the server component fetch limit — kept small for fast load).
+const INITIAL_PAGE_SIZE = 100;
 // Each "Load more" call fetches this many additional rows from the server.
 const LOAD_MORE_BATCH = 500;
 
@@ -63,7 +65,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   const spendPromptShownRef = useRef(false);
   // Pagination — initialJobs is the first page (500 max from server).
   const [loadingMore, setLoadingMore] = useState(false);
-  const [exhausted, setExhausted] = useState(initialJobs.length < LOAD_MORE_BATCH);
+  const [exhausted, setExhausted] = useState(initialJobs.length < INITIAL_PAGE_SIZE);
 
   // Hydrate cooldown from localStorage on mount.
   useEffect(() => {
@@ -79,7 +81,7 @@ export default function JobsClient({ initialJobs }: { initialJobs: ApiJob[] }) {
   // without this the kanban shows stale counts even after a successful refresh.
   useEffect(() => {
     setJobs(initialJobs);
-    setExhausted(initialJobs.length < LOAD_MORE_BATCH);
+    setExhausted(initialJobs.length < INITIAL_PAGE_SIZE);
   }, [initialJobs]);
 
   async function handleLoadMore() {

--- a/app/admin/(dashboard)/jobs/page.tsx
+++ b/app/admin/(dashboard)/jobs/page.tsx
@@ -6,7 +6,7 @@ import JobsClient from "./JobsClient";
 export const revalidate = 0;
 
 export default async function AdminJobsPage() {
-  const jobs = (await getAdminJobs({ limit: 500 })) as ApiJob[];
+  const jobs = (await getAdminJobs({ limit: 100 })) as ApiJob[];
 
   return (
     <div className="max-w-7xl mx-auto">

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <html lang="en">
+      <body>
+        <div className="min-h-screen flex flex-col items-center justify-center px-6 text-center relative overflow-hidden bg-[var(--bg-base)]">
+          <div className="absolute inset-0 -z-10">
+            <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-[var(--accent-cyan)] opacity-10 rounded-full blur-3xl" />
+            <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-[var(--accent-violet)] opacity-10 rounded-full blur-3xl" />
+          </div>
+
+          <h1 className="text-[8rem] md:text-[12rem] font-black leading-none text-transparent bg-clip-text bg-[image:var(--gradient-brand)] select-none">
+            404
+          </h1>
+
+          <h2 className="text-2xl md:text-3xl font-bold text-[var(--text-primary)] mb-4 -mt-4">
+            Page not found
+          </h2>
+
+          <p className="text-[var(--text-secondary)] max-w-md mb-10">
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          </p>
+
+          <Link
+            href="/"
+            className="group inline-flex items-center gap-2 px-8 py-3.5 rounded-full bg-[image:var(--gradient-brand)] text-white font-semibold text-sm transition-all duration-300 hover:opacity-90 shadow-lg"
+          >
+            <ArrowLeft size={16} className="group-hover:-translate-x-1 transition-transform" />
+            Back to home
+          </Link>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -1,18 +1,117 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { FiLogOut } from "react-icons/fi";
+import { FiChevronDown, FiLogOut } from "react-icons/fi";
 import { logoutAction } from "@/app/actions/auth";
 import { adminNavItems } from "@/lib/constants/adminNav";
+import type { NavEntry, NavGroup, NavItem } from "@/lib/types/admin";
+
+function isGroup(entry: NavEntry): entry is NavGroup {
+  return "items" in entry;
+}
+
+function isActive(href: string, pathname: string) {
+  return pathname === href || (href !== "/admin" && pathname.startsWith(href + "/"));
+}
 
 export default function AdminSidebar() {
   const pathname = usePathname();
   const router = useRouter();
 
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(() => {
+    const initial = new Set<string>();
+    for (const entry of adminNavItems) {
+      if (isGroup(entry) && entry.items.some((sub) => isActive(sub.href, pathname ?? ""))) {
+        initial.add(entry.label);
+      }
+    }
+    return initial;
+  });
+
+  useEffect(() => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      for (const entry of adminNavItems) {
+        if (isGroup(entry) && entry.items.some((sub) => isActive(sub.href, pathname))) {
+          next.add(entry.label);
+        }
+      }
+      return next;
+    });
+  }, [pathname]);
+
+  const toggleGroup = (label: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(label)) { next.delete(label); } else { next.add(label); }
+      return next;
+    });
+  };
+
   const handleLogout = async () => {
     await logoutAction();
     router.push("/admin/login");
+  };
+
+  const linkClass = (active: boolean) =>
+    `flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+      active
+        ? "bg-[var(--accent-violet)]/10 text-[var(--accent-violet)]"
+        : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)]"
+    }`;
+
+  const renderItem = (item: NavItem) => {
+    const active = isActive(item.href, pathname);
+    return (
+      <Link key={item.href} href={item.href} className={linkClass(active)}>
+        <item.icon className="w-5 h-5" />
+        {item.label}
+      </Link>
+    );
+  };
+
+  const renderGroup = (group: NavGroup) => {
+    const groupActive = group.items.some((sub) => isActive(sub.href, pathname));
+    const expanded = expandedGroups.has(group.label);
+
+    return (
+      <div key={group.label}>
+        <button
+          onClick={() => toggleGroup(group.label)}
+          className={linkClass(groupActive) + " w-full"}
+        >
+          <group.icon className="w-5 h-5" />
+          {group.label}
+          <FiChevronDown
+            className={`ml-auto w-4 h-4 transition-transform duration-150 ${expanded ? "rotate-180" : ""}`}
+          />
+        </button>
+
+        {expanded && (
+          <div className="mt-1 ml-4 pl-3 border-l border-[var(--border-subtle)] space-y-0.5">
+            {group.items.map((sub) => {
+              const active = isActive(sub.href, pathname);
+              return (
+                <Link
+                  key={sub.href}
+                  href={sub.href}
+                  className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    active
+                      ? "text-[var(--accent-violet)]"
+                      : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)]"
+                  }`}
+                >
+                  <sub.icon className="w-4 h-4" />
+                  {sub.label}
+                </Link>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -23,26 +122,10 @@ export default function AdminSidebar() {
         </h2>
       </div>
 
-      <nav className="flex-1 p-4 space-y-1">
-        {adminNavItems.map((item) => {
-          const isActive =
-            pathname === item.href ||
-            (item.href !== "/admin" && pathname.startsWith(item.href));
-          return (
-            <Link
-              key={item.href}
-              href={item.href}
-              className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors ${
-                isActive
-                  ? "bg-[var(--accent-violet)]/10 text-[var(--accent-violet)]"
-                  : "text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--bg-elevated)]"
-              }`}
-            >
-              <item.icon className="w-5 h-5" />
-              {item.label}
-            </Link>
-          );
-        })}
+      <nav className="flex-1 p-4 space-y-1 overflow-y-auto">
+        {adminNavItems.map((entry) =>
+          isGroup(entry) ? renderGroup(entry) : renderItem(entry)
+        )}
       </nav>
 
       <div className="p-4 border-t border-[var(--border-subtle)]">

--- a/lib/adminApi.ts
+++ b/lib/adminApi.ts
@@ -469,3 +469,22 @@ export async function renderCvPdf(cvVersionId: string): Promise<{ pdf_url: strin
   }
   return res.json();
 }
+
+export async function getAiConfig() {
+  const res = await fetch(`${API_BASE_URL}/ai/config`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+export async function getAiKnownModels() {
+  const res = await fetch(`${API_BASE_URL}/ai/models`, {
+    headers: await getAuthHeader(),
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+

--- a/lib/constants/adminNav.ts
+++ b/lib/constants/adminNav.ts
@@ -2,6 +2,7 @@ import {
   FiAward,
   FiBriefcase,
   FiCompass,
+  FiCpu,
   FiEdit3,
   FiFileText,
   FiGlobe,
@@ -9,26 +10,34 @@ import {
   FiLayout,
   FiList,
   FiMail,
+  FiSliders,
   FiUploadCloud,
   FiUser,
   FiZap,
 } from "react-icons/fi";
-import type { NavItem } from "@/lib/types/admin";
+import type { NavEntry } from "@/lib/types/admin";
 
-export type { NavItem } from "@/lib/types/admin";
+export type { NavItem, NavGroup, NavEntry } from "@/lib/types/admin";
 
-export const adminNavItems: NavItem[] = [
-  { href: "/admin",            label: "Dashboard",  icon: FiHome },
-  { href: "/admin/profile",    label: "Profile",    icon: FiUser },
-  { href: "/admin/projects",   label: "Projects",   icon: FiLayout },
-  { href: "/admin/experience", label: "Experience", icon: FiBriefcase },
-  { href: "/admin/skills",     label: "Skills",     icon: FiList },
-  { href: "/admin/education",  label: "Education",  icon: FiAward },
-  { href: "/admin/blog",       label: "Blog & AI",  icon: FiEdit3 },
-  { href: "/admin/messages",   label: "Inbox",      icon: FiMail },
-  { href: "/admin/translations", label: "Translations", icon: FiGlobe },
+export const adminNavItems: NavEntry[] = [
+  { href: "/admin",            label: "Dashboard",          icon: FiHome },
+  { href: "/admin/profile",    label: "Profile",            icon: FiUser },
+  { href: "/admin/projects",   label: "Projects",           icon: FiLayout },
+  { href: "/admin/experience", label: "Experience",         icon: FiBriefcase },
+  { href: "/admin/skills",     label: "Skills",             icon: FiList },
+  { href: "/admin/education",  label: "Education",          icon: FiAward },
+  { href: "/admin/blog",       label: "Blog",               icon: FiEdit3 },
+  { href: "/admin/messages",   label: "Inbox",              icon: FiMail },
+  { href: "/admin/translations", label: "Translations",     icon: FiGlobe },
   { href: "/admin/imports/linkedin", label: "LinkedIn Import", icon: FiUploadCloud },
   { href: "/admin/cv/generate", label: "CV & Cover Letter", icon: FiFileText },
-  { href: "/admin/jobs",        label: "Jobs",        icon: FiCompass },
-  { href: "/admin/ai/usage",    label: "AI Usage",    icon: FiZap },
+  { href: "/admin/jobs",        label: "Jobs",              icon: FiCompass },
+  {
+    label: "AI",
+    icon: FiCpu,
+    items: [
+      { href: "/admin/ai/usage", label: "Usage",  icon: FiZap },
+      { href: "/admin/ai",       label: "Config", icon: FiSliders },
+    ],
+  },
 ];

--- a/lib/types/admin.ts
+++ b/lib/types/admin.ts
@@ -5,3 +5,11 @@ export interface NavItem {
   label: string;
   icon: IconType;
 }
+
+export interface NavGroup {
+  label: string;
+  icon: IconType;
+  items: NavItem[];
+}
+
+export type NavEntry = NavItem | NavGroup;

--- a/lib/types/ai.ts
+++ b/lib/types/ai.ts
@@ -42,3 +42,37 @@ export interface AiUsageData {
   calls: AiCallRow[];
   stats: AiModelStat[];
 }
+
+export interface AiChainEntry {
+  provider: string;
+  model: string;
+}
+
+export interface AiModelEntry {
+  provider: string;
+  model: string;
+  skipped: boolean;
+  reason?: "rate_limited" | "missing_key" | "invalid_model";
+  until?: number;
+}
+
+export type AiConfigData = Record<string, AiModelEntry[]>;
+
+export interface AiTestResult {
+  ok: boolean;
+  provider: string | null;
+  model: string | null;
+  latency_ms?: number;
+  error?: string;
+}
+
+export interface AiKnownModel {
+  id: number;
+  provider: string;
+  model: string;
+  display_name: string | null;
+  notes: string | null;
+  enabled: boolean;
+  elo_score: number | null;
+  avg_benchmark: number | null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -26,6 +26,13 @@ function isTokenValid(token: string | undefined): boolean {
 export function middleware(req: NextRequest) {
   const path = req.nextUrl.pathname;
 
+  // Static files in public/ — bypass all locale + auth logic.
+  // The matcher regex should exclude these, but Vercel's edge runtime
+  // sometimes routes public/ requests through middleware anyway.
+  if (/\.\w+$/.test(path)) {
+    return NextResponse.next();
+  }
+
   // Admin auth — runs before locale handling
   if (path.startsWith("/admin") && path !== "/admin/login") {
     const token = req.cookies.get("admin_token")?.value;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "app/**": {
+      "maxDuration": 30
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Known Models Catalog** (`/admin/ai`): provider groups with per-row enable/disable toggle (optimistic, no full re-render), ELO score, and avg_benchmark columns
- **Bulk actions**: global and per-provider "Disable paid / Enable paid" buttons via `POST /ai/models/bulk-toggle`; optimistic with revert on failure
- **Sync from providers**: fetches live model lists from Groq/OpenRouter/Google
- **Fetch rankings**: fetches ELO and benchmark scores from HuggingFace leaderboards; reports fetched row counts for debugging; inline help text with HuggingFace token setup instructions when no scores are found
- **Feature chain editor** (EditPanel): any catalog model (enabled or disabled) can be added to a feature's fallback chain; save/reset to DB override
- **Feature table**: each AI feature shows its current fallback chain with skip-status badges (green/orange/red), feature type, and inline test button
- **Provider credits card** on the usage page: OpenRouter balance, Groq/Google console links
- `fix(middleware)`: early `NextResponse.next()` for paths with file extensions — prevents `/resume.pdf` and other public assets from being caught by geo-locale redirect
- `feat`: root `app/not-found.tsx` for admin routes and middleware bypasses
- `feat`: `vercel.json` sets `maxDuration: 30` for long-running server actions

## Test plan

- [ ] `/admin/ai` loads and shows feature chain table + known models catalog
- [ ] Toggle a model on/off — UI updates immediately, no full page re-render
- [ ] "Sync from providers" adds new models; free models enabled, paid disabled
- [ ] "Disable all paid" / "Enable all paid" buttons update the correct subset
- [ ] Per-provider "Disable paid" button only affects that provider's paid models
- [ ] Open EditPanel for a feature — disabled models are visible and selectable
- [ ] Add a model to the chain, save — chain persists after page refresh
- [ ] "Fetch rankings" either updates ELO/benchmark scores or shows a diagnostic error
- [ ] `/resume.pdf` loads correctly in production (no locale redirect)
- [ ] Navigate to a non-existent admin route — custom 404 page renders