### PR TITLE
[2.4] Alternating split-row layout for production projects

### DIFF
--- a/app/v2/work/page.tsx
+++ b/app/v2/work/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import HeroCaseStudy from '@/components/work/hero-case-study';
+import ProductionRows from '@/components/work/production-row';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
@@ -34,7 +35,9 @@ export default function WorkPage() {
 
       <HeroCaseStudy />
 
-      {/* [2.3]–[2.6]: production rows, archive index */}
+      <ProductionRows />
+
+      {/* [2.5]–[2.6]: mock screenshots, archive index */}
 
       <aside className={styles.footnote}>
         <div className={styles.footnoteEyebrow}>— A note on this section</div>

--- a/components/ui/Marginalia.module.css
+++ b/components/ui/Marginalia.module.css
@@ -10,6 +10,7 @@
   transform: rotate(-1.2deg);
   pointer-events: none;
   line-height: 1.45;
+  z-index: 1;
 }
 
 /* CSS-drawn arrow: two borders rotated to form a corner pointing left */

--- a/components/work/production-row.module.css
+++ b/components/work/production-row.module.css
@@ -1,0 +1,255 @@
+/* ── Section ── */
+.section {
+  margin-bottom: 96px;
+}
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 48px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.marker {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  background: var(--ink-dim);
+  transform: rotate(45deg);
+  flex-shrink: 0;
+}
+
+/* ── Row grid ── */
+.prodRow {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 80px;
+  align-items: center;
+  padding: 56px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.flipped {
+  grid-template-columns: 1fr 1.2fr;
+}
+
+.imageFlipped {
+  order: -1;
+}
+
+/* ── Text column ── */
+.text {
+  min-width: 0;
+}
+
+.num {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  margin-bottom: 16px;
+}
+
+.title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(32px, 3.6vw, 48px);
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  margin-bottom: 18px;
+}
+
+.dek {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 18px;
+  line-height: 1.45;
+  color: var(--ink-dim);
+  margin-bottom: 20px;
+  max-width: 520px;
+}
+
+.dek strong {
+  color: var(--ink);
+  font-style: italic;
+  font-weight: 400;
+}
+
+.body {
+  font-size: 14px;
+  line-height: 1.65;
+  color: var(--ink-dim);
+  margin-bottom: 24px;
+  max-width: 520px;
+}
+
+/* ── Metric row ── */
+.metric {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 24px;
+  padding: 14px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.metricValue {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 22px;
+  color: var(--accent);
+  text-transform: none;
+  letter-spacing: -0.01em;
+  margin-right: 4px;
+}
+
+.metricSep {
+  margin: 0 12px;
+  opacity: 0.5;
+}
+
+/* ── Stack ── */
+.stack {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 24px;
+}
+
+.tech {
+  color: var(--ink-dim);
+}
+
+.techSep {
+  margin: 0 7px;
+  opacity: 0.5;
+}
+
+/* ── Links ── */
+.links {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  align-items: baseline;
+}
+
+.primary {
+  color: var(--accent);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 16px;
+  text-decoration: underline;
+  text-decoration-color: var(--accent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 4px;
+  text-transform: none;
+  letter-spacing: -0.005em;
+  transition: color 0.15s, text-decoration-color 0.15s;
+}
+
+.primary:hover {
+  color: var(--accent-soft);
+  text-decoration-color: var(--accent-soft);
+}
+
+.link {
+  color: var(--ink-dim);
+  text-decoration: underline;
+  text-decoration-color: var(--ink-faint);
+  text-underline-offset: 4px;
+  transition: color 0.15s;
+}
+
+.link:hover {
+  color: var(--ink);
+}
+
+/* ── Image column ── */
+.image {
+  position: relative;
+  aspect-ratio: 16 / 10;
+  border: 1px solid var(--rule);
+  overflow: hidden;
+  background: var(--bg-elev);
+  width: 100%;
+}
+
+.img {
+  object-fit: cover;
+  object-position: top center;
+}
+
+.fallback {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 32px;
+}
+
+.fallbackTitle {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(18px, 2.5vw, 28px);
+  color: var(--ink-dim);
+  text-align: center;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.fallbackCaption {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+
+/* ── Empty state ── */
+.empty {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  padding: 56px 0;
+  border-top: 1px solid var(--rule);
+  border-bottom: 1px solid var(--rule);
+}
+
+/* ── Responsive ── */
+@media (max-width: 1100px) {
+  .prodRow,
+  .flipped {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+
+  .imageFlipped {
+    order: 0;
+  }
+}

--- a/components/work/production-row.tsx
+++ b/components/work/production-row.tsx
@@ -1,0 +1,159 @@
+import Image from 'next/image';
+import type { ApiProject } from '@/lib/api';
+import { getLocalizedText } from '@/lib/api';
+import { getAllProjects } from '@/lib/content/projects';
+import styles from './production-row.module.css';
+
+function splitMetric(text: string): { value: string; label: string } {
+  const m = text.match(
+    /^([+\-]?\d[\d,.]*[%×x]?|~\d[\d,.]*[%×x]?|\bpeer\b|\bsolo\b|\bzero\b|\bmillions?\b)\s*[-–—·,]?\s*(.+)/i,
+  );
+  if (m) return { value: m[1].trim(), label: m[2].replace(/\.$/, '').trim() };
+  const words = text.split(' ');
+  return { value: words[0], label: words.slice(1).join(' ').replace(/\.$/, '') };
+}
+
+interface RowProps {
+  project: ApiProject;
+  index: number;
+  flipped: boolean;
+}
+
+function ProductionRow({ project, index, flipped }: RowProps) {
+  const title = getLocalizedText(project.title, 'en');
+  const description = getLocalizedText(project.description, 'en');
+  const problem = project.problem ? getLocalizedText(project.problem, 'en') : null;
+  const outcomes = project.outcomes?.en ?? [];
+  const skills = project.skills?.map((s) => getLocalizedText(s.name, 'en')) ?? [];
+  const timeline = project.timeline ?? '';
+
+  // №02, №03, ... — production starts after the hero (index 0 = №02)
+  const numTag = `№ ${String(index + 2).padStart(2, '0')}${timeline ? ` · ${timeline}` : ''}`;
+
+  // Use description as dek if no problem, else problem as body and description as dek
+  const dek = problem ?? description;
+  const body = problem ? description : null;
+
+  // Inline metric pairs from outcomes (up to 2)
+  const metrics = outcomes.slice(0, 2).map(splitMetric);
+
+  // Primary image
+  const imageSrc =
+    project.images?.find((img) => img.is_primary)?.url ?? project.image_url ?? null;
+
+  return (
+    <article className={`${styles.prodRow} ${flipped ? styles.flipped : ''}`}>
+      <div className={styles.text}>
+        <div className={styles.num}>{numTag}</div>
+
+        <h3 className={styles.title}>{title}</h3>
+
+        {dek && <p className={styles.dek}>{dek}</p>}
+        {body && <p className={styles.body}>{body}</p>}
+
+        {metrics.length > 0 && (
+          <div className={styles.metric}>
+            {metrics.map((m, i) => (
+              <span key={i}>
+                <span className={styles.metricValue}>{m.value}</span>
+                <span>{m.label}</span>
+                {i < metrics.length - 1 && (
+                  <span className={styles.metricSep} aria-hidden="true">·</span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {skills.length > 0 && (
+          <div className={styles.stack}>
+            {skills.map((s, i) => (
+              <span key={`${s}-${i}`}>
+                <span className={styles.tech}>{s}</span>
+                {i < skills.length - 1 && (
+                  <span className={styles.techSep} aria-hidden="true">·</span>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className={styles.links}>
+          <a href={`/work/${project.slug}`} className={styles.primary}>
+            Read the case study →
+          </a>
+          {project.live_url && (
+            <a
+              href={project.live_url}
+              className={styles.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ live
+            </a>
+          )}
+          {project.github_url && (
+            <a
+              href={project.github_url}
+              className={styles.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ↗ code
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className={`${styles.image} ${flipped ? styles.imageFlipped : ''}`}>
+        {imageSrc ? (
+          <Image
+            src={imageSrc}
+            alt={title}
+            fill
+            sizes="(max-width: 1100px) 100vw, 45vw"
+            className={styles.img}
+          />
+        ) : (
+          <div className={styles.fallback}>
+            <span className={styles.fallbackTitle}>{title}</span>
+            <span className={styles.fallbackCaption}>— no image yet</span>
+          </div>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export default async function ProductionRows() {
+  const all = await getAllProjects();
+  const projects = all
+    .filter((p) => p.tier === 'production')
+    .sort((a, b) => a.sort_order - b.sort_order);
+
+  if (projects.length === 0) {
+    return (
+      <div className={styles.section}>
+        <p className={styles.empty}>— No production projects yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.eyebrow}>
+        <span className={styles.marker} aria-hidden="true" />
+        — Production work · two shipped, in daily use
+      </div>
+
+      {projects.map((project, i) => (
+        <ProductionRow
+          key={project.id}
+          project={project}
+          index={i}
+          flipped={i % 2 !== 0}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `components/work/production-row.tsx` — server component that fetches all `tier:'production'` projects and renders them in an alternating 60/40 split-row layout matching the `.prod-row` / `.prod-row.flipped` mockup
- First row: text column left (1.2fr), image right (1fr); second row flips via `order: -1` on the image column with a `1fr 1.2fr` grid — column order swaps, content stays full-width
- Metric row: mono container with serif italic accent values and `·` separators
- Graceful empty state when no production projects are seeded
- Mobile (<1100px): collapses to single stacked column
- Also fixes a pre-existing z-index bug where the hero Marginalia painted behind the image column

## Dependency note

Production rows will render empty until the backend has a `tier` column on the `projects` table (planned as chunk 23 — `feat/23-project-tier`). The frontend type (`tier?: string` in `lib/api.ts`) is already in place.

## Test plan

- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean
- [ ] Visit `/v2/work`: hero renders, production section shows (once tier is seeded) or shows empty-state message
- [ ] Resize below 1100px: rows collapse to single column
- [ ] Hero marginalia ("the piece I'd lead an interview with") visible above the diagram, not behind it

## Gate

**Gate: none** — no Alembic migration, no auth change, no new external API.