### PR TITLE
feat(work): generic project cover image in hero case study [2.3]

### DIFF
--- a/components/work/hero-case-study.module.css
+++ b/components/work/hero-case-study.module.css
@@ -190,33 +190,6 @@
   text-decoration-color: var(--accent-soft);
 }
 
-/* ── Diagram column (placeholder until [2.3]) ── */
-.heroDiagram {
-  position: relative;
-  padding: 32px;
-  background: linear-gradient(180deg, rgba(255, 91, 31, 0.02), transparent 70%);
-  border: 1px solid var(--rule);
-  border-radius: 2px;
-  min-height: 280px;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-}
-
-.diagramCaption {
-  font-family: var(--mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--ink-faint);
-  padding-top: 16px;
-  border-top: 1px dashed var(--rule-bright);
-  line-height: 1.6;
-}
-
-.diagramEm {
-  color: var(--accent-soft);
-}
 
 .empty {
   font-family: var(--mono);

--- a/components/work/hero-case-study.tsx
+++ b/components/work/hero-case-study.tsx
@@ -1,6 +1,7 @@
 import { getHeroProject } from '@/lib/content/projects';
 import { getLocalizedText } from '@/lib/api';
 import Marginalia from '@/components/ui/Marginalia';
+import ProjectImage from './project-image';
 import styles from './hero-case-study.module.css';
 
 function splitMetric(text: string): { value: string; label: string } {
@@ -128,15 +129,8 @@ export default async function HeroCaseStudy() {
           <Marginalia>the piece I&apos;d lead an interview with</Marginalia>
         </div>
 
-        {/* DIAGRAM COLUMN — SVG diagram built in [2.3] */}
-        <div className={styles.heroDiagram}>
-          <div className={styles.diagramCaption}>
-            — Architecture diagram ·{' '}
-            <span className={styles.diagramEm}>
-              SVG diagram coming in the next iteration
-            </span>
-          </div>
-        </div>
+        {/* IMAGE COLUMN — rendered via <ProjectImage>; asset lives in project.images */}
+        <ProjectImage project={project} context="hero" priority />
       </div>
     </article>
   );

--- a/components/work/project-image.module.css
+++ b/components/work/project-image.module.css
@@ -1,0 +1,46 @@
+/* 16:10 frame — used for hero, production rows, and archive */
+.frame {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  border: 1px solid var(--rule);
+  border-radius: 2px;
+  overflow: hidden;
+  background: var(--bg-elev);
+  width: 100%;
+}
+
+.img {
+  object-fit: cover;
+  object-position: top center;
+}
+
+/* Typographic fallback — never a broken-image icon or gray box */
+.fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 32px;
+}
+
+.fallbackTitle {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(18px, 2.5vw, 28px);
+  color: var(--ink-dim);
+  text-align: center;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.fallbackCaption {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}

--- a/components/work/project-image.tsx
+++ b/components/work/project-image.tsx
@@ -1,0 +1,55 @@
+import Image from 'next/image';
+import type { ApiProject } from '@/lib/api';
+import { getLocalizedText } from '@/lib/api';
+import styles from './project-image.module.css';
+
+export type ProjectImageContext = 'hero' | 'row' | 'archive';
+
+const SIZES: Record<ProjectImageContext, string> = {
+  hero: '(max-width: 1100px) 100vw, 50vw',
+  row: '(max-width: 900px) 100vw, 50vw',
+  archive: '(max-width: 900px) 100vw, 33vw',
+};
+
+function getPrimaryImageUrl(project: ApiProject): string | null {
+  return (
+    project.images?.find((img) => img.is_primary)?.url ??
+    project.image_url ??
+    null
+  );
+}
+
+interface Props {
+  project: ApiProject;
+  context: ProjectImageContext;
+  priority?: boolean;
+}
+
+export default function ProjectImage({ project, context, priority = false }: Props) {
+  const src = getPrimaryImageUrl(project);
+  const title = getLocalizedText(project.title, 'en');
+
+  if (!src) {
+    return (
+      <div className={styles.frame} role="img" aria-label={title}>
+        <div className={styles.fallback}>
+          <span className={styles.fallbackTitle}>{title}</span>
+          <span className={styles.fallbackCaption}>— no image yet</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.frame}>
+      <Image
+        src={src}
+        alt={title}
+        fill
+        sizes={SIZES[context]}
+        priority={priority}
+        className={styles.img}
+      />
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,10 @@ const nextConfig: NextConfig = {
     },
   },
   images: {
+    dangerouslyAllowSVG: true,
+    contentDispositionType: 'attachment',
+    // Neutralises script execution for self-authored SVG assets (covers, diagrams)
+    contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
## Summary
- Replaces the ACO-Firefly SVG diagram placeholder with a reusable `ProjectImage` component
- Each project renders its own primary cover image in a 16:10 frame via `next/image`, with a typographic fallback when no image is uploaded
- Removes dead placeholder CSS (`.heroDiagram`, `.diagramCaption`, `.diagramEm`)
- Adds `dangerouslyAllowSVG` + CSP to `next.config.ts` for SVG assets served through `next/image`

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Visit `/v2/work` — hero card right column renders cover image (or serif fallback if no image is set)
- [ ] Mobile: grid collapses to single column, image fills width correctly

Closes #65