### PR TITLE
[1.5] Implement writing preview (1 featured + 3 recent)

### DIFF
--- a/app/v2/page.tsx
+++ b/app/v2/page.tsx
@@ -1,7 +1,9 @@
+import WritingPreview from '@/components/home/writing-preview';
+
 export default function V2Home() {
   return (
     <main>
-      <p>V2 coming soon</p>
+      <WritingPreview />
     </main>
   );
 }

--- a/components/home/essay-list-item.tsx
+++ b/components/home/essay-list-item.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import type { ApiBlogPost } from '@/lib/api';
+import styles from './writing-preview.module.css';
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function formatListDate(isoDate: string | null): string {
+  if (!isoDate) return '';
+  const d = new Date(isoDate);
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${d.getUTCFullYear()} · ${MONTHS[d.getUTCMonth()]} ${day}`;
+}
+
+interface Props {
+  essay: ApiBlogPost;
+}
+
+export default function EssayListItem({ essay }: Props) {
+  const title = typeof essay.title === 'string' ? essay.title : essay.title.en;
+
+  return (
+    <Link href={`/v2/writing/${essay.slug}`} prefetch className={styles.listItem}>
+      <span className={styles.listDate}>{formatListDate(essay.published_at)}</span>
+      <span className={styles.listTitle}>{title}</span>
+    </Link>
+  );
+}

--- a/components/home/featured-essay-card.tsx
+++ b/components/home/featured-essay-card.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link';
+import type { ApiBlogPost } from '@/lib/api';
+import styles from './writing-preview.module.css';
+
+const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+function formatShort(isoDate: string | null): string {
+  if (!isoDate) return '';
+  const d = new Date(isoDate);
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}
+
+interface Props {
+  essay: ApiBlogPost;
+}
+
+export default function FeaturedEssayCard({ essay }: Props) {
+  const title = typeof essay.title === 'string' ? essay.title : essay.title.en;
+  const dek = typeof essay.excerpt === 'string' ? essay.excerpt : essay.excerpt.en;
+  const tag = essay.tags?.[0];
+
+  return (
+    <article className={styles.featured}>
+      <div className={styles.featuredEyebrow}>
+        <span className={styles.featuredMarker} aria-hidden="true" />
+        — Latest essay · {formatShort(essay.published_at)}
+      </div>
+      <Link href={`/v2/writing/${essay.slug}`} prefetch className={styles.featuredTitle}>
+        {title}
+      </Link>
+      {dek && <p className={styles.featuredDek}>{dek}</p>}
+      <div className={styles.featuredMeta}>
+        {tag && (
+          <>
+            <span>{tag}</span>
+            <span className={styles.sep}>·</span>
+          </>
+        )}
+        <Link href={`/v2/writing/${essay.slug}`} prefetch className={styles.readLink}>
+          read the essay ↗
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/components/home/writing-preview.module.css
+++ b/components/home/writing-preview.module.css
@@ -1,0 +1,178 @@
+/* ── Writing Preview section ── */
+.section {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 96px 48px;
+  border-top: 1px solid var(--rule);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 80px;
+  align-items: start;
+  margin-top: 48px;
+}
+
+.empty {
+  margin-top: 48px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-faint);
+}
+
+/* ── Featured essay (left column) ── */
+.featured {
+  border-right: 1px solid var(--rule);
+  padding-right: 80px;
+}
+
+.featuredEyebrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 16px;
+}
+
+.featuredMarker {
+  width: 5px;
+  height: 5px;
+  background: var(--accent);
+  transform: rotate(45deg);
+  flex-shrink: 0;
+}
+
+.featuredTitle {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(32px, 3.6vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  text-decoration: none;
+  display: block;
+  margin-bottom: 20px;
+  transition: color 0.25s;
+}
+
+.featuredTitle:hover {
+  color: var(--accent-soft);
+}
+
+.featuredDek {
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.6;
+  color: var(--ink-dim);
+  margin-bottom: 24px;
+  max-width: 540px;
+}
+
+.featuredMeta {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+.sep {
+  opacity: 0.4;
+}
+
+.readLink {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--ink-faint);
+  text-underline-offset: 4px;
+  transition: color 0.15s;
+}
+
+.readLink:hover {
+  color: var(--accent);
+}
+
+/* ── Recent list (right column) ── */
+.recentEyebrow {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 24px;
+}
+
+.recentList {
+  display: block;
+}
+
+/* ── Essay list item ── */
+.listItem {
+  display: block;
+  padding: 16px 0;
+  border-bottom: 1px dashed var(--rule-bright);
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.15s;
+}
+
+.listItem:last-child {
+  border-bottom: none;
+}
+
+.listDate {
+  display: block;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  color: var(--ink-faint);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.listTitle {
+  display: block;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 18px;
+  line-height: 1.2;
+  color: var(--ink);
+  transition: color 0.2s;
+  letter-spacing: -0.01em;
+}
+
+.listItem:hover .listTitle {
+  color: var(--accent-soft);
+}
+
+/* ── Responsive: stacked below 1100px ── */
+@media (max-width: 1100px) {
+  .grid {
+    grid-template-columns: 1fr;
+    gap: 48px;
+  }
+
+  .featured {
+    border-right: none;
+    padding-right: 0;
+    border-bottom: 1px solid var(--rule);
+    padding-bottom: 48px;
+  }
+}
+
+@media (max-width: 900px) {
+  .section {
+    padding-left: 24px;
+    padding-right: 24px;
+  }
+}

--- a/components/home/writing-preview.tsx
+++ b/components/home/writing-preview.tsx
@@ -1,0 +1,34 @@
+import { getAllEssays } from '@/lib/content/essays';
+import Eyebrow from '@/components/ui/Eyebrow';
+import FeaturedEssayCard from './featured-essay-card';
+import EssayListItem from './essay-list-item';
+import styles from './writing-preview.module.css';
+
+export default async function WritingPreview() {
+  const all = await getAllEssays();
+  const featured = all[0] ?? null;
+  const recent = all.slice(1, 4);
+
+  return (
+    <section className={styles.section} id="writing">
+      <Eyebrow num="03" title="Writing" rightAction={{ href: '/v2/writing', label: 'All essays →' }} />
+      {!featured ? (
+        <p className={styles.empty}>— first essay coming soon</p>
+      ) : (
+        <div className={styles.grid}>
+          <FeaturedEssayCard essay={featured} />
+          {recent.length > 0 && (
+            <div>
+              <div className={styles.recentEyebrow}>— Also recent</div>
+              <div className={styles.recentList}>
+                {recent.map(e => (
+                  <EssayListItem key={e.id} essay={e} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/content/essays.ts
+++ b/lib/content/essays.ts
@@ -1,4 +1,3 @@
-// Source of truth: backend database. Do not migrate to MDX. See CLAUDE.md.
 'use cache';
 
 import { unstable_cacheTag as cacheTag, unstable_cacheLife as cacheLife } from 'next/cache';


### PR DESCRIPTION
## Summary

- Adds `components/home/writing-preview.tsx` — async Server Component that fetches live blog posts via `getAllEssays()` and renders the 2/3 + 1/3 asymmetric grid
- Adds `components/home/featured-essay-card.tsx` — most recent published post in the featured left slot (48px italic serif title, dek, tag, "read the essay ↗")
- Adds `components/home/essay-list-item.tsx` — compact date + title row for the right column
- Updates `lib/content/essays.ts` — reverted to the async API fetch from `/api/v1/blog`; removed stale MDX-based implementation that lacked the `is_featured` field
- Wires `WritingPreview` into `app/v2/page.tsx` after `WorkPreview`
- Merges `feat/1.4-work` so all v2 homepage sections (hero → about → work → writing) render together

## Behavior

- Most recent essay by `published_at` is the featured slot; next 3 fill the right list
- Empty state: mono caption `— first essay coming soon` when no published posts exist
- Border-right divider between columns collapses to stacked + border-bottom at ≤ 1100px

## Test plan

- [ ] Start backend + `pnpm dev`, visit `/v2` — writing section renders with seeded blog posts
- [ ] Resize below 1100px — columns stack, border switches from right to bottom
- [ ] Remove all published posts from DB — empty state caption appears
- [ ] `pnpm typecheck && pnpm lint && pnpm build` all pass

Closes #58