### PR TITLE
feat(projects): add tier select to admin form

### DIFF
--- a/app/admin/(dashboard)/projects/ProjectFormModal.tsx
+++ b/app/admin/(dashboard)/projects/ProjectFormModal.tsx
@@ -54,6 +54,7 @@ export default function ProjectFormModal({
       live_url: project?.liveUrl ?? "",
       is_featured: project?.is_featured ?? false,
       sort_order: project?.sort_order ?? 0,
+      tier: (project?.tier ?? null) as "hero" | "production" | "archive" | null,
     },
   });
 
@@ -73,6 +74,7 @@ export default function ProjectFormModal({
       ...data,
       github_url: data.github_url || null,
       live_url: data.live_url || null,
+      tier: data.tier || null,
       tags: tags.split(",").map((s) => s.trim()).filter(Boolean),
       images,
       image_url: images.find((img) => img.is_primary)?.url || "",
@@ -123,6 +125,7 @@ export default function ProjectFormModal({
       gallery: p.gallery || [],
       is_featured: p.is_featured,
       sort_order: p.sort_order,
+      tier: p.tier ?? null,
       skillIds: p.skills?.map((s: { id: string }) => s.id) ?? skillIds,
     });
   };
@@ -219,7 +222,7 @@ export default function ProjectFormModal({
               </div>
             </div>
 
-            <div className="flex items-center gap-6 pt-2">
+            <div className="flex items-center gap-6 pt-2 flex-wrap">
               <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-[var(--text-primary)]">
                 <input
                   type="checkbox"
@@ -235,6 +238,18 @@ export default function ProjectFormModal({
                   {...register("sort_order", { valueAsNumber: true })}
                   className="w-20 bg-[var(--bg-elevated)] border border-[var(--border-default)] rounded-lg px-3 py-1 text-[var(--text-primary)] focus:ring-2 focus:ring-[var(--accent-violet)] outline-none"
                 />
+              </div>
+              <div className="flex items-center gap-2">
+                <label className="text-sm font-medium text-[var(--text-secondary)]">Tier:</label>
+                <select
+                  {...register("tier")}
+                  className={inputClass}
+                >
+                  <option value="">— none —</option>
+                  <option value="hero">Hero</option>
+                  <option value="production">Production</option>
+                  <option value="archive">Archive</option>
+                </select>
               </div>
             </div>
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -55,6 +55,7 @@ export interface ApiProject {
   outcomes: { en: string[]; es: string[] } | null;
   is_featured: boolean;
   sort_order: number;
+  tier: "hero" | "production" | "archive" | null;
   primary_category_id: string | null;
   skills: ApiSkillRef[];
 }
@@ -491,6 +492,7 @@ export function mapApiProject(p: ApiProject, locale: string = "en"): Project {
     gallery: p.gallery || [],
     is_featured: p.is_featured,
     sort_order: p.sort_order,
+    tier: p.tier ?? null,
     skillIds: p.skills?.map((s) => s.id) || [],
   };
 }

--- a/lib/mockData.ts
+++ b/lib/mockData.ts
@@ -23,6 +23,7 @@ export interface Project {
   gallery?: string[];
   is_featured?: boolean;
   sort_order?: number;
+  tier?: string | null;
 }
 
 export interface SkillItem {

--- a/lib/schemas/project.ts
+++ b/lib/schemas/project.ts
@@ -9,6 +9,7 @@ export const ProjectCreate = z.object({
   live_url: z.string().url("Must be a valid URL").or(z.literal("")).nullable().optional(),
   is_featured: z.boolean().default(false),
   sort_order: z.number().int().default(0),
+  tier: z.enum(["hero", "production", "archive"]).nullable().optional().default(null),
 });
 
 export type ProjectCreate = z.infer<typeof ProjectCreate>;


### PR DESCRIPTION
## Summary

- Adds `tier` field (`hero | production | archive | null`) to the `ProjectCreate` Zod schema
- Exposes `tier` on the `Project` interface (`mockData.ts`) and in `mapApiProject` (`api.ts`)
- Adds `tier` to `ApiProject` interface to match the backend response shape
- Renders a `<select>` in the admin project form modal (alongside Featured / Sort Order) that reads and writes the value through the existing form flow

## Test plan

- [ ] Open admin → Projects, edit an existing project — Tier select appears pre-populated with the current value
- [ ] Change tier, save, reopen modal — value persists (round-trip through API)
- [ ] Set tier to "— none —", save — PATCH body sends `null`, not `""`
- [ ] Create a new project — select defaults to "— none —"
- [ ] `pnpm typecheck` passes (pre-existing `.next/types/app/v2/` errors are unrelated)