### PR TITLE
[1.1] Implement <SiteNav /> with active route + mono resume link

### DIFF
--- a/app/v2/layout.tsx
+++ b/app/v2/layout.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from "react";
 import { fontVariables } from "@/lib/fonts";
+import SiteNav from "@/components/nav/site-nav";
 import "../globals.css";
 
 export default function V2Layout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className={`${fontVariables} v2`}>
+        <SiteNav />
         {children}
       </body>
     </html>

--- a/components/nav/nav-links.tsx
+++ b/components/nav/nav-links.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import styles from './site-nav.module.css';
+
+interface NavLink {
+  label: string;
+  href: string;
+  hideMobile?: true;
+}
+
+const NAV_LINKS: NavLink[] = [
+  { label: 'Home', href: '/v2' },
+  { label: 'Work', href: '/v2/work' },
+  { label: 'Writing', href: '/v2/writing' },
+  { label: 'Experience', href: '/v2/experience', hideMobile: true },
+  { label: 'Credentials', href: '/v2/credentials', hideMobile: true },
+  { label: 'Contact', href: '/v2/contact' },
+];
+
+export default function NavLinks() {
+  const pathname = usePathname();
+
+  function isActive(href: string) {
+    if (href === '/v2') return pathname === '/v2' || pathname === '/v2/';
+    return pathname.startsWith(href);
+  }
+
+  return (
+    <div className={styles.links}>
+      {NAV_LINKS.map(({ label, href, hideMobile }) => (
+        <Link
+          key={href}
+          href={href}
+          className={[
+            styles.link,
+            isActive(href) ? styles.linkActive : '',
+            hideMobile ? styles.hideOnMobile : '',
+          ]
+            .filter(Boolean)
+            .join(' ')}
+        >
+          {label}
+        </Link>
+      ))}
+      <a
+        href="/resume.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.resume}
+      >
+        ↗ Resume
+      </a>
+    </div>
+  );
+}

--- a/components/nav/site-nav.module.css
+++ b/components/nav/site-nav.module.css
@@ -1,0 +1,86 @@
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 24px 48px;
+  border-bottom: 1px solid var(--rule);
+  font-size: 13px;
+  position: sticky;
+  top: 0;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  background: rgba(11, 10, 12, 0.7);
+  z-index: 50;
+}
+
+.logo {
+  font-family: var(--sans);
+  font-weight: 300;
+  font-size: 13px;
+  color: var(--ink-dim);
+  letter-spacing: -0.02em;
+  text-decoration: none;
+}
+
+.logo:hover {
+  color: var(--ink);
+}
+
+.links {
+  display: flex;
+  gap: 32px;
+  color: var(--ink-dim);
+  align-items: center;
+}
+
+.link {
+  font-family: var(--sans);
+  font-weight: 300;
+  font-size: 13px;
+  color: var(--ink-dim);
+  text-decoration: none;
+  transition: color 0.15s;
+  cursor: pointer;
+}
+
+.link:hover {
+  color: var(--ink);
+}
+
+.linkActive {
+  color: var(--ink);
+}
+
+.resume {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: var(--ink-dim);
+  text-transform: uppercase;
+  transition: color 0.15s;
+  padding-left: 16px;
+  border-left: 1px solid var(--rule);
+  margin-left: 4px;
+  text-decoration: none;
+}
+
+.resume:hover {
+  color: var(--accent);
+}
+
+@media (max-width: 900px) {
+  .nav {
+    padding: 16px 24px;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .links {
+    gap: 20px;
+    font-size: 12px;
+  }
+
+  .hideOnMobile {
+    display: none;
+  }
+}

--- a/components/nav/site-nav.tsx
+++ b/components/nav/site-nav.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link';
+import NavLinks from './nav-links';
+import styles from './site-nav.module.css';
+
+export default function SiteNav() {
+  return (
+    <nav className={styles.nav}>
+      <Link href="/v2" className={styles.logo}>
+        {'<zr/>'}
+      </Link>
+      <NavLinks />
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/nav/site-nav.tsx` (Server Component) + `nav-links.tsx` (isolated Client Component for `usePathname` active state)
- Sticky navbar with `backdrop-filter: blur(8px)`, `rgba(11,10,12,0.7)` background
- Logo `<zr/>` in Geist 300 (overrides early mockup which incorrectly used mono)
- Nav links: Geist 300 13px, `--ink-dim` inactive / `--ink` active
- Resume link: JetBrains Mono 11px, uppercase, left `--rule` border separator, opens `/resume.pdf` in new tab
- Experience + Credentials hidden below 900px via CSS module media query
- Rendered in `app/(v2)/layout.tsx` so it appears on every v2 page

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm build` passes
- [ ] Visit `/v2` — Home link is active (bright), others are dim
- [ ] Navigate to another v2 route — active link updates correctly
- [ ] Resume link opens PDF in new tab
- [ ] Resize below 900px — Experience and Credentials disappear, no hamburger
- [ ] Scroll a long page — nav sticks at top with no layout shift
- [ ] Tab through nav links — visible focus rings on every item

Closes #54