### PR TITLE
feat(content): 'use cache' data layer + revalidation webhook [0.6]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,18 @@
 # Local default: http://127.0.0.1:8000/api/v1
 NEXT_PUBLIC_API_URL=http://127.0.0.1:8000/api/v1
 
+# Server-side base URL for the backend API (used by lib/content/* cache adapters).
+# Never exposed to the browser. Same value as NEXT_PUBLIC_API_URL for local dev.
+API_URL=http://127.0.0.1:8000/api/v1
+
+# Auth token for backend API requests (sent as Authorization: Bearer <token>).
+# Generate with: openssl rand -hex 32. Must match API_SECRET in the backend .env.
+API_SECRET=
+
 # ── On-demand Revalidation ───────────────────────────────────────────────────
-# Shared secret between Next.js and FastAPI.
-# Generate with: openssl rand -hex 32
-# Must match REVALIDATION_SECRET in the backend .env.
-REVALIDATION_SECRET=
+# Shared secret for POST /api/revalidate. Backend sends this as x-revalidate-secret.
+# Generate with: openssl rand -hex 32. Must match REVALIDATE_SECRET in the backend .env.
+REVALIDATE_SECRET=
 
 # ── Contact / WhatsApp ───────────────────────────────────────────────────────
 # International phone number (no + or spaces) for the WhatsApp FAB and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:
@@ -99,8 +97,6 @@ jobs:
           echo "Timed out waiting for Vercel preview" && exit 1
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,34 @@ This is a side-by-side refactor:
 
 When implementing an issue, work in the `/v2/*` namespace unless the issue is explicitly tagged `surface: legacy-cleanup`.
 
+## Content architecture — READ THIS BEFORE TOUCHING ANY DATA LAYER
+
+The database is the **source of truth** for all structured career data: projects, experience, skills, credentials, and essays/articles. This data is also used by AI features and other application features outside the portfolio — the portfolio frontend is **one of several consumers**.
+
+**DO NOT migrate database content to MDX files.**
+**DO NOT suggest moving structured career data to the filesystem.**
+**DO NOT create MDX files for projects, experience entries, skills, or credentials.**
+
+The correct data pattern for this project is:
+
+```
+Database (source of truth)
+    ↓
+Backend API
+    ↓
+lib/content/*.ts  ←  'use cache' + cacheTag + revalidateTag
+    ↓
+Portfolio pages   ←  Server Components, reads from cache layer
+```
+
+The cache layer in `lib/content/` makes pages render fast (cache hit = no DB round-trip) while staying fresh (backend calls `/api/revalidate` when data changes). This is set up once in issue [0.6] and then invisible to all subsequent issues.
+
+**The only content that lives as files in this repo:**
+- Long-form case study essays (`app/(v2)/_data/essays/*.mdx`) — authored content that benefits from rich MDX components (code blocks, embedded SVG diagrams)
+- The "currently reading" list (`app/(v2)/_data/currently-reading.ts`) — a manually curated list with no DB equivalent
+
+Everything else comes from the database via the cache layer.
+
 ## Before you start any task
 
 1. Read `.claude/README.md`
@@ -22,6 +50,20 @@ When implementing an issue, work in the `/v2/*` namespace unless the issue is ex
 3. Read `.claude/editorial-voice.md` (writing style, anti-AI manifesto)
 4. Read `.claude/component-patterns.md` (reusable patterns)
 5. If the issue references a mockup, read the corresponding file in `.claude/mockups/`
+
+## How to find the issue you're implementing
+
+Issues are referenced by their title prefix (e.g. `[0.1]`, `[1.2]`), not by number, because GitHub assigns numbers based on repo history. To find an issue by its title prefix:
+
+```bash
+gh issue list --search "in:title [0.6]" --json number,title
+# returns the issue number for that issue in this repo
+```
+
+Then view the full body:
+```bash
+gh issue view <NUMBER> --json title,body,labels
+```
 
 ## Engineering conventions
 
@@ -32,21 +74,19 @@ When implementing an issue, work in the `/v2/*` namespace unless the issue is ex
 - **`nuqs` for URL state**, not `useState`.
 - **`next/image` with explicit `sizes`** for any raster image.
 - **TypeScript strict mode.** No `any`. No `@ts-ignore` without a comment explaining why.
+- **`'use cache'` for all data fetching** from the backend API. See `lib/content/` for the pattern.
 
 ## Per-issue workflow
 
-1. Read the issue completely. Pay attention to the **Scope — out** section as a hard boundary.
-2. Read referenced mockup file in `.claude/mockups/`
-3. Plan your changes — list the files you'll touch
-4. Implement
-5. Self-verify against the acceptance criteria checklist
-6. Run `pnpm typecheck && pnpm lint && pnpm build` before declaring done
-7. If anything in the acceptance criteria is unclear, ask before guessing
+1. Find the issue: `gh issue list --search "in:title [X.Y]" --json number,title`
+2. Read the full issue body: `gh issue view <NUMBER> --json title,body,labels`
+3. Read the referenced mockup file in `.claude/mockups/` if applicable
+4. Plan your changes — list the files you'll touch
+5. Implement
+6. Self-verify against the acceptance criteria checklist
+7. Run `pnpm typecheck && pnpm lint && pnpm build` before declaring done
+8. If anything is unclear, ask before guessing. Do not invent design or architectural decisions.
 
 ## What "done" looks like
 
 Every Claude-Code-ready issue has acceptance criteria as a checklist. Treat them as objective pass/fail. If a criterion says "Lighthouse mobile ≥ 90," run Lighthouse and verify. Don't claim done without verifying.
-
-## When you're stuck
-
-If the design intent is unclear from the issue + mockups + design system docs, **stop and ask**. Do not invent design decisions — the whole point of this documentation is that every decision is already made. If something isn't documented, it's a gap we should fix, not a license to improvise.

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,32 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
-import { revalidatePath } from "next/cache";
+import { NextRequest, NextResponse } from 'next/server';
+import { revalidateTag } from 'next/cache';
+
+const TAG_MAP: Record<string, string[]> = {
+  projects:    ['projects', 'work', 'homepage-work-preview'],
+  experience:  ['experience', 'homepage-about'],
+  skills:      ['skills'],
+  credentials: ['credentials'],
+  essays:      ['essays', 'homepage-writing-preview'],
+};
 
 export async function POST(req: NextRequest) {
-  const secret = req.headers.get("x-revalidation-secret");
+  const secret = req.headers.get('x-revalidate-secret');
 
-  if (
-    !process.env.REVALIDATION_SECRET ||
-    secret !== process.env.REVALIDATION_SECRET
-  ) {
-    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  if (!process.env.REVALIDATE_SECRET || secret !== process.env.REVALIDATE_SECRET) {
+    return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
   }
 
-  let body: { path?: unknown };
+  let body: { tags?: unknown };
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ message: "Invalid JSON body" }, { status: 400 });
+    return NextResponse.json({ message: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { path } = body;
-
-  if (!path || typeof path !== "string" || !path.startsWith("/")) {
+  if (!Array.isArray(body.tags) || !body.tags.every((t) => typeof t === 'string')) {
     return NextResponse.json(
-      { message: "Body must contain a valid `path` string starting with '/'" },
-      { status: 400 }
+      { message: 'Body must contain a `tags` string array' },
+      { status: 400 },
     );
   }
 
-  revalidatePath(path);
-  return NextResponse.json({ revalidated: true, path });
+  const revalidated: string[] = [];
+  for (const tag of body.tags as string[]) {
+    for (const mapped of TAG_MAP[tag] ?? []) {
+      revalidateTag(mapped);
+      revalidated.push(mapped);
+    }
+  }
+
+  return NextResponse.json({ revalidated: true, tags: revalidated });
 }

--- a/app/v2/sandbox/page.tsx
+++ b/app/v2/sandbox/page.tsx
@@ -3,11 +3,10 @@ import Marginalia from '@/components/ui/Marginalia';
 import DiamondMarker from '@/components/ui/DiamondMarker';
 import MonoCaption from '@/components/ui/MonoCaption';
 import SectionRule from '@/components/ui/SectionRule';
-import Mdx from '@/components/ui/Mdx';
 import { getAllProjects } from '@/lib/content/projects';
 
 export default async function SandboxPage() {
-  const projects = getAllProjects();
+  const projects = await getAllProjects();
   return (
     <main
       style={{
@@ -116,23 +115,8 @@ export default async function SandboxPage() {
       <section style={{ marginBottom: '64px' }}>
         <p style={labelStyle}>— MDX body render · [0.4]</p>
         <MonoCaption prefix="—">
-          {projects.length} project(s) loaded · slug: {projects[0]?.frontmatter.slug}
+          {projects.length} project(s) loaded · slug: {projects[0]?.slug}
         </MonoCaption>
-        {projects[0] && (
-          <div
-            style={{
-              marginTop: '24px',
-              padding: '24px',
-              border: '1px solid var(--rule)',
-              fontFamily: 'var(--sans)',
-              fontSize: '14px',
-              color: 'var(--ink-dim)',
-              lineHeight: '1.6',
-            }}
-          >
-            <Mdx source={projects[0].content} />
-          </div>
-        )}
       </section>
     </main>
   );

--- a/lib/content/credentials.ts
+++ b/lib/content/credentials.ts
@@ -1,31 +1,26 @@
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
-import {
-  CredentialFrontmatterSchema,
-  type CredentialFrontmatter,
-  type ContentEntry,
-} from './schemas';
+// Source of truth: backend database. Do not migrate to MDX. See CLAUDE.md.
+'use cache';
 
-const DATA_DIR = path.join(process.cwd(), 'app/v2/_data/credentials');
+import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';
+import type { ApiEducation } from '../api';
 
-function parseFile(filePath: string): ContentEntry<CredentialFrontmatter> {
-  const raw = fs.readFileSync(filePath, 'utf8');
-  const { data, content } = matter(raw);
-  const slug = path.basename(filePath, '.mdx');
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000/api/v1';
 
-  const result = CredentialFrontmatterSchema.safeParse(data);
-  if (!result.success) {
-    throw new Error(
-      `Invalid frontmatter in ${path.relative(process.cwd(), filePath)}:\n${result.error.toString()}`
-    );
-  }
-
-  return { frontmatter: result.data, content: content.trim(), slug };
+function authHeaders(): HeadersInit {
+  if (process.env.API_SECRET) return { Authorization: `Bearer ${process.env.API_SECRET}` };
+  return {};
 }
 
-export function getAllCredentials(): ContentEntry<CredentialFrontmatter>[] {
-  if (!fs.existsSync(DATA_DIR)) return [];
-  const files = fs.readdirSync(DATA_DIR).filter((f) => f.endsWith('.mdx'));
-  return files.map((f) => parseFile(path.join(DATA_DIR, f)));
+export async function getAllCredentials(): Promise<ApiEducation[]> {
+  'use cache';
+  cacheTag('credentials');
+  cacheLife('days');
+  try {
+    const res = await fetch(`${API_URL}/education`, { headers: authHeaders() });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
 }

--- a/lib/content/essays.ts
+++ b/lib/content/essays.ts
@@ -1,43 +1,40 @@
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
-import {
-  EssayFrontmatterSchema,
-  type EssayFrontmatter,
-  type ContentEntry,
-} from './schemas';
+// Source of truth: backend database. Do not migrate to MDX. See CLAUDE.md.
+'use cache';
 
-const DATA_DIR = path.join(process.cwd(), 'app/v2/_data/essays');
+import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';
+import type { ApiBlogPost } from '../api';
 
-function parseFile(filePath: string): ContentEntry<EssayFrontmatter> {
-  const raw = fs.readFileSync(filePath, 'utf8');
-  const { data, content } = matter(raw);
-  const slug = path.basename(filePath, '.mdx');
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000/api/v1';
 
-  const result = EssayFrontmatterSchema.safeParse(data);
-  if (!result.success) {
-    throw new Error(
-      `Invalid frontmatter in ${path.relative(process.cwd(), filePath)}:\n${result.error.toString()}`
-    );
+function authHeaders(): HeadersInit {
+  if (process.env.API_SECRET) return { Authorization: `Bearer ${process.env.API_SECRET}` };
+  return {};
+}
+
+export async function getAllEssays(): Promise<ApiBlogPost[]> {
+  'use cache';
+  cacheTag('essays');
+  cacheLife('days');
+  try {
+    const res = await fetch(`${API_URL}/blog`, { headers: authHeaders() });
+    if (!res.ok) return [];
+    const data = await res.json();
+    const items = Array.isArray(data) ? data : data.items;
+    return Array.isArray(items) ? items : [];
+  } catch {
+    return [];
   }
-
-  return { frontmatter: result.data, content: content.trim(), slug };
 }
 
-export function getAllEssays(): ContentEntry<EssayFrontmatter>[] {
-  if (!fs.existsSync(DATA_DIR)) return [];
-  const files = fs.readdirSync(DATA_DIR).filter((f) => f.endsWith('.mdx'));
-  return files
-    .map((f) => parseFile(path.join(DATA_DIR, f)))
-    .sort(
-      (a, b) =>
-        new Date(b.frontmatter.publishedAt).getTime() -
-        new Date(a.frontmatter.publishedAt).getTime()
-    );
-}
-
-export function getEssay(slug: string): ContentEntry<EssayFrontmatter> | undefined {
-  const filePath = path.join(DATA_DIR, `${slug}.mdx`);
-  if (!fs.existsSync(filePath)) return undefined;
-  return parseFile(filePath);
+export async function getEssay(slug: string): Promise<ApiBlogPost | null> {
+  'use cache';
+  cacheTag('essays');
+  cacheLife('days');
+  try {
+    const res = await fetch(`${API_URL}/blog/${slug}`, { headers: authHeaders() });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
 }

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -1,39 +1,39 @@
-import fs from 'fs';
-import path from 'path';
-import matter from 'gray-matter';
-import {
-  ProjectFrontmatterSchema,
-  type ProjectFrontmatter,
-  type ContentEntry,
-} from './schemas';
+// Source of truth: backend database. Do not migrate to MDX. See CLAUDE.md.
+'use cache';
 
-const DATA_DIR = path.join(process.cwd(), 'app/v2/_data/projects');
+import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';
+import type { ApiProject } from '../api';
 
-function parseFile(filePath: string): ContentEntry<ProjectFrontmatter> {
-  const raw = fs.readFileSync(filePath, 'utf8');
-  const { data, content } = matter(raw);
-  const slug = path.basename(filePath, '.mdx');
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000/api/v1';
 
-  const result = ProjectFrontmatterSchema.safeParse(data);
-  if (!result.success) {
-    throw new Error(
-      `Invalid frontmatter in ${path.relative(process.cwd(), filePath)}:\n${result.error.toString()}`
-    );
+function authHeaders(): HeadersInit {
+  if (process.env.API_SECRET) return { Authorization: `Bearer ${process.env.API_SECRET}` };
+  return {};
+}
+
+export async function getAllProjects(): Promise<ApiProject[]> {
+  'use cache';
+  cacheTag('projects');
+  cacheLife('days');
+  try {
+    const res = await fetch(`${API_URL}/projects`, { headers: authHeaders() });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
   }
-
-  return { frontmatter: result.data, content: content.trim(), slug };
 }
 
-export function getAllProjects(): ContentEntry<ProjectFrontmatter>[] {
-  if (!fs.existsSync(DATA_DIR)) return [];
-  const files = fs.readdirSync(DATA_DIR).filter((f) => f.endsWith('.mdx'));
-  return files
-    .map((f) => parseFile(path.join(DATA_DIR, f)))
-    .sort((a, b) => a.frontmatter.order - b.frontmatter.order);
-}
-
-export function getProject(slug: string): ContentEntry<ProjectFrontmatter> | undefined {
-  const filePath = path.join(DATA_DIR, `${slug}.mdx`);
-  if (!fs.existsSync(filePath)) return undefined;
-  return parseFile(filePath);
+export async function getProject(slug: string): Promise<ApiProject | null> {
+  'use cache';
+  cacheTag('projects');
+  cacheLife('days');
+  try {
+    const res = await fetch(`${API_URL}/projects/${slug}`, { headers: authHeaders() });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
 }

--- a/lib/content/skills.ts
+++ b/lib/content/skills.ts
@@ -2,7 +2,7 @@
 'use cache';
 
 import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';
-import type { ApiExperience } from '../api';
+import type { ApiSkillGroup } from '../api';
 
 const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000/api/v1';
 
@@ -11,24 +11,16 @@ function authHeaders(): HeadersInit {
   return {};
 }
 
-export async function getAllRoles(): Promise<ApiExperience[]> {
+export async function getAllSkills(): Promise<ApiSkillGroup[]> {
   'use cache';
-  cacheTag('experience');
+  cacheTag('skills');
   cacheLife('days');
   try {
-    const res = await fetch(`${API_URL}/experience`, { headers: authHeaders() });
+    const res = await fetch(`${API_URL}/skills`, { headers: authHeaders() });
     if (!res.ok) return [];
     const data = await res.json();
     return Array.isArray(data) ? data : [];
   } catch {
     return [];
   }
-}
-
-export async function getRole(slug: string): Promise<ApiExperience | null> {
-  'use cache';
-  cacheTag('experience');
-  cacheLife('days');
-  const roles = await getAllRoles();
-  return roles.find((r) => r.id === slug) ?? null;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,7 @@ const withNextIntl = createNextIntlPlugin("./lib/i18n/request.ts");
 const nextConfig: NextConfig = {
   pageExtensions: ['ts', 'tsx', 'mdx'],
   experimental: {
+    useCache: true,
     serverActions: {
       // LinkedIn ZIP exports can exceed the 1 MB default limit
       bodySizeLimit: "20mb",

--- a/package.json
+++ b/package.json
@@ -63,5 +63,6 @@
     "tailwindcss": "^4.1.4",
     "typescript": "^5",
     "vitest": "^3.0.5"
-  }
+  },
+  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977"
 }


### PR DESCRIPTION
## Summary

- Replace MDX filesystem readers with five typed backend API adapters in `lib/content/`
- Each adapter uses Next.js 15 `'use cache'` + `cacheTag()` + `cacheLife('days')` — server-side cached, invisible to the browser
- Rewrite `app/api/revalidate/route.ts` to tag-based revalidation with the full tag map
- Enable `experimental.useCache` in `next.config.ts`
- Document `API_URL`, `API_SECRET`, `REVALIDATE_SECRET` in `.env.example`

## Test plan

- [ ] `POST /api/revalidate` with correct `x-revalidate-secret` → `{ revalidated: true, tags: [...] }` ✓ (verified locally)
- [ ] `POST /api/revalidate` with wrong/missing secret → 401 ✓ (verified locally)
- [ ] `/v2/sandbox` shows project count + slug from live backend (requires backend running)
- [ ] `pnpm build` passes ✓