### PR TITLE
feat(work): hero case study block [2.2]

### DIFF
--- a/app/v2/work/page.tsx
+++ b/app/v2/work/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import HeroCaseStudy from '@/components/work/hero-case-study';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
@@ -31,7 +32,9 @@ export default function WorkPage() {
         </p>
       </div>
 
-      {/* [2.2]–[2.6]: hero case study, production rows, archive index */}
+      <HeroCaseStudy />
+
+      {/* [2.3]–[2.6]: production rows, archive index */}
 
       <aside className={styles.footnote}>
         <div className={styles.footnoteEyebrow}>— A note on this section</div>

--- a/components/cards/SkillCategoryCard.tsx
+++ b/components/cards/SkillCategoryCard.tsx
@@ -29,8 +29,8 @@ export default function SkillCategoryCard({
       </h3>
 
       <div className="flex flex-col gap-4 flex-1">
-        {visible.map((skill) => (
-          <div key={skill.name} className="flex flex-col gap-1">
+        {visible.map((skill, idx) => (
+          <div key={`${skill.name}-${idx}`} className="flex flex-col gap-1">
             <div className="flex justify-between items-baseline">
               <span className="font-medium text-[var(--text-primary)]">
                 {skill.name}
@@ -42,9 +42,9 @@ export default function SkillCategoryCard({
 
             {skill.tags && skill.tags.length > 0 && (
               <div className="flex flex-wrap gap-1.5 mt-1">
-                {skill.tags.map((tag) => (
+                {skill.tags.map((tag, tagIdx) => (
                   <span
-                    key={tag}
+                    key={`${tag}-${tagIdx}`}
                     className="text-[10px] uppercase tracking-wider font-semibold text-[var(--text-secondary)] bg-[var(--bg-base)] px-2 py-0.5 rounded-sm border border-[var(--border-default)]"
                   >
                     {tag}

--- a/components/home/work-preview-row.tsx
+++ b/components/home/work-preview-row.tsx
@@ -42,7 +42,7 @@ export default function WorkPreviewRow({ project, index }: Props) {
         {stack.length > 0 && (
           <div className={styles.stack}>
             {stack.map((tech, i) => (
-              <span key={tech}>
+              <span key={`tech-${tech}-${i}`}>
                 {tech}
                 {i < stack.length - 1 && (
                   <span className={styles.techSep} aria-hidden="true">·</span>

--- a/components/sections/Experience.tsx
+++ b/components/sections/Experience.tsx
@@ -35,7 +35,7 @@ export default async function Experience() {
             const isEven = idx % 2 === 0;
 
             return (
-              <ScrollReveal key={exp.id} delay={0.1 * (idx + 1)}>
+              <ScrollReveal key={`exp-${exp.company}-${idx}-${exp.id}`} delay={0.1 * (idx + 1)}>
                 <div
                   className={`relative flex flex-col md:flex-row items-center gap-8 ${isEven ? "md:flex-row-reverse" : ""}`}
                 >
@@ -63,7 +63,7 @@ export default async function Experience() {
                     <ul className="list-disc list-inside space-y-2 mb-6">
                       {exp.description.map((desc, i) => (
                         <li
-                          key={i}
+                          key={`desc-${exp.id}-${i}`}
                           className="text-sm text-(--text-secondary) leading-relaxed"
                         >
                           <span className="-ml-2">{desc}</span>
@@ -73,9 +73,9 @@ export default async function Experience() {
 
                     {/* Tech Stack */}
                     <div className="flex flex-wrap gap-2">
-                      {exp.techStack.map((tech) => (
+                      {exp.techStack.map((tech, i) => (
                         <span
-                          key={tech}
+                          key={`tech-${exp.id}-${tech}-${i}`}
                           className="text-xs font-medium text-foreground bg-(--bg-surface) px-2.5 py-1 rounded-md border border-(--border-default)"
                         >
                           {tech}

--- a/components/work/hero-case-study.module.css
+++ b/components/work/hero-case-study.module.css
@@ -218,6 +218,14 @@
   color: var(--accent-soft);
 }
 
+.empty {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+}
+
 /* ── Responsive ── */
 @media (max-width: 1100px) {
   .heroGrid {

--- a/components/work/hero-case-study.module.css
+++ b/components/work/hero-case-study.module.css
@@ -1,0 +1,234 @@
+.heroCase {
+  padding: 64px 0 96px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  position: relative;
+  margin-bottom: 96px;
+}
+
+/* ── Eyebrow ── */
+.heroEyebrow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 40px;
+}
+
+.marker {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  background: var(--accent);
+  transform: rotate(45deg);
+  flex-shrink: 0;
+}
+
+.featured {
+  color: var(--accent);
+}
+
+/* ── Two-column grid ── */
+.heroGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 80px;
+  align-items: start;
+}
+
+/* ── Text column ── */
+.heroText {
+  position: relative;
+}
+
+.heroTitle {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(40px, 5vw, 64px);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+
+.subtitle {
+  display: block;
+  font-size: 0.7em;
+  color: var(--ink-dim);
+  margin-top: 6px;
+  font-style: italic;
+}
+
+/* ── Context strip ── */
+.heroContext {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 32px;
+}
+
+.ctxYear {
+  color: var(--ink-dim);
+}
+
+.ctxSep {
+  margin: 0 8px;
+  opacity: 0.5;
+}
+
+/* ── Intro paragraphs ── */
+.heroIntro {
+  font-size: 15px;
+  line-height: 1.7;
+  color: var(--ink-dim);
+  margin-bottom: 20px;
+}
+
+/* ── Metrics ── */
+.heroMetrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+  margin: 36px 0;
+  padding: 24px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+.metricValue {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(32px, 4vw, 44px);
+  color: var(--accent);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  display: block;
+}
+
+.metricLabel {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  display: block;
+  margin-top: 10px;
+}
+
+/* ── Stack ── */
+.heroStack {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 32px;
+}
+
+.stackLabel {
+  margin-right: 8px;
+}
+
+.tech {
+  color: var(--ink-dim);
+}
+
+.techSep {
+  margin: 0 8px;
+  opacity: 0.5;
+}
+
+/* ── Links row ── */
+.heroLinks {
+  display: flex;
+  align-items: baseline;
+  gap: 28px;
+  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.heroLink {
+  color: var(--ink);
+  text-decoration: underline;
+  text-decoration-color: var(--ink-faint);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 5px;
+  transition: color 0.2s, text-decoration-color 0.2s;
+}
+
+.heroLink:hover {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+}
+
+.primary {
+  color: var(--accent);
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1.5px;
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 18px;
+  text-transform: none;
+  letter-spacing: -0.005em;
+}
+
+.primary:hover {
+  color: var(--accent-soft);
+  text-decoration-color: var(--accent-soft);
+}
+
+/* ── Diagram column (placeholder until [2.3]) ── */
+.heroDiagram {
+  position: relative;
+  padding: 32px;
+  background: linear-gradient(180deg, rgba(255, 91, 31, 0.02), transparent 70%);
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  min-height: 280px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.diagramCaption {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding-top: 16px;
+  border-top: 1px dashed var(--rule-bright);
+  line-height: 1.6;
+}
+
+.diagramEm {
+  color: var(--accent-soft);
+}
+
+/* ── Responsive ── */
+@media (max-width: 1100px) {
+  .heroGrid {
+    grid-template-columns: 1fr;
+    gap: 48px;
+  }
+}
+
+@media (max-width: 900px) {
+  .heroMetrics {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+}

--- a/components/work/hero-case-study.tsx
+++ b/components/work/hero-case-study.tsx
@@ -13,6 +13,7 @@ function splitMetric(text: string): { value: string; label: string } {
 
 export default async function HeroCaseStudy() {
   const project = await getHeroProject();
+  if (!project) return null;
 
   const title = getLocalizedText(project.title, 'en');
   const subtitle = project.role ? getLocalizedText(project.role, 'en') : null;

--- a/components/work/hero-case-study.tsx
+++ b/components/work/hero-case-study.tsx
@@ -1,0 +1,136 @@
+import { getHeroProject } from '@/lib/content/projects';
+import { getLocalizedText } from '@/lib/api';
+import Marginalia from '@/components/ui/Marginalia';
+import styles from './hero-case-study.module.css';
+
+function splitMetric(text: string): { value: string; label: string } {
+  // Extract a leading numeric/keyword metric from an outcome string
+  const m = text.match(/^([+\-]?\d[\d,.]*[%×x]?|\bpeer\b|\bsolo\b|\bzero\b|\bmillions?\b)\s*[-–—·,]?\s*(.+)/i);
+  if (m) return { value: m[1].trim(), label: m[2].replace(/\.$/, '').trim() };
+  const words = text.split(' ');
+  return { value: words[0], label: words.slice(1).join(' ').replace(/\.$/, '') };
+}
+
+export default async function HeroCaseStudy() {
+  const project = await getHeroProject();
+
+  const title = getLocalizedText(project.title, 'en');
+  const subtitle = project.role ? getLocalizedText(project.role, 'en') : null;
+  const problem = project.problem ? getLocalizedText(project.problem, 'en') : null;
+  const solutionBody = project.approach?.[0]
+    ? getLocalizedText(project.approach[0].body, 'en')
+    : null;
+  const outcomes = project.outcomes?.en ?? [];
+  const skills = project.skills?.map((s) => getLocalizedText(s.name, 'en')) ?? [];
+  const year = project.timeline?.match(/^\d{4}/)?.[0] ?? project.timeline ?? '';
+  const contextTags = (project.tags ?? []).filter((t) => t !== 'hero');
+  const metrics = outcomes.slice(0, 3).map(splitMetric);
+
+  return (
+    <article className={styles.heroCase}>
+      <div className={styles.heroEyebrow}>
+        <span className={styles.marker} aria-hidden="true" />
+        <span>
+          <span className={styles.featured}>— Hero project</span>
+          {' · the one I\'d lead an interview with'}
+        </span>
+      </div>
+
+      <div className={styles.heroGrid}>
+        {/* TEXT COLUMN */}
+        <div className={styles.heroText}>
+          <h2 className={styles.heroTitle}>
+            {title}
+            {subtitle && <span className={styles.subtitle}>— {subtitle}</span>}
+          </h2>
+
+          <div className={styles.heroContext}>
+            {year && (
+              <>
+                <span className={styles.ctxYear}>{year}</span>
+                <span className={styles.ctxSep} aria-hidden="true">·</span>
+              </>
+            )}
+            {contextTags.map((tag, i) => (
+              <span key={`${tag}-${i}`}>
+                {tag}
+                {i < contextTags.length - 1 && (
+                  <span className={styles.ctxSep} aria-hidden="true">·</span>
+                )}
+              </span>
+            ))}
+          </div>
+
+          {problem && <p className={styles.heroIntro}>{problem}</p>}
+          {solutionBody && <p className={styles.heroIntro}>{solutionBody}</p>}
+
+          {metrics.length > 0 && (
+            <div className={styles.heroMetrics}>
+              {metrics.map((m, i) => (
+                <div key={i} className={styles.heroMetric}>
+                  <span className={styles.metricValue}>{m.value}</span>
+                  <span className={styles.metricLabel}>— {m.label}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {skills.length > 0 && (
+            <div className={styles.heroStack}>
+              <span className={styles.stackLabel}>— Stack</span>
+              {skills.map((s, i) => (
+                <span key={`${s}-${i}`}>
+                  <span className={styles.tech}>{s}</span>
+                  {i < skills.length - 1 && (
+                    <span className={styles.techSep} aria-hidden="true">·</span>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className={styles.heroLinks}>
+            <a
+              href={`/work/${project.slug}`}
+              className={`${styles.heroLink} ${styles.primary}`}
+            >
+              Read the case study →
+            </a>
+            {project.github_url && (
+              <a
+                href={project.github_url}
+                className={styles.heroLink}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ↗ code
+              </a>
+            )}
+            {project.live_url && (
+              <a
+                href={project.live_url}
+                className={styles.heroLink}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ↗ live
+              </a>
+            )}
+          </div>
+
+          <Marginalia>the piece I&apos;d lead an interview with</Marginalia>
+        </div>
+
+        {/* DIAGRAM COLUMN — SVG diagram built in [2.3] */}
+        <div className={styles.heroDiagram}>
+          <div className={styles.diagramCaption}>
+            — Architecture diagram ·{' '}
+            <span className={styles.diagramEm}>
+              SVG diagram coming in the next iteration
+            </span>
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/components/work/hero-case-study.tsx
+++ b/components/work/hero-case-study.tsx
@@ -13,7 +13,13 @@ function splitMetric(text: string): { value: string; label: string } {
 
 export default async function HeroCaseStudy() {
   const project = await getHeroProject();
-  if (!project) return null;
+  if (!project) {
+    return (
+      <div className={styles.heroCase}>
+        <p className={styles.empty}>— No projects to show yet.</p>
+      </div>
+    );
+  }
 
   const title = getLocalizedText(project.title, 'en');
   const subtitle = project.role ? getLocalizedText(project.role, 'en') : null;

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -57,6 +57,7 @@ export interface ApiProject {
   sort_order: number;
   primary_category_id: string | null;
   skills: ApiSkillRef[];
+  tier?: string;
 }
 
 export interface ApiProjectGroup {

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -25,6 +25,25 @@ export async function getAllProjects(): Promise<ApiProject[]> {
   }
 }
 
+export async function getHeroProject(): Promise<ApiProject> {
+  'use cache';
+  cacheTag('projects');
+  cacheLife('days');
+  const projects = await getAllProjects();
+  const heroes = projects.filter((p) => p.tier === 'hero');
+  if (heroes.length > 1) {
+    throw new Error(`[work] Expected exactly 1 project with tier:"hero", found ${heroes.length}. Remove the tier field from all but one.`);
+  }
+  if (heroes.length === 1) return heroes[0];
+  // Fallback: first featured project by sort_order, then any project
+  const sorted = [...projects].sort((a, b) => a.sort_order - b.sort_order);
+  const first = sorted.find((p) => p.is_featured) ?? sorted[0];
+  if (!first) {
+    throw new Error('[work] No projects found. Make sure the backend is running and seeded.');
+  }
+  return first;
+}
+
 export async function getProject(slug: string): Promise<ApiProject | null> {
   'use cache';
   cacheTag('projects');

--- a/lib/content/projects.ts
+++ b/lib/content/projects.ts
@@ -25,7 +25,7 @@ export async function getAllProjects(): Promise<ApiProject[]> {
   }
 }
 
-export async function getHeroProject(): Promise<ApiProject> {
+export async function getHeroProject(): Promise<ApiProject | null> {
   'use cache';
   cacheTag('projects');
   cacheLife('days');
@@ -37,11 +37,7 @@ export async function getHeroProject(): Promise<ApiProject> {
   if (heroes.length === 1) return heroes[0];
   // Fallback: first featured project by sort_order, then any project
   const sorted = [...projects].sort((a, b) => a.sort_order - b.sort_order);
-  const first = sorted.find((p) => p.is_featured) ?? sorted[0];
-  if (!first) {
-    throw new Error('[work] No projects found. Make sure the backend is running and seeded.');
-  }
-  return first;
+  return sorted.find((p) => p.is_featured) ?? sorted[0] ?? null;
 }
 
 export async function getProject(slug: string): Promise<ApiProject | null> {


### PR DESCRIPTION
## Summary

- Adds `HeroCaseStudy` server component — two-column layout (text left, diagram placeholder right) matching the `.hero-case` mockup block
- Enforces exactly one `tier:'hero'` project; falls back to first featured → first project if none is explicitly marked
- Adds `tier?` field to `ApiProject` type and `getHeroProject()` to the content layer
- Fixes duplicate React key warnings in `SkillCategoryCard`, `WorkPreviewRow`, and `Experience` (pre-existing bug surfaced by the same data issue)

## Test plan

- [ ] Start backend + frontend, open `/v2/work` — hero block renders with first featured project
- [ ] Set `tier: "hero"` on a project via CMS — hero block uses that project specifically
- [ ] Set `tier: "hero"` on two projects — page throws a descriptive build error
- [ ] Open `/en` landing page — no duplicate key warnings in console