### PR TITLE
feat(admin/ai): show ELO + bench% in chain editor and sort catalog by…

### DIFF
--- a/app/actions/ai.ts
+++ b/app/actions/ai.ts
@@ -197,6 +197,7 @@ export async function fetchAiModelRankings(): Promise<{
   sources?: string[];
   updated_elo?: number;
   updated_benchmark?: number;
+  updated_notes?: number;
   reordered_features?: string[];
   fetched_rows?: Record<string, number>;
   errors?: string[];

--- a/app/admin/(dashboard)/ai/AiConfigClient.tsx
+++ b/app/admin/(dashboard)/ai/AiConfigClient.tsx
@@ -91,13 +91,19 @@ function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPane
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null);
 
   const isEmbedFeature = FEATURE_META[feature]?.type === "embed";
-  const compatibleModels = knownModels.filter(
-    (m) => m.enabled && (isEmbedFeature ? isEmbeddingModel(m) : !isEmbeddingModel(m))
-  );
+  const compatibleModels = knownModels
+    .filter((m) => m.enabled && (isEmbedFeature ? isEmbeddingModel(m) : !isEmbeddingModel(m)))
+    .sort((a, b) => {
+      const eloA = a.elo_score ?? -1;
+      const eloB = b.elo_score ?? -1;
+      if (eloA !== eloB) return eloB - eloA;
+      return (b.avg_benchmark ?? -1) - (a.avg_benchmark ?? -1);
+    });
   const providerGroups = compatibleModels.reduce<Record<string, AiKnownModel[]>>((acc, m) => {
     (acc[m.provider] ??= []).push(m);
     return acc;
   }, {});
+  const modelLookup = new Map(knownModels.map((m) => [`${m.provider}|${m.model}`, m]));
   const isCustom = selected === CUSTOM_SENTINEL;
 
   const addEntry = () => {
@@ -200,6 +206,18 @@ function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPane
                   placeholder="model"
                   className="flex-1 px-2 py-1 text-xs rounded border border-[var(--border-default)] bg-[var(--bg-elevated)] text-[var(--text-primary)] focus:outline-none focus:border-[var(--accent-violet)]"
                 />
+                {(() => {
+                  const cm = modelLookup.get(`${entry.provider}|${entry.model}`);
+                  const parts = [
+                    cm?.elo_score != null ? `ELO ${cm.elo_score}` : null,
+                    cm?.avg_benchmark != null ? `${cm.avg_benchmark.toFixed(1)}%` : null,
+                  ].filter(Boolean);
+                  return parts.length > 0 ? (
+                    <span className="text-[10px] tabular-nums text-[var(--text-muted)] shrink-0 whitespace-nowrap">
+                      {parts.join(" · ")}
+                    </span>
+                  ) : null;
+                })()}
                 <button
                   onClick={() => removeEntry(i)}
                   className="text-[var(--text-muted)] hover:text-[var(--color-error)] transition-colors shrink-0"
@@ -223,14 +241,19 @@ function EditPanel({ feature, initial, knownModels, onClose, onSaved }: EditPane
                   <option value="">— select a model —</option>
                   {Object.entries(providerGroups).map(([prov, ms]) => (
                     <optgroup key={prov} label={prov}>
-                      {ms.map((m) => (
-                        <option
-                          key={m.id}
-                          value={`${m.provider}|${m.model}`}
-                        >
-                          {m.display_name ?? m.model}{m.notes ? ` (${m.notes})` : ""}{!m.enabled ? " — disabled" : ""}
-                        </option>
-                      ))}
+                      {ms.map((m) => {
+                        const scoreParts = [
+                          m.elo_score != null ? `ELO ${m.elo_score}` : null,
+                          m.avg_benchmark != null ? `${m.avg_benchmark.toFixed(1)}%` : null,
+                        ].filter(Boolean).join(" · ");
+                        const label = m.display_name ?? m.model;
+                        const suffix = [scoreParts, m.notes].filter(Boolean).join(" — ");
+                        return (
+                          <option key={m.id} value={`${m.provider}|${m.model}`}>
+                            {label}{suffix ? `  ·  ${suffix}` : ""}
+                          </option>
+                        );
+                      })}
                     </optgroup>
                   ))}
                   <option value={CUSTOM_SENTINEL}>Custom…</option>

--- a/app/admin/(dashboard)/ai/AiModelsManager.tsx
+++ b/app/admin/(dashboard)/ai/AiModelsManager.tsx
@@ -124,6 +124,7 @@ export default function AiModelsManager({ models }: Props) {
     const parts: string[] = [];
     if ((res.updated_elo ?? 0) > 0) parts.push(`${res.updated_elo} ELO scores`);
     if ((res.updated_benchmark ?? 0) > 0) parts.push(`${res.updated_benchmark} benchmark scores`);
+    if ((res.updated_notes ?? 0) > 0) parts.push(`${res.updated_notes} notes`);
     const scored = parts.length ? `Updated ${parts.join(" + ")}.` : "No new scores matched.";
     const reordered = (res.reordered_features?.length ?? 0) > 0
       ? ` Auto-reordered ${res.reordered_features!.length} chain(s): ${res.reordered_features!.join(", ")}.`
@@ -219,15 +220,13 @@ export default function AiModelsManager({ models }: Props) {
           <p>{rankingResult}</p>
           {rankingResult.includes("No new scores") && (
             <p className="text-violet-400/70">
-              <strong>AlpacaEval</strong> is tried first and is fully public — no token needed.
-              The LMSYS and Open LLM leaderboards are <strong>gated</strong>: a token alone is not
-              enough. You must visit each dataset page on HuggingFace and click{" "}
-              <em>Agree and access repository</em>:
-              {" "}
-              <a href="https://huggingface.co/datasets/lmsys/chatbot-arena-leaderboard" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">chatbot-arena-leaderboard</a>
-              {" · "}
-              <a href="https://huggingface.co/datasets/HuggingFaceH4/open_llm_leaderboard" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">open_llm_leaderboard</a>.
-              Then add your <strong>Read</strong> token to{" "}
+              <strong>Chatbot Arena</strong> (lmarena-ai) and{" "}
+              <strong>open-llm-leaderboard/contents</strong> are public — no token needed.
+              The HuggingFace-hosted variants{" "}
+              <a href="https://huggingface.co/datasets/HuggingFaceH4/open_llm_leaderboard" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">HuggingFaceH4/open_llm_leaderboard</a>
+              {" and "}
+              <a href="https://huggingface.co/datasets/open-llm-leaderboard-v2/contents" target="_blank" rel="noreferrer" className="underline hover:text-violet-300">open-llm-leaderboard-v2</a>
+              {" "}are <strong>gated</strong>: accept terms on their pages, then set{" "}
               <code className="bg-violet-500/20 px-1 rounded">HUGGINGFACE_API_TOKEN</code> in{" "}
               <code className="bg-violet-500/20 px-1 rounded">backend/.env</code>.
             </p>
@@ -253,7 +252,15 @@ export default function AiModelsManager({ models }: Props) {
           </thead>
           <tbody>
             {providers.map((prov) => {
-              const provModels = localModels.filter((m) => m.provider === prov);
+              const provModels = localModels
+                .filter((m) => m.provider === prov)
+                .sort((a, b) => {
+                  if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+                  const eloA = a.elo_score ?? -1;
+                  const eloB = b.elo_score ?? -1;
+                  if (eloA !== eloB) return eloB - eloA;
+                  return (b.avg_benchmark ?? -1) - (a.avg_benchmark ?? -1);
+                });
               const paidCount = provModels.filter((m) => !isFreeModel(m)).length;
               return (
                 <Fragment key={prov}>


### PR DESCRIPTION
… score

Chain editor (EditPanel):
- Dropdown options sorted by ELO desc → bench desc within each provider group
- Option labels include scores: "Gemini 2.5 Pro  ·  ELO 1450 · 87.3%"
- Each draggable chain entry shows a score badge (ELO N · X.X%) for quick reference

Known models catalog (AiModelsManager):
- Within each provider group: enabled models first, then sorted by ELO desc → bench desc
- fetchAiModelRankings feedback now includes updated_notes count
- Updated stale help text: AlpacaEval is gone, correct public sources listed

actions/ai.ts: add updated_notes to fetchAiModelRankings return type