### PR TITLE
feat(footer): implement <SiteFooter /> with colophon + secondary nav [1.7]

### DIFF
--- a/app/v2/layout.tsx
+++ b/app/v2/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { fontVariables } from "@/lib/fonts";
 import SiteNav from "@/components/nav/site-nav";
+import SiteFooter from "@/components/site/footer";
 import "../globals.css";
 
 export default function V2Layout({ children }: { children: ReactNode }) {
@@ -9,6 +10,7 @@ export default function V2Layout({ children }: { children: ReactNode }) {
       <body className={`${fontVariables} v2`}>
         <SiteNav />
         {children}
+        <SiteFooter />
       </body>
     </html>
   );

--- a/components/site/footer.module.css
+++ b/components/site/footer.module.css
@@ -1,0 +1,72 @@
+.footer {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 48px 48px 64px;
+  border-top: 1px solid var(--rule);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: start;
+}
+
+.colophon {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  line-height: 1.7;
+  letter-spacing: 0.04em;
+}
+
+.colophon .name {
+  color: var(--ink-dim);
+}
+
+.colophon a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--ink-faint);
+  text-underline-offset: 3px;
+  transition: color 0.15s;
+}
+
+.colophon a:hover {
+  color: var(--accent);
+}
+
+.updated {
+  color: var(--accent-soft);
+}
+
+.navSecondary {
+  display: flex;
+  gap: 32px;
+  justify-content: flex-end;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+
+.navSecondary a {
+  color: inherit;
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.navSecondary a:hover {
+  color: var(--accent);
+}
+
+@media (max-width: 900px) {
+  .footer {
+    grid-template-columns: 1fr;
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+
+  .navSecondary {
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}

--- a/components/site/footer.tsx
+++ b/components/site/footer.tsx
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import Link from 'next/link';
+import { getProfile } from '@/lib/content/profile';
 import styles from './footer.module.css';
 
 function getLastUpdated(): string {
@@ -22,8 +23,11 @@ const NAV_LINKS = [
   { label: '↗ RSS', href: '/feed.xml' },
 ];
 
-export default function SiteFooter() {
-  const lastUpdated = getLastUpdated();
+export default async function SiteFooter() {
+  const [profile, lastUpdated] = await Promise.all([
+    getProfile(),
+    Promise.resolve(getLastUpdated()),
+  ]);
 
   return (
     <footer className={styles.footer}>
@@ -34,14 +38,14 @@ export default function SiteFooter() {
         <br />
         {'Last updated '}
         <span className={styles.updated}>{lastUpdated}</span>
-        {' · '}
-        <a
-          href="https://github.com/zergcore/portfolio"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          ↗ source on GitHub
-        </a>
+        {profile?.github_url && (
+          <>
+            {' · '}
+            <a href={profile.github_url} target="_blank" rel="noopener noreferrer">
+              ↗ source on GitHub
+            </a>
+          </>
+        )}
       </div>
 
       <nav className={styles.navSecondary}>

--- a/components/site/footer.tsx
+++ b/components/site/footer.tsx
@@ -1,0 +1,56 @@
+import { execSync } from 'child_process';
+import Link from 'next/link';
+import styles from './footer.module.css';
+
+function getLastUpdated(): string {
+  const envDate = process.env.BUILD_DATE;
+  if (envDate) return envDate;
+  try {
+    return execSync('git log -1 --format=%cd --date=format:"%B %Y"', {
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return new Date().toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  }
+}
+
+const NAV_LINKS = [
+  { label: 'Work', href: '/v2/work' },
+  { label: 'Writing', href: '/v2/writing' },
+  { label: 'About', href: '/v2/#about' },
+  { label: 'Contact', href: '/v2/contact' },
+  { label: '↗ RSS', href: '/feed.xml' },
+];
+
+export default function SiteFooter() {
+  const lastUpdated = getLastUpdated();
+
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.colophon}>
+        <span className={styles.name}>— Zaidibeth Ramos</span>
+        <br />
+        {'Built with Next.js 15 · Instrument Serif & Geist · Vercel'}
+        <br />
+        {'Last updated '}
+        <span className={styles.updated}>{lastUpdated}</span>
+        {' · '}
+        <a
+          href="https://github.com/zergcore/portfolio"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          ↗ source on GitHub
+        </a>
+      </div>
+
+      <nav className={styles.navSecondary}>
+        {NAV_LINKS.map(({ label, href }) => (
+          <Link key={href} href={href}>
+            {label}
+          </Link>
+        ))}
+      </nav>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/site/footer.tsx` — Server Component with two-column layout
- Left colophon: name, build stack, last-updated date (reads `BUILD_DATE` env or falls back to `git log` timestamp), `↗ source on GitHub` link
- Right secondary nav: Work · Writing · About · Contact · ↗ RSS — all JetBrains Mono 11px uppercase
- Adds `components/site/footer.module.css` — matches mockup exactly; stacks to single column at ≤ 900px
- Wires `<SiteFooter />` into `app/v2/layout.tsx`

## Test plan

- [ ] Start `pnpm dev`, open `/v2`, scroll to bottom — verify both columns render
- [ ] Confirm last-updated date matches most recent git commit month/year
- [ ] Click `↗ source on GitHub` — opens `https://github.com/zergcore/portfolio`
- [ ] Resize to < 900px — columns stack vertically, nav links left-align
- [ ] `BUILD_DATE="June 2026" pnpm dev` — footer shows "June 2026"
- [ ] `pnpm typecheck && pnpm lint && pnpm build` — all pass

Closes #60