### PR TITLE
feat(chunk-21): pipeline UX hardening — frontend

### DIFF
--- a/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
+++ b/app/admin/(dashboard)/jobs/[id]/JobDetailClient.tsx
@@ -233,9 +233,13 @@ export default function JobDetailClient({
             {(job.match_score * 100).toFixed(0)}%
           </div>
           {job.match_explanation && (
-            <p className="mt-2 text-xs italic text-[var(--text-secondary)]">
-              {job.match_explanation}
-            </p>
+            <div className="mt-2 space-y-1">
+              {job.match_explanation.split("\n").filter(Boolean).map((line, i) => (
+                <p key={i} className="text-xs italic text-[var(--text-secondary)]">
+                  {line}
+                </p>
+              ))}
+            </div>
           )}
         </div>
 


### PR DESCRIPTION
## Summary

- **Feature B (frontend)**: `match_explanation` in `JobDetailClient.tsx` now splits on `\n` and renders each line as its own `<p>`. Single-sentence legacy rows (existing DB values) still render correctly as one paragraph.

## Companion PR

Backend: zergcore/portfolio_backend#34

## Commits

1. `feat(admin/jobs): render match_explanation as 3 separate lines`

## Test plan

- [ ] Job with new 3-line `match_explanation` → each line appears on its own row in the match score card
- [ ] Job with old single-sentence `match_explanation` → renders as a single paragraph, no visual regression
- [ ] `npx tsc --noEmit` clean ✅ (verified before push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)