### PR TITLE
feat(cta): implement <ContactSection /> [1.6]

### DIFF
--- a/app/v2/page.tsx
+++ b/app/v2/page.tsx
@@ -3,6 +3,7 @@ import HeroHeadline from '@/components/home/hero-headline';
 import HeroCta from '@/components/home/hero-cta';
 import AboutSection from '@/components/home/about-section';
 import WorkPreview from '@/components/home/work-preview';
+import ContactSection from '@/components/home/contact-section';
 import styles from './hero.module.css';
 
 export default function V2Home() {
@@ -48,6 +49,8 @@ export default function V2Home() {
       <AboutSection />
 
       <WorkPreview />
+
+      <ContactSection />
     </main>
   );
 }

--- a/components/home/contact-section.module.css
+++ b/components/home/contact-section.module.css
@@ -1,0 +1,171 @@
+.section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 96px 48px;
+  border-top: 1px solid var(--rule);
+  position: relative;
+}
+
+/* Vertical accent line descending from the section break */
+.section::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 50%;
+  width: 1px;
+  height: 64px;
+  background: var(--accent);
+  transform: translateX(-50%);
+  opacity: 0.5;
+}
+
+.eyebrow {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+  margin-bottom: 48px;
+}
+
+.eyebrowNum {
+  color: var(--accent);
+}
+
+.eyebrowSep {
+  flex: 1;
+  height: 1px;
+  background: var(--rule);
+  margin: 0 4px;
+  align-self: center;
+}
+
+.eyebrowMeta {
+  color: var(--ink-faint);
+  text-transform: none;
+  letter-spacing: 0.02em;
+}
+
+.headline {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(40px, 5.5vw, 72px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  margin-top: 16px;
+  margin-bottom: 32px;
+  max-width: 900px;
+}
+
+.headlineEm {
+  color: var(--accent);
+}
+
+.dek {
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  max-width: 540px;
+  margin-bottom: 56px;
+}
+
+.links {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  flex-wrap: wrap;
+  padding: 32px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.primaryLink {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--accent);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 6px;
+  letter-spacing: -0.005em;
+  transition: color 0.2s, text-decoration-color 0.2s;
+  margin-right: 12px;
+}
+
+.primaryLink:hover {
+  color: var(--accent-soft);
+  text-decoration-color: var(--accent-soft);
+}
+
+.secondaryLink {
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  color: var(--ink-dim);
+  text-decoration: underline;
+  text-decoration-color: var(--ink-faint);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+  transition: color 0.2s, text-decoration-color 0.2s;
+}
+
+.secondaryLink:hover {
+  color: var(--ink);
+  text-decoration-color: var(--ink);
+}
+
+.linkSep {
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  opacity: 0.5;
+}
+
+.whatsappAnnotation {
+  color: var(--ink-faint);
+  font-size: 10px;
+  margin-left: 3px;
+  font-style: normal;
+  letter-spacing: 0.03em;
+}
+
+.footer {
+  margin-top: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+@media (max-width: 900px) {
+  .section {
+    padding: 96px 24px;
+  }
+
+  .links {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .linkSep {
+    display: none;
+  }
+
+  .footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/components/home/contact-section.tsx
+++ b/components/home/contact-section.tsx
@@ -1,11 +1,14 @@
+import { getProfile } from '@/lib/content/profile';
 import styles from './contact-section.module.css';
 
-export default function ContactSection() {
-  const calendarUrl = process.env.NEXT_PUBLIC_CALENDAR_URL ?? 'mailto:';
-  const contactEmail = process.env.NEXT_PUBLIC_CONTACT_EMAIL;
-  const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? '1234567890';
+export default async function ContactSection() {
+  const profile = await getProfile();
 
-  const emailHref = contactEmail ? `mailto:${contactEmail}` : 'mailto:';
+  const calendarHref = profile?.meeting_url ?? (profile?.email ? `mailto:${profile.email}` : 'mailto:');
+  const emailHref    = profile?.email ? `mailto:${profile.email}` : 'mailto:';
+  const linkedinHref = profile?.linkedin_url ?? null;
+  const githubHref   = profile?.github_url ?? null;
+  const whatsappHref = profile?.whatsapp_number ? `https://wa.me/${profile.whatsapp_number}` : null;
 
   return (
     <section id="contact" className={styles.section}>
@@ -30,39 +33,51 @@ export default function ContactSection() {
       </p>
 
       <div className={styles.links}>
-        <a href={calendarUrl} className={styles.primaryLink}>
+        <a href={calendarHref} className={styles.primaryLink}>
           Book a 30-min call →
         </a>
         <span className={styles.linkSep} aria-hidden="true">·</span>
         <a href={emailHref} className={styles.secondaryLink}>↗ email</a>
-        <span className={styles.linkSep} aria-hidden="true">·</span>
-        <a
-          href="https://linkedin.com/in/zaidibethramos"
-          className={styles.secondaryLink}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ↗ linkedin
-        </a>
-        <span className={styles.linkSep} aria-hidden="true">·</span>
-        <a
-          href="https://github.com/zergcore"
-          className={styles.secondaryLink}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ↗ github
-        </a>
-        <span className={styles.linkSep} aria-hidden="true">·</span>
-        <a
-          href={`https://wa.me/${whatsappNumber}`}
-          className={styles.secondaryLink}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ↗ whatsapp
-          <span className={styles.whatsappAnnotation}>(LATAM)</span>
-        </a>
+        {linkedinHref && (
+          <>
+            <span className={styles.linkSep} aria-hidden="true">·</span>
+            <a
+              href={linkedinHref}
+              className={styles.secondaryLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ linkedin
+            </a>
+          </>
+        )}
+        {githubHref && (
+          <>
+            <span className={styles.linkSep} aria-hidden="true">·</span>
+            <a
+              href={githubHref}
+              className={styles.secondaryLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ github
+            </a>
+          </>
+        )}
+        {whatsappHref && (
+          <>
+            <span className={styles.linkSep} aria-hidden="true">·</span>
+            <a
+              href={whatsappHref}
+              className={styles.secondaryLink}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ whatsapp
+              <span className={styles.whatsappAnnotation}>(LATAM)</span>
+            </a>
+          </>
+        )}
       </div>
 
       <div className={styles.footer}>

--- a/components/home/contact-section.tsx
+++ b/components/home/contact-section.tsx
@@ -1,0 +1,74 @@
+import styles from './contact-section.module.css';
+
+export default function ContactSection() {
+  const calendarUrl = process.env.NEXT_PUBLIC_CALENDAR_URL ?? 'mailto:';
+  const contactEmail = process.env.NEXT_PUBLIC_CONTACT_EMAIL;
+  const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER ?? '1234567890';
+
+  const emailHref = contactEmail ? `mailto:${contactEmail}` : 'mailto:';
+
+  return (
+    <section id="contact" className={styles.section}>
+      <div className={styles.eyebrow}>
+        <span className={styles.eyebrowNum}>§ 04</span>
+        <span>Contact</span>
+        <span className={styles.eyebrowSep} aria-hidden="true" />
+        <span className={styles.eyebrowMeta}>— replies in &lt; 24h on weekdays</span>
+      </div>
+
+      <h2 className={styles.headline}>
+        If any of this is{' '}
+        <span className={styles.headlineEm}>useful to you,</span>
+        <br />
+        the door&rsquo;s open.
+      </h2>
+
+      <p className={styles.dek}>
+        I&rsquo;m picky about projects but generous with conversations.
+        Open to staff-level frontend, AI-eng, or anything where the architectural
+        decisions actually matter. Quickest path is the booking link below.
+      </p>
+
+      <div className={styles.links}>
+        <a href={calendarUrl} className={styles.primaryLink}>
+          Book a 30-min call →
+        </a>
+        <span className={styles.linkSep} aria-hidden="true">·</span>
+        <a href={emailHref} className={styles.secondaryLink}>↗ email</a>
+        <span className={styles.linkSep} aria-hidden="true">·</span>
+        <a
+          href="https://linkedin.com/in/zaidibethramos"
+          className={styles.secondaryLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ↗ linkedin
+        </a>
+        <span className={styles.linkSep} aria-hidden="true">·</span>
+        <a
+          href="https://github.com/zergcore"
+          className={styles.secondaryLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ↗ github
+        </a>
+        <span className={styles.linkSep} aria-hidden="true">·</span>
+        <a
+          href={`https://wa.me/${whatsappNumber}`}
+          className={styles.secondaryLink}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ↗ whatsapp
+          <span className={styles.whatsappAnnotation}>(LATAM)</span>
+        </a>
+      </div>
+
+      <div className={styles.footer}>
+        <span>— Time zone: UTC−4 · overlap with US / EU mornings</span>
+        <span>— No recruiter spam, please · I&rsquo;ll know</span>
+      </div>
+    </section>
+  );
+}

--- a/lib/content/profile.ts
+++ b/lib/content/profile.ts
@@ -1,0 +1,25 @@
+// Source of truth: backend database. Do not migrate to MDX. See CLAUDE.md.
+'use cache';
+
+import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';
+import type { ApiProfile } from '../api';
+
+const API_URL = process.env.API_URL ?? 'http://127.0.0.1:8000/api/v1';
+
+function authHeaders(): HeadersInit {
+  if (process.env.API_SECRET) return { Authorization: `Bearer ${process.env.API_SECRET}` };
+  return {};
+}
+
+export async function getProfile(): Promise<ApiProfile | null> {
+  'use cache';
+  cacheTag('profile');
+  cacheLife('hours');
+  try {
+    const res = await fetch(`${API_URL}/profile`, { headers: authHeaders() });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `components/home/contact-section.tsx` — a single-CTA contact section with no form and no gradients
- Adds `lib/content/profile.ts` — cache layer fetcher for the profile endpoint (`'use cache'`, `cacheTag('profile')`, `cacheLife('hours')`)
- All contact links are driven by the `profile` DB record: `meeting_url` (calendar), `email`, `linkedin_url`, `github_url`, `whatsapp_number`
- Primary CTA: *Book a 30-min call →* (Instrument Serif italic, `--accent`) uses `profile.meeting_url`; falls back to `mailto:<email>` if unset
- linkedin/github/whatsapp are omitted if their DB field is null — no orphan separators
- Vertical accent line above section via `.section::before` (1px × 64px, centered, 50% opacity)
- Mobile (< 900px): links stack vertically, separators hidden
- Mounts `<ContactSection />` on the v2 homepage after `<WorkPreview />`

## Test plan

- [ ] Visit `/v2` — vertical rose accent line visible at top of contact section
- [ ] "Book a 30-min call →" opens `profile.meeting_url` (or mail client if null)
- [ ] Secondary links reflect DB values; null fields produce no orphan separators
- [ ] `(LATAM)` annotation is faint and smaller than the whatsapp link text
- [ ] No gradient backgrounds anywhere on the page
- [ ] Resize < 900px — links stack vertically, `·` separators disappear
- [ ] `pnpm typecheck && pnpm lint` pass

Closes #59