### PR TITLE
feat(home): work preview rows — featured projects [1.4]

### DIFF
--- a/app/v2/page.tsx
+++ b/app/v2/page.tsx
@@ -2,6 +2,7 @@ import AvailabilityPill from '@/components/home/availability-pill';
 import HeroHeadline from '@/components/home/hero-headline';
 import HeroCta from '@/components/home/hero-cta';
 import AboutSection from '@/components/home/about-section';
+import WorkPreview from '@/components/home/work-preview';
 import styles from './hero.module.css';
 
 export default function V2Home() {
@@ -45,6 +46,8 @@ export default function V2Home() {
       </section>
 
       <AboutSection />
+
+      <WorkPreview />
     </main>
   );
 }

--- a/components/home/work-preview-row.module.css
+++ b/components/home/work-preview-row.module.css
@@ -1,0 +1,146 @@
+.row {
+  display: grid;
+  grid-template-columns: 80px 1fr 280px auto;
+  gap: 32px;
+  align-items: center;
+  padding: 32px 0;
+  border-bottom: 1px solid var(--rule);
+  text-decoration: none;
+  color: inherit;
+  position: relative;
+}
+
+.row:first-child {
+  border-top: 1px solid var(--rule);
+}
+
+/* CSS-only manicule: 8px accent line slides in from left */
+.row::before {
+  content: "";
+  position: absolute;
+  left: -16px;
+  top: 50%;
+  width: 0;
+  height: 1px;
+  background: var(--accent);
+  transition: width 0.3s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.row:hover::before {
+  width: 8px;
+}
+
+.row:hover .title {
+  color: var(--accent-soft);
+}
+
+.row:hover .arrow {
+  color: var(--accent);
+  transform: translateX(4px);
+}
+
+/* ── Column: number / tier ── */
+.num {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+}
+
+.tier {
+  display: block;
+  color: var(--ink-faint);
+  font-size: 9px;
+  margin-top: 4px;
+  text-transform: uppercase;
+}
+
+/* ── Column: main (title + dek) ── */
+.main {
+  padding-right: 24px;
+}
+
+.title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(22px, 2.4vw, 30px);
+  line-height: 1.15;
+  color: var(--ink);
+  margin-bottom: 8px;
+  letter-spacing: -0.015em;
+  transition: color 0.2s;
+}
+
+.dek {
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-dim);
+  max-width: 540px;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ── Column: stack + metric ── */
+.stackMetric {
+  /* hidden below 1100px via media query */
+}
+
+.stack {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  line-height: 1.7;
+}
+
+.techSep {
+  margin: 0 6px;
+  opacity: 0.5;
+}
+
+.metric {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-top: 4px;
+}
+
+/* ── Column: arrow ── */
+.arrow {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--ink-faint);
+  transition: color 0.2s, transform 0.2s;
+}
+
+/* ── Responsive ── */
+@media (max-width: 1100px) {
+  .row {
+    grid-template-columns: 60px 1fr auto;
+  }
+
+  .stackMetric {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .row {
+    grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 24px 0;
+  }
+
+  .arrow {
+    display: none;
+  }
+}

--- a/components/home/work-preview-row.tsx
+++ b/components/home/work-preview-row.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import type { ApiProject } from '@/lib/api';
+import styles from './work-preview-row.module.css';
+
+interface Props {
+  project: ApiProject;
+  /** 0-based index — determines tier label and № display */
+  index: number;
+}
+
+export default function WorkPreviewRow({ project, index }: Props) {
+  const tier = index === 0 ? 'Hero' : 'Production';
+  const num = String(index + 1).padStart(2, '0');
+  const title = project.title.en;
+  const dek = project.description.en;
+
+  // Prefer skill names; fall back to tags if no skills are associated
+  const stack =
+    project.skills.length > 0
+      ? project.skills.map((s) => s.name.en)
+      : (project.tags ?? []);
+
+  const metric = project.outcomes?.en?.[0] ?? null;
+
+  return (
+    <Link
+      href={`/v2/work/${project.slug}`}
+      prefetch
+      className={styles.row}
+    >
+      <div className={styles.num}>
+        № {num}
+        <span className={styles.tier}>— {tier}</span>
+      </div>
+
+      <div className={styles.main}>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.dek}>{dek}</p>
+      </div>
+
+      <div className={styles.stackMetric}>
+        {stack.length > 0 && (
+          <div className={styles.stack}>
+            {stack.map((tech, i) => (
+              <span key={tech}>
+                {tech}
+                {i < stack.length - 1 && (
+                  <span className={styles.techSep} aria-hidden="true">·</span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+        {metric && <div className={styles.metric}>{metric}</div>}
+      </div>
+
+      <span className={styles.arrow} aria-hidden="true">→</span>
+    </Link>
+  );
+}

--- a/components/home/work-preview.module.css
+++ b/components/home/work-preview.module.css
@@ -1,0 +1,53 @@
+.section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 96px 48px;
+  border-top: 1px solid var(--rule);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+.footer {
+  margin-top: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding-top: 24px;
+}
+
+.viewAll {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 18px;
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 5px;
+  transition: color 0.2s;
+}
+
+.viewAll:hover {
+  color: var(--accent);
+}
+
+.footerMeta {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+@media (max-width: 900px) {
+  .section {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}

--- a/components/home/work-preview.tsx
+++ b/components/home/work-preview.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { getAllProjects } from '@/lib/content/projects';
+import Eyebrow from '@/components/ui/Eyebrow';
+import WorkPreviewRow from './work-preview-row';
+import styles from './work-preview.module.css';
+
+export default async function WorkPreview() {
+  const all = await getAllProjects();
+
+  // Featured projects only, sorted by sort_order; index 0 → Hero tier, 1–2 → Production tier
+  const rows = all
+    .filter((p) => p.is_featured)
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .slice(0, 3);
+
+  const totalCount = all.filter((p) => p.is_featured).length;
+
+  return (
+    <section className={styles.section} id="work">
+      <Eyebrow
+        num="02"
+        title="Selected Work"
+        rightAction={{ href: '/v2/work', label: 'All work →' }}
+      />
+
+      <div className={styles.grid}>
+        {rows.map((project, i) => (
+          <WorkPreviewRow key={project.id} project={project} index={i} />
+        ))}
+      </div>
+
+      <div className={styles.footer}>
+        <Link href="/v2/work" className={styles.viewAll}>
+          Read all case studies →
+        </Link>
+        <span className={styles.footerMeta}>
+          — {rows.length} featured above
+          {totalCount > rows.length && ` · ${totalCount - rows.length} more in the archive`}
+        </span>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/home/work-preview.tsx` — async Server Component that fetches featured projects via `getAllProjects()`, filters by `is_featured`, sorts by `sort_order`, and renders the top 3
- Adds `components/home/work-preview-row.tsx` — one row per project linking to `/v2/work/[slug]` with `<Link prefetch>`
- CSS-only manicule hover: 8px accent line slides in from left via `::before { width: 0 → 8px }` transition; title shifts to `--accent-soft`, arrow translates right
- Stack + metric column hidden below 1100px; layout collapses to single column below 900px
- Description clamped to 2 lines (`-webkit-line-clamp: 2`) to tease the detail page
- Wires `<WorkPreview />` into `app/v2/page.tsx` after `<AboutSection />`

## Test plan

- [ ] Start backend + `pnpm dev`, open `/v2` — three featured projects render in order
- [ ] With backend down — section renders empty (no crash)
- [ ] Hover a row — manicule slides in, title pinks, arrow nudges right (no JS)
- [ ] Resize below 1100px — stack column disappears
- [ ] Resize below 900px — layout goes single-column, arrow hides
- [ ] Long description — truncates to 2 lines with ellipsis
- [ ] Click a row — navigates to `/v2/work/[slug]` (404 expected until Epic 2)